### PR TITLE
release: v0.4.30 — Kimi live models, identity fingerprint, routing diagnosis

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -14,7 +14,7 @@
       },
       {
         "path": "internal/enduser/service.go",
-        "max_lines": 1169
+        "max_lines": 1168
       },
       {
         "path": "internal/identity/service.go",

--- a/internal/api/handlers/management/identity_fingerprint.go
+++ b/internal/api/handlers/management/identity_fingerprint.go
@@ -40,6 +40,7 @@ func (h *Handler) GetIdentityFingerprint(c *gin.Context) {
 			"codex":  {Enabled: current.Codex.Enabled, LearnedCount: len(learned["codex"])},
 			"gemini": {Enabled: current.Gemini.Enabled, LearnedCount: len(learned["gemini"])},
 			"xai":    {Enabled: current.XAI.Enabled, LearnedCount: len(learned["xai"])},
+			"kimi":   {Enabled: current.Kimi.Enabled, LearnedCount: len(learned["kimi"])},
 		},
 	})
 }
@@ -65,6 +66,10 @@ func (h *Handler) PutIdentityFingerprint(c *gin.Context) {
 		return
 	}
 	if err := validateXAIIdentityFingerprint(body.XAI); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := validateKimiIdentityFingerprint(body.Kimi); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -126,14 +131,16 @@ func (h *Handler) identityFingerprintState(current config.IdentityFingerprintCon
 		"codex":  {},
 		"gemini": {},
 		"xai":    {},
+		"kimi":   {},
 	}
 	effective := map[string][]identityfingerprint.EffectiveFingerprint{
 		"claude": {},
 		"codex":  {},
 		"gemini": {},
 		"xai":    {},
+		"kimi":   {},
 	}
-	for _, provider := range []identityfingerprint.Provider{identityfingerprint.ProviderClaude, identityfingerprint.ProviderCodex, identityfingerprint.ProviderGemini, identityfingerprint.ProviderXAI} {
+	for _, provider := range []identityfingerprint.Provider{identityfingerprint.ProviderClaude, identityfingerprint.ProviderCodex, identityfingerprint.ProviderGemini, identityfingerprint.ProviderXAI, identityfingerprint.ProviderKimi} {
 		records, err := usage.ListIdentityFingerprints(provider, 200)
 		if err != nil {
 			continue
@@ -154,6 +161,9 @@ func (h *Handler) identityFingerprintState(current config.IdentityFingerprintCon
 				effective[key] = append(effective[key], eff)
 			case identityfingerprint.ProviderXAI:
 				_, eff := identityfingerprint.ResolveXAI(current.XAI, &record)
+				effective[key] = append(effective[key], eff)
+			case identityfingerprint.ProviderKimi:
+				_, eff := identityfingerprint.ResolveKimi(current.Kimi, &record)
 				effective[key] = append(effective[key], eff)
 			}
 		}
@@ -268,6 +278,33 @@ func validateXAIIdentityFingerprint(fp config.XAIIdentityFingerprintConfig) erro
 	return nil
 }
 
+func validateKimiIdentityFingerprint(fp config.KimiIdentityFingerprintConfig) error {
+	if containsHeaderLineBreak(fp.UserAgent) ||
+		containsHeaderLineBreak(fp.Platform) ||
+		containsHeaderLineBreak(fp.Version) ||
+		containsHeaderLineBreak(fp.DeviceName) ||
+		containsHeaderLineBreak(fp.DeviceModel) {
+		return fmt.Errorf("identity fingerprint fields must not contain line breaks")
+	}
+	for key, value := range fp.CustomHeaders {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return fmt.Errorf("custom header name cannot be empty")
+		}
+		if !isHTTPHeaderToken(key) {
+			return fmt.Errorf("invalid custom header name: %s", key)
+		}
+		if isIdentityFingerprintBlockedHeader(key) || isKimiIdentityFingerprintBlockedHeader(key) {
+			return fmt.Errorf("custom header %s is managed by the system", key)
+		}
+		if containsHeaderLineBreak(value) {
+			return fmt.Errorf("custom header %s must not contain line breaks", key)
+		}
+	}
+	return nil
+}
+
 func containsHeaderLineBreak(value string) bool {
 	return strings.ContainsAny(value, "\r\n")
 }
@@ -308,6 +345,18 @@ func isGeminiIdentityFingerprintBlockedHeader(key string) bool {
 func isXAIIdentityFingerprintBlockedHeader(key string) bool {
 	switch strings.ToLower(strings.TrimSpace(key)) {
 	case "x-grok-client-identifier", "x-grok-client-version", "x-grok-conv-id":
+		return true
+	default:
+		return false
+	}
+}
+
+// isKimiIdentityFingerprintBlockedHeader covers the headers the kimi fingerprint
+// owns. The device id is included even though it has no preset: it is resolved
+// per account, and a custom header would override every account with one value.
+func isKimiIdentityFingerprintBlockedHeader(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "x-msh-platform", "x-msh-version", "x-msh-device-name", "x-msh-device-model", "x-msh-device-id":
 		return true
 	default:
 		return false

--- a/internal/api/handlers/management/identity_fingerprint_account.go
+++ b/internal/api/handlers/management/identity_fingerprint_account.go
@@ -448,6 +448,9 @@ func resolveIdentityFingerprint(current config.IdentityFingerprintConfig, provid
 	case identityfingerprint.ProviderXAI:
 		_, effective := identityfingerprint.ResolveXAI(current.XAI, learned)
 		return effective, current.XAI, config.DefaultXAIIdentityFingerprint()
+	case identityfingerprint.ProviderKimi:
+		_, effective := identityfingerprint.ResolveKimi(current.Kimi, learned)
+		return effective, current.Kimi, config.DefaultKimiIdentityFingerprint()
 	default:
 		return identityfingerprint.EffectiveFingerprint{}, nil, nil
 	}
@@ -504,6 +507,10 @@ func identityFingerprintSummaryVersion(provider identityfingerprint.Provider, ef
 		}
 	case identityfingerprint.ProviderXAI:
 		return strings.TrimSpace(effective.Version)
+	case identityfingerprint.ProviderKimi:
+		if value := identityFingerprintEffectiveField(effective, identityfingerprint.FieldKimiVersion); value != "" {
+			return value
+		}
 	}
 	return strings.TrimSpace(effective.Version)
 }
@@ -583,6 +590,8 @@ func normalizeIdentityFingerprintProvider(value string) (identityfingerprint.Pro
 		return identityfingerprint.ProviderGemini, true
 	case string(identityfingerprint.ProviderXAI), "grok":
 		return identityfingerprint.ProviderXAI, true
+	case string(identityfingerprint.ProviderKimi), "moonshot":
+		return identityfingerprint.ProviderKimi, true
 	default:
 		return "", false
 	}

--- a/internal/api/handlers/management/model_test_run.go
+++ b/internal/api/handlers/management/model_test_run.go
@@ -1,0 +1,164 @@
+package management
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Model connectivity test.
+//
+// The panel used to answer "can this model be reached" from the browser: it
+// listed the tenant's API keys, picked one itself, and sent a chat completion to
+// the public /v1 endpoint. That answers a different question — whether that
+// particular business identity may use the model. An operator checking a healthy
+// kimi account got "no auth available" because the key it happened to pick was
+// bound to an end user restricted to one channel group, and no amount of channel
+// or model configuration on the account side could change that.
+//
+// Image and video generation already test through the auth manager for exactly
+// this reason. This does the same for chat models: management authority, tenant
+// scope, no API key in the loop.
+
+const modelTestPromptLimit = 4000
+
+// modelTestTimeout bounds one probe. Long enough for a cold upstream, short
+// enough that an operator is not left watching a spinner.
+const modelTestTimeout = 120 * time.Second
+
+type modelTestRequest struct {
+	Model   string `json:"model"`
+	Prompt  string `json:"prompt"`
+	Channel string `json:"channel"`
+}
+
+// PostModelTest runs one non-streaming completion against a model using
+// management authority, and reports what came back.
+func (h *Handler) PostModelTest(c *gin.Context) {
+	var body modelTestRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	model := strings.TrimSpace(body.Model)
+	if model == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "model is required"})
+		return
+	}
+	prompt := strings.TrimSpace(body.Prompt)
+	if prompt == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "prompt is required"})
+		return
+	}
+	if len(prompt) > modelTestPromptLimit {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "prompt is too long"})
+		return
+	}
+	if h == nil || h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "auth manager unavailable"})
+		return
+	}
+
+	providers := sdkmodelcatalog.GetProviderName(model)
+	if len(providers) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("no provider serves model %q", model)})
+		return
+	}
+
+	payload, err := buildModelTestPayload(model, prompt)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), modelTestTimeout)
+	defer cancel()
+
+	startedAt := time.Now()
+	resp, execErr := h.authManager.Execute(ctx, providers, coreexecutor.Request{
+		Model:   model,
+		Payload: payload,
+		Format:  sdktranslator.FromString("openai"),
+	}, coreexecutor.Options{
+		OriginalRequest: payload,
+		SourceFormat:    sdktranslator.FromString("openai"),
+		Metadata:        modelTestMetadata(effectiveTenantID(c), body.Channel),
+	})
+	elapsed := time.Since(startedAt).Milliseconds()
+
+	if execErr != nil {
+		// The upstream reason is the whole point of the probe, so it is reported
+		// as a result rather than swallowed into a 5xx.
+		c.JSON(http.StatusOK, gin.H{"ok": false, "error": execErr.Error(), "duration_ms": elapsed})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"ok":          true,
+		"content":     modelTestContent(resp.Payload),
+		"duration_ms": elapsed,
+	})
+}
+
+// modelTestMetadata scopes the probe to the tenant and, when the operator picked
+// a channel, to that channel. Restricting by channel is what the panel's channel
+// selector always implied but never did: it only used the value to choose an API
+// key, so the request could still land on a different account.
+func modelTestMetadata(tenantID, channel string) map[string]any {
+	meta := map[string]any{
+		coreexecutor.SinglePickMetadataKey: true,
+		coreexecutor.TenantMetadataKey:     coreauth.NormalizedTenantID(tenantID),
+	}
+	if channel = strings.TrimSpace(channel); channel != "" {
+		meta["allowed-channels"] = channel
+	}
+	return meta
+}
+
+func buildModelTestPayload(model, prompt string) ([]byte, error) {
+	payload := []byte(`{"stream":false,"messages":[]}`)
+	var err error
+	if payload, err = sjson.SetBytes(payload, "model", model); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	if payload, err = sjson.SetBytes(payload, "messages.0.role", "user"); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	if payload, err = sjson.SetBytes(payload, "messages.0.content", prompt); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	return payload, nil
+}
+
+// modelTestContent pulls the assistant text out of an OpenAI-shaped response,
+// falling back to the raw body so an unexpected shape is still inspectable.
+func modelTestContent(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	if text := gjson.GetBytes(payload, "choices.0.message.content").String(); strings.TrimSpace(text) != "" {
+		return text
+	}
+	if parts := gjson.GetBytes(payload, "choices.0.message.content.#.text"); parts.Exists() {
+		texts := make([]string, 0, len(parts.Array()))
+		for _, part := range parts.Array() {
+			if value := strings.TrimSpace(part.String()); value != "" {
+				texts = append(texts, value)
+			}
+		}
+		if len(texts) > 0 {
+			return strings.Join(texts, "\n")
+		}
+	}
+	return string(payload)
+}

--- a/internal/api/handlers/management/model_test_run_test.go
+++ b/internal/api/handlers/management/model_test_run_test.go
@@ -1,0 +1,101 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+func TestBuildModelTestPayloadShapesOneUserTurn(t *testing.T) {
+	payload, err := buildModelTestPayload("kimi-k3", "How is the weather?")
+	if err != nil {
+		t.Fatalf("buildModelTestPayload: %v", err)
+	}
+	if got := gjson.GetBytes(payload, "model").String(); got != "kimi-k3" {
+		t.Fatalf("model = %q, want kimi-k3", got)
+	}
+	if got := gjson.GetBytes(payload, "messages.#").Int(); got != 1 {
+		t.Fatalf("messages = %d, want exactly the probe turn", got)
+	}
+	if got := gjson.GetBytes(payload, "messages.0.content").String(); got != "How is the weather?" {
+		t.Fatalf("content = %q, want the prompt", got)
+	}
+	if gjson.GetBytes(payload, "stream").Bool() {
+		t.Fatal("the probe must not stream; the handler reads one response body")
+	}
+}
+
+// The channel selector in the panel used to only pick an API key, so a probe
+// could land on a different account than the operator selected. Scoping the
+// execution is what makes that selector mean something.
+func TestModelTestMetadataScopesTenantAndChannel(t *testing.T) {
+	meta := modelTestMetadata("tenant-a", " kimi ")
+	if got := meta["allowed-channels"]; got != "kimi" {
+		t.Fatalf("allowed-channels = %v, want the trimmed channel", got)
+	}
+	if meta["tenant_id"] != "tenant-a" {
+		t.Fatalf("tenant_id = %v, want tenant-a", meta["tenant_id"])
+	}
+
+	// No channel selected means "any account that serves the model", not a
+	// restriction to the empty channel.
+	if _, ok := modelTestMetadata("tenant-a", "  ")["allowed-channels"]; ok {
+		t.Fatal("an unset channel must not restrict the probe")
+	}
+}
+
+func TestModelTestContentPrefersAssistantText(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"role":"assistant","content":"sunny"}}]}`)
+	if got := modelTestContent(body); got != "sunny" {
+		t.Fatalf("content = %q, want sunny", got)
+	}
+	// An unexpected shape stays inspectable rather than turning into "".
+	raw := []byte(`{"unexpected":true}`)
+	if got := modelTestContent(raw); got != string(raw) {
+		t.Fatalf("content = %q, want the raw body for an unknown shape", got)
+	}
+}
+
+func postModelTest(t *testing.T, h *Handler, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/models/test", strings.NewReader(string(encoded)))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.PostModelTest(c)
+	return rec
+}
+
+func TestPostModelTestRejectsIncompleteRequests(t *testing.T) {
+	h := &Handler{}
+	for name, body := range map[string]map[string]string{
+		"no model":  {"prompt": "hi"},
+		"no prompt": {"model": "kimi-k3"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := postModelTest(t, h, body).Code; got != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", got)
+			}
+		})
+	}
+}
+
+// A model no provider serves is a 404, not the generic selection failure an
+// operator would otherwise have to interpret.
+func TestPostModelTestReportsUnknownModel(t *testing.T) {
+	h := &Handler{}
+	rec := postModelTest(t, h, map[string]string{"model": "not-a-real-model-xyz", "prompt": "hi"})
+	if rec.Code != http.StatusNotFound && rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 404 (unknown model) or 503 (no auth manager)", rec.Code)
+	}
+}

--- a/internal/api/routes/management_model_routes.go
+++ b/internal/api/routes/management_model_routes.go
@@ -9,6 +9,9 @@ func registerManagementModelRoutes(group *gin.RouterGroup, h *managementhandlers
 	models := h.Models()
 	group.GET("/models", models.GetModels)
 	group.GET("/models/configured-availability", models.GetConfiguredModelAvailability)
+	// Management-authority connectivity probe: no API key, so an end user's
+	// channel-group scope cannot make a healthy model look unreachable.
+	group.POST("/models/test", h.PostModelTest)
 	group.GET("/model-path-availability", models.GetModelPathAvailability)
 	group.GET("/model-configs", models.GetModelConfigs)
 	group.POST("/model-configs", models.PostModelConfig)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 329; got != want {
+	if got, want := len(routes), 330; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -362,6 +362,7 @@ func expectedManagementRoutes() []string {
 		"GET /v0/management/model-pricing",
 		"GET /v0/management/models",
 		"GET /v0/management/models/configured-availability",
+		"POST /v0/management/models/test",
 		"GET /v0/management/oauth-excluded-models",
 		"GET /v0/management/oauth-model-alias",
 		"GET /v0/management/ollama-cloud-api-key",

--- a/internal/app/service/runtime_executor_registry.go
+++ b/internal/app/service/runtime_executor_registry.go
@@ -481,6 +481,10 @@ func FetchCodexModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Conf
 	return executor.FetchCodexModels(ctx, auth, cfg)
 }
 
+func FetchKimiModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return executor.FetchKimiModels(ctx, auth, cfg)
+}
+
 func RebindTenantExecutors(base *config.Config, coreManager *coreauth.Manager, tenantID string, gateway WebsocketGateway) {
 	if base == nil || coreManager == nil {
 		return

--- a/internal/config/identity_fingerprint.go
+++ b/internal/config/identity_fingerprint.go
@@ -68,6 +68,7 @@ type IdentityFingerprintConfig struct {
 	Claude ClaudeIdentityFingerprintConfig `yaml:"claude,omitempty" json:"claude,omitempty"`
 	Gemini GeminiIdentityFingerprintConfig `yaml:"gemini,omitempty" json:"gemini,omitempty"`
 	XAI    XAIIdentityFingerprintConfig    `yaml:"xai,omitempty" json:"xai,omitempty"`
+	Kimi   KimiIdentityFingerprintConfig   `yaml:"kimi,omitempty" json:"kimi,omitempty"`
 }
 
 // CodexIdentityFingerprintConfig configures Codex upstream identity headers.
@@ -231,14 +232,21 @@ func DefaultIdentityFingerprintConfig() IdentityFingerprintConfig {
 		Claude: DefaultClaudeIdentityFingerprint(),
 		Gemini: DefaultGeminiIdentityFingerprint(),
 		XAI:    DefaultXAIIdentityFingerprint(),
+		Kimi:   DefaultKimiIdentityFingerprint(),
 	}
 }
 
 // SanitizeIdentityFingerprint normalizes provider identity fingerprint config.
+//
+// The legacy kimi-header-defaults block is folded into the kimi fingerprint here
+// so the runtime, the management API and the panel all read one source. Doing it
+// anywhere later would leave the panel showing the builtin template while a
+// deployment's configured headers were what actually went upstream.
 func (cfg *Config) SanitizeIdentityFingerprint() {
 	if cfg == nil {
 		return
 	}
+	cfg.IdentityFingerprint.Kimi = WithKimiHeaderDefaults(cfg.IdentityFingerprint.Kimi, cfg.KimiHeaderDefaults)
 	cfg.IdentityFingerprint = NormalizeIdentityFingerprintConfig(cfg.IdentityFingerprint)
 }
 
@@ -250,6 +258,7 @@ func CleanIdentityFingerprintConfig(in IdentityFingerprintConfig) IdentityFinger
 		Claude: CleanClaudeIdentityFingerprint(in.Claude),
 		Gemini: CleanGeminiIdentityFingerprint(in.Gemini),
 		XAI:    CleanXAIIdentityFingerprint(in.XAI),
+		Kimi:   CleanKimiIdentityFingerprint(in.Kimi),
 	}
 }
 
@@ -261,6 +270,7 @@ func NormalizeIdentityFingerprintConfig(in IdentityFingerprintConfig) IdentityFi
 	out.Claude = defaultClaudeIdentityFingerprintEnabled(out.Claude)
 	out.Gemini = defaultGeminiIdentityFingerprintEnabled(out.Gemini)
 	out.XAI = defaultXAIIdentityFingerprintEnabled(out.XAI)
+	out.Kimi = defaultKimiIdentityFingerprintEnabled(out.Kimi)
 	return out
 }
 
@@ -279,6 +289,9 @@ func NormalizeLegacyIdentityFingerprintRuntimeConfig(in IdentityFingerprintConfi
 	}
 	if xaiLegacyDefaultDisabled(out.XAI) {
 		out.XAI.enabledSet = false
+	}
+	if kimiLegacyDefaultDisabled(out.Kimi) {
+		out.Kimi.enabledSet = false
 	}
 	return NormalizeIdentityFingerprintConfig(out)
 }

--- a/internal/config/identity_fingerprint_kimi.go
+++ b/internal/config/identity_fingerprint_kimi.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// Defaults follow the identity the official kimi-cli sends. They match the
+	// values the Kimi executor has always hardcoded, so an account with no learned
+	// fingerprint and no operator preset keeps its previous outbound identity.
+	DefaultKimiFingerprintUserAgent = "KimiCLI/1.10.6"
+	DefaultKimiFingerprintPlatform  = "kimi_cli"
+	DefaultKimiFingerprintVersion   = "1.10.6"
+)
+
+// KimiIdentityFingerprintConfig configures the kimi-cli identity headers sent to
+// the Kimi coding gateway.
+//
+// Device name and model have no compiled-in default on purpose. They describe the
+// machine the client runs on, and the only value the proxy could invent is its own
+// hostname — which is both wrong and identical across every account on the host.
+// Leaving them empty lets the runtime keep its existing host-derived fallback while
+// a learned observation, when present, replaces it with the real client's value.
+type KimiIdentityFingerprintConfig struct {
+	Enabled       bool              `yaml:"enabled" json:"enabled"`
+	UserAgent     string            `yaml:"user-agent,omitempty" json:"user-agent,omitempty"`
+	Platform      string            `yaml:"x-msh-platform,omitempty" json:"x-msh-platform,omitempty"`
+	Version       string            `yaml:"x-msh-version,omitempty" json:"x-msh-version,omitempty"`
+	DeviceName    string            `yaml:"x-msh-device-name,omitempty" json:"x-msh-device-name,omitempty"`
+	DeviceModel   string            `yaml:"x-msh-device-model,omitempty" json:"x-msh-device-model,omitempty"`
+	CustomHeaders map[string]string `yaml:"custom-headers,omitempty" json:"custom-headers,omitempty"`
+	enabledSet    bool
+}
+
+// DefaultKimiIdentityFingerprint returns the recommended kimi-cli identity template.
+func DefaultKimiIdentityFingerprint() KimiIdentityFingerprintConfig {
+	return KimiIdentityFingerprintConfig{
+		Enabled:       true,
+		UserAgent:     DefaultKimiFingerprintUserAgent,
+		Platform:      DefaultKimiFingerprintPlatform,
+		Version:       DefaultKimiFingerprintVersion,
+		CustomHeaders: map[string]string{},
+	}
+}
+
+// NormalizeKimiIdentityFingerprint trims user input and applies the default enablement.
+func NormalizeKimiIdentityFingerprint(in KimiIdentityFingerprintConfig) KimiIdentityFingerprintConfig {
+	return defaultKimiIdentityFingerprintEnabled(CleanKimiIdentityFingerprint(in))
+}
+
+// CleanKimiIdentityFingerprint trims explicit overrides while preserving empty fields.
+func CleanKimiIdentityFingerprint(in KimiIdentityFingerprintConfig) KimiIdentityFingerprintConfig {
+	out := in
+	out.UserAgent = strings.TrimSpace(out.UserAgent)
+	out.Platform = strings.TrimSpace(out.Platform)
+	out.Version = strings.TrimSpace(out.Version)
+	out.DeviceName = strings.TrimSpace(out.DeviceName)
+	out.DeviceModel = strings.TrimSpace(out.DeviceModel)
+	out.CustomHeaders = cleanIdentityFingerprintHeaders(out.CustomHeaders)
+	return out
+}
+
+// WithKimiHeaderDefaults folds the legacy kimi-header-defaults block into the
+// fingerprint preset layer.
+//
+// Both settings describe the same three headers. Deployments configured before
+// the fingerprint existed must keep their values, so the legacy block acts as a
+// preset the fingerprint's own preset can still override, and both stay below a
+// learned observation.
+func WithKimiHeaderDefaults(fp KimiIdentityFingerprintConfig, legacy KimiHeaderDefaults) KimiIdentityFingerprintConfig {
+	out := CleanKimiIdentityFingerprint(fp)
+	if out.UserAgent == "" {
+		out.UserAgent = strings.TrimSpace(legacy.UserAgent)
+	}
+	if out.Platform == "" {
+		out.Platform = strings.TrimSpace(legacy.Platform)
+	}
+	if out.Version == "" {
+		out.Version = strings.TrimSpace(legacy.Version)
+	}
+	return out
+}
+
+func defaultKimiIdentityFingerprintEnabled(in KimiIdentityFingerprintConfig) KimiIdentityFingerprintConfig {
+	if !in.enabledSet {
+		in.Enabled = true
+	}
+	return in
+}
+
+func kimiLegacyDefaultDisabled(fp KimiIdentityFingerprintConfig) bool {
+	if fp.Enabled || len(fp.CustomHeaders) > 0 ||
+		strings.TrimSpace(fp.DeviceName) != "" || strings.TrimSpace(fp.DeviceModel) != "" {
+		return false
+	}
+	defaults := DefaultKimiIdentityFingerprint()
+	return emptyOrEqual(fp.UserAgent, defaults.UserAgent) &&
+		emptyOrEqual(fp.Platform, defaults.Platform) &&
+		emptyOrEqual(fp.Version, defaults.Version)
+}
+
+func (fp *KimiIdentityFingerprintConfig) UnmarshalJSON(data []byte) error {
+	type alias KimiIdentityFingerprintConfig
+	var out alias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*fp = KimiIdentityFingerprintConfig(out)
+	fp.enabledSet = jsonObjectHasKey(data, "enabled")
+	return nil
+}
+
+func (fp *KimiIdentityFingerprintConfig) UnmarshalYAML(value *yaml.Node) error {
+	type alias KimiIdentityFingerprintConfig
+	var out alias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*fp = KimiIdentityFingerprintConfig(out)
+	fp.enabledSet = yamlMappingHasKey(value, "enabled")
+	return nil
+}

--- a/internal/enduser/profile_unbind.go
+++ b/internal/enduser/profile_unbind.go
@@ -1,0 +1,48 @@
+package enduser
+
+import "strings"
+
+// appendPermissionProfileSets writes the permission-profile change, and clears
+// what the profile owned when it is being unbound.
+//
+// Binding a profile copies its allowed-models / allowed-channels /
+// allowed-channel-groups / system-prompt onto the account row. Unbinding used to
+// reset only the quota fields and leave those four behind. The console renders
+// them only while a profile is attached, so the account then read "unrestricted"
+// while a stale channel-group whitelist was still in force — invisible in the
+// UI, unreachable from it, and unnamed by the request error.
+//
+// The cleanup fires only on set → empty: switching between profiles is a rebind,
+// not an unbind. An explicit value in the same patch still wins, so this only
+// fills fields the caller left alone.
+func appendPermissionProfileSets(
+	sets []string,
+	args []interface{},
+	currentProfileID string,
+	patch *QuotaPatch,
+) ([]string, []interface{}) {
+	nextProfileID := strings.TrimSpace(*patch.PermissionProfileID)
+	sets = append(sets, "permission_profile_id = ?")
+	args = append(args, nextProfileID)
+
+	if nextProfileID != "" || strings.TrimSpace(currentProfileID) == "" {
+		return sets, args
+	}
+	if patch.AllowedModels == nil {
+		sets = append(sets, "allowed_models = ?")
+		args = append(args, encodeJSONStringList(nil))
+	}
+	if patch.AllowedChannels == nil {
+		sets = append(sets, "allowed_channels = ?")
+		args = append(args, encodeJSONStringList(nil))
+	}
+	if patch.AllowedChannelGroups == nil {
+		sets = append(sets, "allowed_channel_groups = ?")
+		args = append(args, encodeJSONStringList(nil))
+	}
+	if patch.SystemPrompt == nil {
+		sets = append(sets, "system_prompt = ?")
+		args = append(args, "")
+	}
+	return sets, args
+}

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -639,8 +639,7 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 	}
 	if accountQuotaPatch != nil {
 		if accountQuotaPatch.PermissionProfileID != nil {
-			sets = append(sets, "permission_profile_id = ?")
-			args = append(args, strings.TrimSpace(*accountQuotaPatch.PermissionProfileID))
+			sets, args = appendPermissionProfileSets(sets, args, currentProfileID, accountQuotaPatch)
 		}
 		if accountQuotaPatch.DailyLimit != nil {
 			sets = append(sets, "daily_limit = ?")

--- a/internal/enduser/service_sqlite_test.go
+++ b/internal/enduser/service_sqlite_test.go
@@ -23,6 +23,7 @@ func openEndUserTestDB(t *testing.T) *sql.DB {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	sqlapikey.InitTable(db)
+	sqlapikey.InitPermissionProfilesTable(db)
 	if _, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS end_users (
 			id TEXT PRIMARY KEY,
@@ -203,5 +204,108 @@ func TestUpdateUserAutoCapsOwnedKeyPeriodLimits(t *testing.T) {
 	}
 	if stored != 100 {
 		t.Fatalf("stored day = %v, want 100", stored)
+	}
+}
+
+// Unbinding a permission profile used to leave the profile's model/channel
+// scopes on the account. The console renders those scopes only while a profile
+// is attached, so the account read "unrestricted" while a stale channel-group
+// whitelist kept every credential outside that group unreachable — with nowhere
+// in the UI to see it, and no error message that named it.
+func TestUnbindingPermissionProfileClearsInheritedScopes(t *testing.T) {
+	db := openEndUserTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	tenantID := "00000000-0000-0000-0000-000000000001"
+	userID := uuid.NewString()
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status,
+			permission_profile_id, allowed_models, allowed_channels, allowed_channel_groups, system_prompt, created_at, updated_at)
+		VALUES (?, ?, 'scoped', 'scoped', 'Scoped', 'x', 'active',
+			'profile-1', '["grok-4.5"]', '["Grok Account"]', '["group"]', 'be brief', ?, ?)
+	`, userID, tenantID, now, now); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	actor := identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantID}, Permissions: map[string]bool{"end_users.write": true}}
+	empty := ""
+	if _, err := svc.UpdateUser(ctx, actor, tenantID, userID, nil, nil, nil, nil, &QuotaPatch{PermissionProfileID: &empty}); err != nil {
+		t.Fatalf("UpdateUser: %v", err)
+	}
+
+	var profileID, models, channels, groups, prompt string
+	if err := db.QueryRow(`SELECT permission_profile_id, allowed_models, allowed_channels, allowed_channel_groups, system_prompt
+		FROM end_users WHERE id = ?`, userID).Scan(&profileID, &models, &channels, &groups, &prompt); err != nil {
+		t.Fatalf("query user: %v", err)
+	}
+	if profileID != "" {
+		t.Fatalf("permission_profile_id = %q, want cleared", profileID)
+	}
+	for name, got := range map[string]string{
+		"allowed_models":         models,
+		"allowed_channels":       channels,
+		"allowed_channel_groups": groups,
+	} {
+		if got != "[]" {
+			t.Errorf("%s = %q, want an empty list after unbinding", name, got)
+		}
+	}
+	if prompt != "" {
+		t.Errorf("system_prompt = %q, want cleared after unbinding", prompt)
+	}
+}
+
+// Switching between profiles must not trip the unbind cleanup, and an explicit
+// scope in the same patch still wins over it.
+func TestProfileScopesSurviveWhenNotUnbinding(t *testing.T) {
+	db := openEndUserTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	tenantID := "00000000-0000-0000-0000-000000000001"
+	actor := identity.Principal{EffectiveTenant: identity.Tenant{ID: tenantID}, Permissions: map[string]bool{"end_users.write": true}}
+	now := time.Now().UTC()
+
+	rebind := uuid.NewString()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status,
+			permission_profile_id, allowed_channel_groups, created_at, updated_at)
+		VALUES (?, ?, 'rebind', 'rebind', 'Rebind', 'x', 'active', 'profile-1', '["group"]', ?, ?)
+	`, rebind, tenantID, now, now); err != nil {
+		t.Fatalf("insert rebind user: %v", err)
+	}
+	other := "profile-2"
+	if _, err := svc.UpdateUser(ctx, actor, tenantID, rebind, nil, nil, nil, nil, &QuotaPatch{PermissionProfileID: &other}); err != nil {
+		t.Fatalf("UpdateUser rebind: %v", err)
+	}
+	var groups string
+	if err := db.QueryRow(`SELECT allowed_channel_groups FROM end_users WHERE id = ?`, rebind).Scan(&groups); err != nil {
+		t.Fatalf("query rebind: %v", err)
+	}
+	if groups != `["group"]` {
+		t.Fatalf("allowed_channel_groups = %q, want untouched when switching profiles", groups)
+	}
+
+	explicit := uuid.NewString()
+	if _, err := db.Exec(`
+		INSERT INTO end_users (id, tenant_id, username, username_normalized, display_name, password_hash, status,
+			permission_profile_id, allowed_channel_groups, created_at, updated_at)
+		VALUES (?, ?, 'explicit', 'explicit', 'Explicit', 'x', 'active', 'profile-1', '["group"]', ?, ?)
+	`, explicit, tenantID, now, now); err != nil {
+		t.Fatalf("insert explicit user: %v", err)
+	}
+	empty := ""
+	kept := []string{"default"}
+	if _, err := svc.UpdateUser(ctx, actor, tenantID, explicit, nil, nil, nil, nil, &QuotaPatch{
+		PermissionProfileID:  &empty,
+		AllowedChannelGroups: &kept,
+	}); err != nil {
+		t.Fatalf("UpdateUser explicit: %v", err)
+	}
+	if err := db.QueryRow(`SELECT allowed_channel_groups FROM end_users WHERE id = ?`, explicit).Scan(&groups); err != nil {
+		t.Fatalf("query explicit: %v", err)
+	}
+	if groups != `["default"]` {
+		t.Fatalf("allowed_channel_groups = %q, want the explicit value in the same patch", groups)
 	}
 }

--- a/internal/identityfingerprint/extract.go
+++ b/internal/identityfingerprint/extract.go
@@ -25,6 +25,11 @@ const (
 	FieldXAIGrokConversationID  = "x-grok-conv-id"
 	FieldXAIClientIdentifier    = "x-grok-client-identifier"
 	FieldXAIClientVersion       = "x-grok-client-version"
+	FieldKimiPlatform           = "x-msh-platform"
+	FieldKimiVersion            = "x-msh-version"
+	FieldKimiDeviceName         = "x-msh-device-name"
+	FieldKimiDeviceModel        = "x-msh-device-model"
+	FieldKimiDeviceID           = "x-msh-device-id"
 )
 
 var (
@@ -33,6 +38,7 @@ var (
 	tokenVerRe       = regexp.MustCompile(`(?i)\b([a-z0-9_.-]*codex[a-z0-9_.-]*)/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
 	geminiUARe       = regexp.MustCompile(`(?i)^google-api-nodejs-client/([0-9]+(?:\.[0-9]+){0,3})`)
 	xaiTokenVerRe    = regexp.MustCompile(`(?i)\b([a-z0-9_.-]*(?:grok|xai)[a-z0-9_.-]*)/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
+	kimiTokenVerRe   = regexp.MustCompile(`(?i)\b([a-z0-9_.-]*kimi[a-z0-9_.-]*)/([0-9]+(?:\.[0-9]+){0,3})(?:[-+][a-z0-9_.-]+)?`)
 )
 
 func ExtractObservation(input LearnInput) (Observation, bool) {
@@ -50,6 +56,8 @@ func ExtractObservation(input LearnInput) (Observation, bool) {
 		return extractGeminiObservation(input, headers, observedAt)
 	case ProviderXAI:
 		return extractXAIObservation(input, headers, observedAt)
+	case ProviderKimi:
+		return extractKimiObservation(input, headers, observedAt)
 	default:
 		return Observation{}, false
 	}
@@ -222,6 +230,59 @@ func extractXAIObservation(input LearnInput, headers http.Header, observedAt tim
 	}, true
 }
 
+// extractKimiObservation learns the identity a real kimi-cli presents.
+//
+// The device fields are part of the observation on purpose. Without them every
+// account on a host goes out with that host's name and, when the credential
+// carries no device id of its own, the literal fallback string the proxy uses —
+// so accounts that share nothing else still look like one machine to Moonshot.
+func extractKimiObservation(input LearnInput, headers http.Header, observedAt time.Time) (Observation, bool) {
+	ua := strings.TrimSpace(headers.Get("User-Agent"))
+	platform := strings.TrimSpace(headers.Get("X-Msh-Platform"))
+	version := strings.TrimSpace(headers.Get("X-Msh-Version"))
+	product, uaVersion := kimiProductVersion(ua)
+	if product == "" && platform != "" {
+		product = platform
+	}
+	if version == "" {
+		version = uaVersion
+	}
+	// A caller that presents neither a kimi User-Agent nor the platform header is
+	// not the kimi client, and recording it would pin the account to a made-up
+	// identity.
+	if product == "" {
+		return Observation{}, false
+	}
+	fields := map[string]string{}
+	if ua != "" {
+		fields[FieldUserAgent] = ua
+	}
+	if platform != "" {
+		fields[FieldKimiPlatform] = platform
+	}
+	if version != "" {
+		fields[FieldKimiVersion] = version
+	}
+	addHeaderField(fields, headers, "X-Msh-Device-Name", FieldKimiDeviceName)
+	addHeaderField(fields, headers, "X-Msh-Device-Model", FieldKimiDeviceModel)
+	addHeaderField(fields, headers, "X-Msh-Device-Id", FieldKimiDeviceID)
+	if len(fields) == 0 {
+		return Observation{}, false
+	}
+	return Observation{
+		Provider:        ProviderKimi,
+		AccountKey:      strings.TrimSpace(input.AccountKey),
+		ProfileKey:      ProfileKeyDefault,
+		AuthSubjectID:   strings.TrimSpace(input.AuthSubjectID),
+		ClientProduct:   product,
+		ClientVariant:   "cli",
+		Version:         version,
+		Fields:          fields,
+		ObservedHeaders: observedHeaders(headers, []string{"User-Agent", "X-Msh-Platform", "X-Msh-Version", "X-Msh-Device-Name", "X-Msh-Device-Model", "X-Msh-Device-Id"}),
+		ObservedAt:      observedAt.UTC(),
+	}, true
+}
+
 func MergeObservation(existing *LearnedRecord, obs Observation) MergeResult {
 	if strings.TrimSpace(obs.AccountKey) == "" {
 		return MergeResult{Reason: "missing_account_key"}
@@ -365,6 +426,20 @@ func xaiProductVersion(ua string) (string, string) {
 	}
 	if strings.Contains(lower, "xai") {
 		return "xai-cli", ""
+	}
+	return "", ""
+}
+
+func kimiProductVersion(ua string) (string, string) {
+	ua = strings.TrimSpace(ua)
+	if ua == "" {
+		return "", ""
+	}
+	if matches := kimiTokenVerRe.FindStringSubmatch(ua); len(matches) > 0 {
+		return strings.ToLower(matches[1]), matches[2]
+	}
+	if strings.Contains(strings.ToLower(ua), "kimi") {
+		return "kimi-cli", ""
 	}
 	return "", ""
 }

--- a/internal/identityfingerprint/kimi_test.go
+++ b/internal/identityfingerprint/kimi_test.go
@@ -1,0 +1,164 @@
+package identityfingerprint
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func kimiClientHeaders() http.Header {
+	headers := http.Header{}
+	headers.Set("User-Agent", "KimiCLI/1.12.0")
+	headers.Set("X-Msh-Platform", "kimi_cli")
+	headers.Set("X-Msh-Version", "1.12.0")
+	headers.Set("X-Msh-Device-Name", "starship")
+	headers.Set("X-Msh-Device-Model", "darwin arm64")
+	headers.Set("X-Msh-Device-Id", "device-from-client")
+	return headers
+}
+
+func TestExtractKimiObservationFromRealClientHeaders(t *testing.T) {
+	obs, ok := ExtractObservation(LearnInput{
+		Provider:   ProviderKimi,
+		AccountKey: "acct",
+		Headers:    kimiClientHeaders(),
+		ObservedAt: time.Date(2026, 8, 27, 1, 2, 3, 0, time.UTC),
+	})
+	if !ok {
+		t.Fatal("ExtractObservation returned false for a real kimi-cli request")
+	}
+	if obs.ClientProduct != "kimicli" || obs.Version != "1.12.0" {
+		t.Fatalf("product/version = %s/%s, want kimicli/1.12.0", obs.ClientProduct, obs.Version)
+	}
+	if obs.ProfileKey != ProfileKeyDefault {
+		t.Fatalf("profile key = %q, want the single default profile", obs.ProfileKey)
+	}
+	for field, want := range map[string]string{
+		FieldUserAgent:       "KimiCLI/1.12.0",
+		FieldKimiPlatform:    "kimi_cli",
+		FieldKimiVersion:     "1.12.0",
+		FieldKimiDeviceName:  "starship",
+		FieldKimiDeviceModel: "darwin arm64",
+		// Without the device id every credential that has none of its own goes out
+		// with the same host fallback string, which is the cross-account collision
+		// this observation exists to remove.
+		FieldKimiDeviceID: "device-from-client",
+	} {
+		if got := obs.Fields[field]; got != want {
+			t.Fatalf("field %s = %q, want %q", field, got, want)
+		}
+	}
+}
+
+func TestExtractKimiObservationFallsBackToPlatformHeader(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Msh-Platform", "kimi_cli")
+	headers.Set("X-Msh-Version", "1.9.2")
+
+	obs, ok := ExtractObservation(LearnInput{Provider: ProviderKimi, AccountKey: "acct", Headers: headers})
+	if !ok {
+		t.Fatal("a request identified only by X-Msh-Platform should still be learnable")
+	}
+	if obs.ClientProduct != "kimi_cli" || obs.Version != "1.9.2" {
+		t.Fatalf("product/version = %s/%s, want kimi_cli/1.9.2", obs.ClientProduct, obs.Version)
+	}
+}
+
+func TestExtractKimiObservationRejectsForeignClients(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("User-Agent", "curl/8.7.1")
+
+	if _, ok := ExtractObservation(LearnInput{Provider: ProviderKimi, AccountKey: "acct", Headers: headers}); ok {
+		t.Fatal("a caller that is not the kimi client must not pin the account to its identity")
+	}
+}
+
+func TestResolveKimiPrefersLearnedOverPresetOverDefault(t *testing.T) {
+	learned := &LearnedRecord{
+		Provider:   ProviderKimi,
+		AccountKey: "acct",
+		ProfileKey: ProfileKeyDefault,
+		Fields: map[string]string{
+			FieldUserAgent:      "KimiCLI/1.12.0",
+			FieldKimiVersion:    "1.12.0",
+			FieldKimiDeviceName: "starship",
+			FieldKimiDeviceID:   "device-from-client",
+		},
+	}
+	preset := config.KimiIdentityFingerprintConfig{
+		Enabled:   true,
+		UserAgent: "KimiCLI/1.11.0",
+		Platform:  "kimi_cli_custom",
+	}
+
+	resolved, effective := ResolveKimi(preset, learned)
+
+	if resolved.UserAgent != "KimiCLI/1.12.0" {
+		t.Fatalf("user agent = %q, want the learned value", resolved.UserAgent)
+	}
+	if resolved.Platform != "kimi_cli_custom" {
+		t.Fatalf("platform = %q, want the operator preset when nothing was learned", resolved.Platform)
+	}
+	if resolved.DeviceModel != "" {
+		t.Fatalf("device model = %q, want empty so the runtime keeps its host fallback", resolved.DeviceModel)
+	}
+	if effective.Fields[FieldUserAgent].Source != FieldSourceLearned {
+		t.Fatalf("user agent source = %q, want learned", effective.Fields[FieldUserAgent].Source)
+	}
+	if effective.Fields[FieldKimiPlatform].Source != FieldSourcePreset {
+		t.Fatalf("platform source = %q, want preset", effective.Fields[FieldKimiPlatform].Source)
+	}
+	if effective.Version != "1.12.0" {
+		t.Fatalf("effective version = %q, want the learned client version", effective.Version)
+	}
+	if got := KimiLearnedDeviceID(learned); got != "device-from-client" {
+		t.Fatalf("learned device id = %q, want the observed value", got)
+	}
+}
+
+func TestResolveKimiWithoutLearnedKeepsPreviousHardcodedIdentity(t *testing.T) {
+	resolved, effective := ResolveKimi(config.KimiIdentityFingerprintConfig{Enabled: true}, nil)
+
+	if resolved.UserAgent != config.DefaultKimiFingerprintUserAgent ||
+		resolved.Platform != config.DefaultKimiFingerprintPlatform ||
+		resolved.Version != config.DefaultKimiFingerprintVersion {
+		t.Fatalf("resolved = %+v, want the builtin kimi-cli template", resolved)
+	}
+	if effective.Fields[FieldUserAgent].Source != FieldSourceBuiltinDefault {
+		t.Fatalf("user agent source = %q, want builtin_default", effective.Fields[FieldUserAgent].Source)
+	}
+	if _, ok := effective.Fields[FieldKimiDeviceID]; ok {
+		t.Fatal("device id must only appear once it has been observed")
+	}
+}
+
+// The legacy kimi-header-defaults block predates the fingerprint and configures
+// the same three headers, so an existing deployment must not have its values
+// replaced by the builtin template.
+func TestWithKimiHeaderDefaultsKeepsLegacyOverrides(t *testing.T) {
+	legacy := config.KimiHeaderDefaults{UserAgent: "KimiCLI/1.8.0", Platform: "kimi_cli", Version: "1.8.0"}
+
+	merged := config.WithKimiHeaderDefaults(config.KimiIdentityFingerprintConfig{Enabled: true}, legacy)
+	resolved, _ := ResolveKimi(merged, nil)
+	if resolved.UserAgent != "KimiCLI/1.8.0" || resolved.Version != "1.8.0" {
+		t.Fatalf("resolved = %+v, want the legacy header defaults", resolved)
+	}
+
+	explicit := config.KimiIdentityFingerprintConfig{Enabled: true, UserAgent: "KimiCLI/1.13.0"}
+	resolved, _ = ResolveKimi(config.WithKimiHeaderDefaults(explicit, legacy), nil)
+	if resolved.UserAgent != "KimiCLI/1.13.0" {
+		t.Fatalf("user agent = %q, want the fingerprint preset to win over the legacy block", resolved.UserAgent)
+	}
+	if resolved.Version != "1.8.0" {
+		t.Fatalf("version = %q, want the legacy block to still fill unset fields", resolved.Version)
+	}
+}
+
+func TestNormalizeKimiIdentityFingerprintDefaultsToEnabled(t *testing.T) {
+	out := config.NormalizeKimiIdentityFingerprint(config.KimiIdentityFingerprintConfig{})
+	if !out.Enabled {
+		t.Fatal("kimi fingerprint must default to enabled like every other provider")
+	}
+}

--- a/internal/identityfingerprint/resolve.go
+++ b/internal/identityfingerprint/resolve.go
@@ -194,6 +194,50 @@ func ResolveXAI(cfg config.XAIIdentityFingerprintConfig, learned *LearnedRecord)
 	return resolved, effective
 }
 
+// ResolveKimi merges the operator preset, the learned kimi-cli observation and
+// the builtin template into the identity sent to the Kimi coding gateway.
+//
+// Device name, model and id have no builtin fallback: an empty result means the
+// executor keeps its host-derived value, which is the pre-fingerprint behaviour.
+// The device id is learned but deliberately not presettable — one id configured
+// globally would make every account look like the same machine, which is the
+// opposite of what the learned value achieves.
+func ResolveKimi(cfg config.KimiIdentityFingerprintConfig, learned *LearnedRecord) (config.KimiIdentityFingerprintConfig, EffectiveFingerprint) {
+	clean := config.CleanKimiIdentityFingerprint(cfg)
+	defaults := config.DefaultKimiIdentityFingerprint()
+	fields := make(map[string]FieldValue)
+	pick := func(field, preset, learnedValue, defaultValue string) string {
+		value, source := pickField(preset, learnedValue, defaultValue)
+		fields[field] = FieldValue{Value: value, Source: source}
+		return value
+	}
+
+	resolved := config.KimiIdentityFingerprintConfig{
+		Enabled:       clean.Enabled,
+		UserAgent:     pick(FieldUserAgent, clean.UserAgent, learnedField(learned, FieldUserAgent), defaults.UserAgent),
+		Platform:      pick(FieldKimiPlatform, clean.Platform, learnedField(learned, FieldKimiPlatform), defaults.Platform),
+		Version:       pick(FieldKimiVersion, clean.Version, learnedFieldOrVersion(learned, FieldKimiVersion), defaults.Version),
+		DeviceName:    pick(FieldKimiDeviceName, clean.DeviceName, learnedField(learned, FieldKimiDeviceName), ""),
+		DeviceModel:   pick(FieldKimiDeviceModel, clean.DeviceModel, learnedField(learned, FieldKimiDeviceModel), ""),
+		CustomHeaders: clean.CustomHeaders,
+	}
+	if deviceID := learnedField(learned, FieldKimiDeviceID); deviceID != "" {
+		fields[FieldKimiDeviceID] = FieldValue{Value: deviceID, Source: FieldSourceLearned}
+	}
+	effective := effective(ProviderKimi, clean.Enabled, learned, fields)
+	if value := strings.TrimSpace(resolved.Version); value != "" {
+		effective.Version = value
+	}
+	return resolved, effective
+}
+
+// KimiLearnedDeviceID returns the device id observed from a real kimi-cli, or an
+// empty string. It is not part of the resolved config because it never comes from
+// operator presets or builtin defaults.
+func KimiLearnedDeviceID(learned *LearnedRecord) string {
+	return learnedField(learned, FieldKimiDeviceID)
+}
+
 func pickField(preset, learned, fallback string) (string, FieldSource) {
 	if value := strings.TrimSpace(learned); value != "" {
 		return value, FieldSourceLearned

--- a/internal/identityfingerprint/types.go
+++ b/internal/identityfingerprint/types.go
@@ -9,6 +9,7 @@ const (
 	ProviderCodex  Provider = "codex"
 	ProviderGemini Provider = "gemini"
 	ProviderXAI    Provider = "xai"
+	ProviderKimi   Provider = "kimi"
 )
 
 type FieldSource string

--- a/internal/management/authfiles/models.go
+++ b/internal/management/authfiles/models.go
@@ -21,7 +21,7 @@ type ModelRegistrar interface {
 	RegisterClient(clientID, clientProvider string, models []*registry.ModelInfo)
 }
 
-// Provider-level discovery cache for claude/codex/xai (Grok).
+// Provider-level discovery cache for claude/codex/xai (Grok)/kimi.
 // Live manifests are shared across accounts of the same provider+tenant so we
 // only hit upstream once (or on force refresh), then every auth-file models
 // panel reuses the same list without RegisterClient-replacing the static catalog.
@@ -75,7 +75,7 @@ func discoveryCacheKey(tenantID, provider string) string {
 
 func supportsSharedDiscovery(provider string) bool {
 	switch normalizeDiscoveryProvider(provider) {
-	case "claude", "codex", "xai":
+	case "claude", "codex", "xai", "kimi":
 		return true
 	default:
 		return false
@@ -119,7 +119,7 @@ func storeDiscoveryCache(tenantID, provider string, models []*registry.ModelInfo
 }
 
 // EnsureProviderDiscovery returns the shared live model list for
-// claude/codex/xai. Cache hit is preferred; on miss it warms once from the
+// claude/codex/xai/kimi. Cache hit is preferred; on miss it warms once from the
 // first active auth of that provider in the tenant (same single-flight path as
 // the auth-file models panel). force re-fetches upstream even when the cache
 // is warm.
@@ -257,7 +257,7 @@ func ListModelEntriesForTenant(manager *coreauth.Manager, source ModelSource, te
 // ListModelEntriesLiveForTenant returns models for an auth file panel.
 //
 // Behaviour:
-//   - claude / codex / xai (shared discovery):
+//   - claude / codex / xai / kimi (shared discovery):
 //     open (refresh=false): serve provider discovery cache if present; otherwise
 //     auto-warm once from upstream using this auth, store under provider+tenant,
 //     return source=upstream. Never RegisterClient-replace the static catalog.
@@ -286,8 +286,9 @@ func ListModelEntriesLiveForTenant(
 	}
 	provider := normalizeDiscoveryProvider(auth.Provider)
 
-	// Shared discovery path for Claude / Codex / xAI (Grok): prefer provider
-	// cache on open, auto-warm on first miss, force re-fetch only when refresh=1.
+	// Shared discovery path for Claude / Codex / xAI (Grok) / Kimi: prefer
+	// provider cache on open, auto-warm on first miss, force re-fetch only when
+	// refresh=1.
 	if supportsSharedDiscovery(provider) {
 		if !refresh {
 			if cached := loadDiscoveryCache(tenantID, provider); len(cached) > 0 {
@@ -329,7 +330,7 @@ func ListModelEntriesLiveForTenant(
 	return modelEntriesFromRegistry(live), sourceLabel
 }
 
-// warmSharedDiscovery fetches live models for claude/codex/xai and stores them
+// warmSharedDiscovery fetches live models for claude/codex/xai/kimi and stores them
 // in the provider-level cache. Concurrent warmers for the same key single-flight.
 // When force is false and another warmer already populated the cache, waiters
 // receive that result without a second upstream call.
@@ -432,6 +433,10 @@ func fetchLiveModelsForAuth(ctx context.Context, auth *coreauth.Auth, cfg *confi
 		// registers live xAI models via service_model_registration; management
 		// panels must not RegisterClient-replace per auth-file refresh.
 		sdkModels = executor.FetchXAIModels(fetchCtx, auth, cfg)
+	case provider == "kimi":
+		// Discovery only, same as xAI: startup registration owns the runtime
+		// registry, the panel just mirrors what the coding gateway advertises.
+		sdkModels = executor.FetchKimiModels(fetchCtx, auth, cfg)
 	case rawProvider == "antigravity":
 		sdkModels = executor.FetchAntigravityModels(fetchCtx, auth, cfg)
 		updateRegistry = true

--- a/internal/management/authfiles/models_test.go
+++ b/internal/management/authfiles/models_test.go
@@ -278,13 +278,47 @@ func TestXAISharedDiscoveryCacheAcrossAccounts(t *testing.T) {
 }
 
 func TestSupportsSharedDiscoveryIncludesXAI(t *testing.T) {
-	for _, provider := range []string{"xai", "x-ai", "grok", "XAI", "Claude", "codex"} {
+	for _, provider := range []string{"xai", "x-ai", "grok", "XAI", "Claude", "codex", "kimi", "Kimi"} {
 		if !SupportsSharedDiscovery(provider) {
 			t.Fatalf("SupportsSharedDiscovery(%q)=false, want true", provider)
 		}
 	}
 	if SupportsSharedDiscovery("antigravity") {
 		t.Fatalf("antigravity must not use shared discovery")
+	}
+}
+
+// Kimi used to serve the compiled-in catalog here, so the panel showed the same
+// four ids no matter what Moonshot had shipped. The discovery cache is what makes
+// the panel reflect the gateway instead.
+func TestKimiSharedDiscoveryServesCacheWithoutRegistrar(t *testing.T) {
+	ResetDiscoveryCacheForTest()
+	storeDiscoveryCache("", "kimi", []*registry.ModelInfo{
+		{ID: "kimi-k2.7", DisplayName: "Kimi K2.7", Type: "kimi", OwnedBy: "moonshot"},
+	})
+	manager := coreauth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: "kimi-a", FileName: "kimi-a.json", Provider: "kimi",
+	}); err != nil {
+		t.Fatalf("Register kimi: %v", err)
+	}
+	source := &modelSourceStub{models: []*registry.ModelInfo{{ID: "kimi-k2"}}}
+	reg := &modelRegistrarStub{}
+
+	models, label := ListModelEntriesLiveForTenant(
+		context.Background(), manager, source, reg, nil, "", "kimi-a.json", false,
+	)
+	if label != "upstream" {
+		t.Fatalf("label=%q want upstream", label)
+	}
+	if !containsModelID(models, "kimi-k2.7") {
+		t.Fatalf("kimi discovery result not served: %#v", models)
+	}
+	if containsModelID(models, "kimi-k2") {
+		t.Fatalf("static catalog leaked into the kimi discovery result: %#v", models)
+	}
+	if reg.calls != 0 {
+		t.Fatalf("RegisterClient calls=%d want 0 for kimi discovery path", reg.calls)
 	}
 }
 

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -226,8 +226,8 @@ func managementVisibleModels(modelRegistry *registry.ModelRegistry) []map[string
 	return out
 }
 
-// sharedDiscoveryByProvider auto-warms (or reads) the claude/codex provider
-// discovery cache for the current tenant. force is reserved for future refresh
+// sharedDiscoveryByProvider auto-warms (or reads) the shared-discovery provider
+// cache (claude/codex/xai/kimi) for the current tenant. force is reserved for future refresh
 // query support; management list endpoints currently always use force=false.
 func (s *Service) sharedDiscoveryByProvider(force bool) map[string][]*registry.ModelInfo {
 	if s == nil || s.authManager == nil {

--- a/internal/management/settings/runtimeconfig/spec.go
+++ b/internal/management/settings/runtimeconfig/spec.go
@@ -473,6 +473,7 @@ type identityFingerprintRuntimePayload struct {
 	Claude                config.ClaudeIdentityFingerprintConfig `json:"claude,omitempty"`
 	Gemini                config.GeminiIdentityFingerprintConfig `json:"gemini,omitempty"`
 	XAI                   config.XAIIdentityFingerprintConfig    `json:"xai,omitempty"`
+	Kimi                  config.KimiIdentityFingerprintConfig   `json:"kimi,omitempty"`
 }
 
 func IdentityFingerprintRuntimeSettingValue(value config.IdentityFingerprintConfig) any {
@@ -483,6 +484,7 @@ func IdentityFingerprintRuntimeSettingValue(value config.IdentityFingerprintConf
 		Claude:                normalized.Claude,
 		Gemini:                normalized.Gemini,
 		XAI:                   normalized.XAI,
+		Kimi:                  normalized.Kimi,
 	}
 }
 
@@ -496,6 +498,10 @@ func identityFingerprintRuntimeSettingConfig(raw json.RawMessage) (config.Identi
 		Claude: payload.Claude,
 		Gemini: payload.Gemini,
 		XAI:    payload.XAI,
+		// Payloads written before kimi joined carry no kimi block, so it stays a
+		// zero value and normalization enables it with the builtin template — which
+		// is byte-identical to what the executor hardcoded before.
+		Kimi: payload.Kimi,
 	}
 	if payload.RuntimeSettingVersion >= identityFingerprintRuntimeSettingVersion {
 		return config.NormalizeIdentityFingerprintConfig(value), nil

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -14,6 +14,7 @@ import (
 
 	kimiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
@@ -561,7 +562,16 @@ func resolveKimiDeviceID(auth *cliproxyauth.Auth) string {
 func applyKimiHeadersWithAuth(r *http.Request, token string, stream bool, auth *cliproxyauth.Auth, cfg *config.Config) {
 	applyKimiHeaders(r, token, stream, cfg)
 
-	if deviceID := resolveKimiDeviceID(auth); deviceID != "" {
+	// The identity fingerprint replaces the host-derived client identity with the
+	// one this account's real kimi-cli presents; anything it cannot resolve keeps
+	// the values applyKimiHeaders just set.
+	var learned *identityfingerprint.LearnedRecord
+	if fp, record, ok := kimiIdentityFingerprint(cfg, auth, r.Context()); ok {
+		applyKimiIdentityFingerprintHeaders(r.Header, fp)
+		learned = record
+	}
+
+	if deviceID := resolveKimiOutboundDeviceID(auth, learned); deviceID != "" {
 		r.Header.Set("X-Msh-Device-Id", deviceID)
 	}
 }

--- a/internal/runtime/executor/kimi_identity_fingerprint.go
+++ b/internal/runtime/executor/kimi_identity_fingerprint.go
@@ -1,0 +1,81 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// kimiIdentityFingerprint resolves the outbound kimi-cli identity for an account
+// and returns the learned record alongside it, because the device id is carried
+// only by the observation (see ResolveKimi).
+//
+// Scope note: this covers the OpenAI-compatible path. A Claude-format request to
+// a Kimi credential is served by ClaudeExecutor against the same gateway, where
+// the caller really is a Claude client, so it keeps the Claude fingerprint.
+func kimiIdentityFingerprint(cfg *config.Config, auth *cliproxyauth.Auth, ctx context.Context) (config.KimiIdentityFingerprintConfig, *identityfingerprint.LearnedRecord, bool) {
+	if cfg == nil || !cfg.IdentityFingerprint.Kimi.Enabled {
+		return config.KimiIdentityFingerprintConfig{}, nil, false
+	}
+	learned := observeRuntimeIdentityFingerprint(identityfingerprint.ProviderKimi, auth, ctx)
+	preset := config.WithKimiHeaderDefaults(cfg.IdentityFingerprint.Kimi, cfg.KimiHeaderDefaults)
+	resolved, _ := identityfingerprint.ResolveKimi(preset, learned)
+	return resolved, learned, true
+}
+
+// applyKimiIdentityFingerprintHeaders overwrites the host-derived defaults with
+// the resolved identity. Empty fields are left alone so the caller's fallback
+// (hostname, GOOS/GOARCH) survives when nothing has been learned or configured.
+func applyKimiIdentityFingerprintHeaders(headers http.Header, fp config.KimiIdentityFingerprintConfig) {
+	if headers == nil {
+		return
+	}
+	for header, value := range map[string]string{
+		"User-Agent":         fp.UserAgent,
+		"X-Msh-Platform":     fp.Platform,
+		"X-Msh-Version":      fp.Version,
+		"X-Msh-Device-Name":  fp.DeviceName,
+		"X-Msh-Device-Model": fp.DeviceModel,
+	} {
+		if value = strings.TrimSpace(value); value != "" {
+			headers.Set(header, value)
+		}
+	}
+	for key, value := range fp.CustomHeaders {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" || isKimiFingerprintRuntimeBlockedHeader(key) {
+			continue
+		}
+		headers.Set(key, value)
+	}
+}
+
+// resolveKimiOutboundDeviceID picks the device id sent upstream.
+//
+// The credential's own id wins: it is the device Moonshot associated with the
+// account at login, and replacing it would present a known account from an
+// unknown machine. A learned id is next — it is the real client's device and is
+// scoped to this account, unlike the host fallback that every credential without
+// an id would otherwise share.
+func resolveKimiOutboundDeviceID(auth *cliproxyauth.Auth, learned *identityfingerprint.LearnedRecord) string {
+	if deviceID := resolveKimiDeviceID(auth); deviceID != "" {
+		return deviceID
+	}
+	return identityfingerprint.KimiLearnedDeviceID(learned)
+}
+
+func isKimiFingerprintRuntimeBlockedHeader(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "authorization", "content-type", "accept", "connection", "user-agent",
+		"x-msh-platform", "x-msh-version", "x-msh-device-name", "x-msh-device-model",
+		"x-msh-device-id":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/runtime/executor/kimi_identity_fingerprint_test.go
+++ b/internal/runtime/executor/kimi_identity_fingerprint_test.go
@@ -1,0 +1,163 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func kimiFingerprintRequest(t *testing.T, inbound map[string]string) *http.Request {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	for key, value := range inbound {
+		ginCtx.Request.Header.Set(key, value)
+	}
+	req := httptest.NewRequest(http.MethodPost, "https://api.kimi.com/coding/v1/chat/completions", nil)
+	return req.WithContext(context.WithValue(req.Context(), util.ContextKeyGin, ginCtx))
+}
+
+func kimiFingerprintConfig() *config.Config {
+	return &config.Config{
+		IdentityFingerprint: config.IdentityFingerprintConfig{
+			Kimi: config.NormalizeKimiIdentityFingerprint(config.KimiIdentityFingerprintConfig{}),
+		},
+	}
+}
+
+func TestApplyKimiHeadersAdoptsLearnedClientIdentity(t *testing.T) {
+	req := kimiFingerprintRequest(t, map[string]string{
+		"User-Agent":         "KimiCLI/1.12.0",
+		"X-Msh-Platform":     "kimi_cli",
+		"X-Msh-Version":      "1.12.0",
+		"X-Msh-Device-Name":  "starship",
+		"X-Msh-Device-Model": "darwin arm64",
+		"X-Msh-Device-Id":    "device-from-client",
+	})
+	auth := &cliproxyauth.Auth{ID: "kimi-learned-account", Provider: "kimi"}
+
+	applyKimiHeadersWithAuth(req, "token", false, auth, kimiFingerprintConfig())
+
+	for header, want := range map[string]string{
+		"User-Agent":         "KimiCLI/1.12.0",
+		"X-Msh-Platform":     "kimi_cli",
+		"X-Msh-Version":      "1.12.0",
+		"X-Msh-Device-Name":  "starship",
+		"X-Msh-Device-Model": "darwin arm64",
+		// No credential-scoped id exists, so the client's own device is used rather
+		// than the host fallback every such credential would otherwise share.
+		"X-Msh-Device-Id": "device-from-client",
+	} {
+		if got := req.Header.Get(header); got != want {
+			t.Fatalf("%s = %q, want %q", header, got, want)
+		}
+	}
+}
+
+func TestApplyKimiHeadersKeepsCredentialDeviceIDOverLearnedOne(t *testing.T) {
+	req := kimiFingerprintRequest(t, map[string]string{
+		"User-Agent":      "KimiCLI/1.12.0",
+		"X-Msh-Platform":  "kimi_cli",
+		"X-Msh-Device-Id": "device-from-client",
+	})
+	auth := &cliproxyauth.Auth{
+		ID:       "kimi-bound-device-account",
+		Provider: "kimi",
+		Metadata: map[string]any{"device_id": "device-from-login"},
+	}
+
+	applyKimiHeadersWithAuth(req, "token", false, auth, kimiFingerprintConfig())
+
+	// The login-time device is the one Moonshot associated with the account.
+	if got := req.Header.Get("X-Msh-Device-Id"); got != "device-from-login" {
+		t.Fatalf("X-Msh-Device-Id = %q, want the credential's own device id", got)
+	}
+	if got := req.Header.Get("User-Agent"); got != "KimiCLI/1.12.0" {
+		t.Fatalf("User-Agent = %q, want the learned client version", got)
+	}
+}
+
+func TestApplyKimiHeadersIgnoresForeignClientIdentity(t *testing.T) {
+	req := kimiFingerprintRequest(t, map[string]string{
+		"User-Agent":      "curl/8.7.1",
+		"X-Msh-Device-Id": "not-a-kimi-device",
+	})
+	auth := &cliproxyauth.Auth{ID: "kimi-foreign-client-account", Provider: "kimi"}
+
+	applyKimiHeadersWithAuth(req, "token", false, auth, kimiFingerprintConfig())
+
+	if got := req.Header.Get("User-Agent"); got != config.DefaultKimiFingerprintUserAgent {
+		t.Fatalf("User-Agent = %q, want the builtin kimi-cli identity", got)
+	}
+	if got := req.Header.Get("X-Msh-Device-Id"); got == "not-a-kimi-device" {
+		t.Fatal("a non-kimi caller must not set the account's outbound device id")
+	}
+	// The host fallback still applies, matching the pre-fingerprint behaviour.
+	if got := req.Header.Get("X-Msh-Device-Name"); got != getKimiHostname() {
+		t.Fatalf("X-Msh-Device-Name = %q, want the host fallback", got)
+	}
+}
+
+func TestApplyKimiHeadersWithFingerprintDisabledKeepsLegacyDefaults(t *testing.T) {
+	req := kimiFingerprintRequest(t, map[string]string{
+		"User-Agent":     "KimiCLI/1.12.0",
+		"X-Msh-Platform": "kimi_cli",
+	})
+	cfg := &config.Config{
+		KimiHeaderDefaults: config.KimiHeaderDefaults{UserAgent: "KimiCLI/1.8.0", Version: "1.8.0"},
+	}
+	auth := &cliproxyauth.Auth{ID: "kimi-fingerprint-off-account", Provider: "kimi"}
+
+	applyKimiHeadersWithAuth(req, "token", false, auth, cfg)
+
+	if got := req.Header.Get("User-Agent"); got != "KimiCLI/1.8.0" {
+		t.Fatalf("User-Agent = %q, want the configured header defaults when the fingerprint is off", got)
+	}
+	if got := req.Header.Get("X-Msh-Version"); got != "1.8.0" {
+		t.Fatalf("X-Msh-Version = %q, want the configured header defaults", got)
+	}
+}
+
+func TestApplyKimiHeadersFingerprintKeepsLegacyHeaderDefaultsAsPreset(t *testing.T) {
+	req := kimiFingerprintRequest(t, nil)
+	cfg := kimiFingerprintConfig()
+	cfg.KimiHeaderDefaults = config.KimiHeaderDefaults{UserAgent: "KimiCLI/1.8.0", Version: "1.8.0"}
+	auth := &cliproxyauth.Auth{ID: "kimi-legacy-preset-account", Provider: "kimi"}
+
+	applyKimiHeadersWithAuth(req, "token", false, auth, cfg)
+
+	// Enabling the fingerprint must not silently replace an operator's existing
+	// kimi-header-defaults with the builtin template.
+	if got := req.Header.Get("User-Agent"); got != "KimiCLI/1.8.0" {
+		t.Fatalf("User-Agent = %q, want the legacy header defaults to survive", got)
+	}
+	if got := req.Header.Get("X-Msh-Platform"); got != config.DefaultKimiFingerprintPlatform {
+		t.Fatalf("X-Msh-Platform = %q, want the builtin value for the field legacy config left unset", got)
+	}
+}
+
+func TestKimiFingerprintCustomHeadersCannotOverrideManagedHeaders(t *testing.T) {
+	headers := http.Header{}
+	applyKimiIdentityFingerprintHeaders(headers, config.KimiIdentityFingerprintConfig{
+		Enabled:   true,
+		UserAgent: "KimiCLI/1.12.0",
+		CustomHeaders: map[string]string{
+			"X-Msh-Device-Id": "spoofed",
+			"X-Msh-Trace":     "kept",
+		},
+	})
+
+	if got := headers.Get("X-Msh-Device-Id"); got != "" {
+		t.Fatalf("X-Msh-Device-Id = %q, want the managed header left untouched", got)
+	}
+	if got := headers.Get("X-Msh-Trace"); got != "kept" {
+		t.Fatalf("X-Msh-Trace = %q, want unmanaged custom headers applied", got)
+	}
+}

--- a/internal/runtime/executor/kimi_models.go
+++ b/internal/runtime/executor/kimi_models.go
@@ -1,0 +1,273 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	kimiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	kimiModelsPath = "/v1/models"
+	// Upstream advertises bare ids (k2.5); routing uses the kimi- namespace and
+	// stripKimiPrefix removes it again before the chat request goes out. Keeping
+	// discovery in the prefixed namespace is what makes a newly released id
+	// routable without a catalog change.
+	kimiModelIDPrefix = "kimi-"
+)
+
+var kimiModelsCache struct {
+	mu     sync.RWMutex
+	models []*sdkmodelcatalog.ModelInfo
+}
+
+type kimiModelsResponse struct {
+	Data []kimiModelPayload `json:"data"`
+}
+
+type kimiModelPayload struct {
+	ID                  string `json:"id"`
+	Object              string `json:"object"`
+	Created             int64  `json:"created"`
+	OwnedBy             string `json:"owned_by"`
+	DisplayName         string `json:"display_name"`
+	Description         string `json:"description"`
+	ContextLength       int    `json:"context_length"`
+	MaxCompletionTokens int    `json:"max_completion_tokens"`
+}
+
+func cloneKimiModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		clone := *model
+		if len(model.SupportedGenerationMethods) > 0 {
+			clone.SupportedGenerationMethods = append([]string(nil), model.SupportedGenerationMethods...)
+		}
+		if len(model.SupportedParameters) > 0 {
+			clone.SupportedParameters = append([]string(nil), model.SupportedParameters...)
+		}
+		clone.Thinking = cloneKimiThinking(model.Thinking)
+		out = append(out, &clone)
+	}
+	return out
+}
+
+func storeKimiModels(models []*sdkmodelcatalog.ModelInfo) bool {
+	cloned := cloneKimiModels(models)
+	if len(cloned) == 0 {
+		return false
+	}
+	kimiModelsCache.mu.Lock()
+	kimiModelsCache.models = cloned
+	kimiModelsCache.mu.Unlock()
+	return true
+}
+
+func loadKimiModels() []*sdkmodelcatalog.ModelInfo {
+	kimiModelsCache.mu.RLock()
+	cloned := cloneKimiModels(kimiModelsCache.models)
+	kimiModelsCache.mu.RUnlock()
+	return cloned
+}
+
+// fallbackKimiModels keeps the last successful discovery result. It deliberately
+// does not fall back to the compiled-in catalog: callers that need a guaranteed
+// list (startup registration) apply that fallback themselves, so an empty return
+// here still means "upstream told us nothing".
+func fallbackKimiModels() []*sdkmodelcatalog.ModelInfo {
+	if models := loadKimiModels(); len(models) > 0 {
+		log.Debugf("kimi executor: using cached model list (%d models)", len(models))
+		return models
+	}
+	return nil
+}
+
+// FetchKimiModels retrieves the account's live model list from the Kimi coding
+// gateway, which exposes the OpenAI-compatible /v1/models listing on the same
+// base URL and credentials as chat completions.
+func FetchKimiModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	token := strings.TrimSpace(kimiCreds(auth))
+	if token == "" {
+		return fallbackKimiModels()
+	}
+
+	modelsURL := strings.TrimRight(kimiauth.KimiAPIBaseURL, "/") + kimiModelsPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return fallbackKimiModels()
+	}
+	// Same identity headers as chat traffic: the gateway rejects requests that do
+	// not look like kimi-cli, and the device id must match the account's.
+	applyKimiHeadersWithAuth(req, token, false, auth, cfg)
+
+	resp, err := newProxyAwareHTTPClient(ctx, cfg, auth, 0).Do(req)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			log.Debugf("kimi executor: models request failed: %v", err)
+		}
+		return fallbackKimiModels()
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("kimi executor: close models response body error: %v", errClose)
+		}
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		log.Debugf("kimi executor: models request failed with status %d", resp.StatusCode)
+		return fallbackKimiModels()
+	}
+
+	body, err := readUpstreamResponseBody("kimi", resp.Body)
+	if err != nil {
+		log.Debugf("kimi executor: models response read failed: %v", err)
+		return fallbackKimiModels()
+	}
+
+	models, ok := parseKimiModels(body, time.Now().Unix())
+	if !ok {
+		log.Debug("kimi executor: fetched empty or invalid model list; retaining cached model list")
+		return fallbackKimiModels()
+	}
+	storeKimiModels(models)
+	return models
+}
+
+func parseKimiModels(body []byte, now int64) ([]*sdkmodelcatalog.ModelInfo, bool) {
+	var decoded kimiModelsResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, false
+	}
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(decoded.Data))
+	seen := make(map[string]struct{}, len(decoded.Data))
+	for _, item := range decoded.Data {
+		upstreamID := strings.TrimSpace(item.ID)
+		if upstreamID == "" {
+			continue
+		}
+		model := kimiModelInfoFromPayload(item, upstreamID, now)
+		key := strings.ToLower(model.ID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, model)
+	}
+	return out, len(out) > 0
+}
+
+func kimiModelInfoFromPayload(item kimiModelPayload, upstreamID string, now int64) *sdkmodelcatalog.ModelInfo {
+	modelID := namespaceKimiModelID(upstreamID)
+	object := strings.TrimSpace(item.Object)
+	if object == "" {
+		object = "model"
+	}
+	ownedBy := strings.TrimSpace(item.OwnedBy)
+	if ownedBy == "" {
+		ownedBy = "moonshot"
+	}
+	created := item.Created
+	if created == 0 {
+		created = now
+	}
+	model := &sdkmodelcatalog.ModelInfo{
+		ID:                  modelID,
+		Object:              object,
+		Created:             created,
+		OwnedBy:             ownedBy,
+		Type:                "kimi",
+		DisplayName:         firstNonEmptyString(item.DisplayName, kimiDisplayNameFromID(modelID)),
+		Name:                modelID,
+		Version:             modelID,
+		Description:         strings.TrimSpace(item.Description),
+		ContextLength:       item.ContextLength,
+		InputTokenLimit:     item.ContextLength,
+		MaxCompletionTokens: item.MaxCompletionTokens,
+		OutputTokenLimit:    item.MaxCompletionTokens,
+	}
+	if !strings.EqualFold(modelID, upstreamID) {
+		model.UpstreamModelID = upstreamID
+	}
+	// The listing carries ids, not capabilities. Reasoning support and token
+	// limits come from the compiled-in catalog when it knows the model; a model
+	// the catalog has never seen keeps Thinking nil rather than inheriting a
+	// guessed budget, because an unsupported reasoning_effort is a 400 upstream.
+	if static := sdkmodelcatalog.LookupStaticModelInfo(modelID); static != nil {
+		model.Thinking = cloneKimiThinking(static.Thinking)
+		if model.Description == "" {
+			model.Description = static.Description
+		}
+		model.DisplayName = firstNonEmptyString(item.DisplayName, static.DisplayName, model.DisplayName)
+		if model.ContextLength == 0 {
+			model.ContextLength = static.ContextLength
+			model.InputTokenLimit = static.ContextLength
+		}
+		if model.MaxCompletionTokens == 0 {
+			model.MaxCompletionTokens = static.MaxCompletionTokens
+			model.OutputTokenLimit = static.MaxCompletionTokens
+		}
+	}
+	return model
+}
+
+// namespaceKimiModelID puts an upstream id into the kimi- routing namespace.
+// Ids that already carry the prefix are left alone so the gateway switching to
+// prefixed ids would not produce kimi-kimi-k2.
+func namespaceKimiModelID(upstreamID string) string {
+	trimmed := strings.TrimSpace(upstreamID)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(trimmed), kimiModelIDPrefix) {
+		return trimmed
+	}
+	return kimiModelIDPrefix + trimmed
+}
+
+// kimiDisplayNameFromID renders kimi-k2.5 as "Kimi K2.5" so a model the catalog
+// does not know still reads like the curated entries in the panel.
+func kimiDisplayNameFromID(modelID string) string {
+	trimmed := strings.TrimSpace(modelID)
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.Split(trimmed, "-")
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+func cloneKimiThinking(thinking *sdkmodelcatalog.ThinkingSupport) *sdkmodelcatalog.ThinkingSupport {
+	if thinking == nil {
+		return nil
+	}
+	clone := *thinking
+	if len(thinking.Levels) > 0 {
+		clone.Levels = append([]string(nil), thinking.Levels...)
+	}
+	return &clone
+}

--- a/internal/runtime/executor/kimi_models_test.go
+++ b/internal/runtime/executor/kimi_models_test.go
@@ -1,0 +1,209 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	kimiauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/kimi"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+type kimiModelsRoundTripper struct {
+	req    *http.Request
+	body   string
+	status int
+}
+
+func (k *kimiModelsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	k.req = req
+	status := k.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(k.body)),
+		Request:    req,
+	}, nil
+}
+
+func resetKimiModelsCacheForTest() {
+	kimiModelsCache.mu.Lock()
+	kimiModelsCache.models = nil
+	kimiModelsCache.mu.Unlock()
+}
+
+func kimiOAuthAuth() *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{
+		Provider: "kimi",
+		Metadata: map[string]any{
+			"access_token": "kimi-token",
+			"device_id":    "device-abc",
+		},
+	}
+}
+
+func fetchKimiModelsWithBody(t *testing.T, body string) ([]*sdkmodelcatalog.ModelInfo, *kimiModelsRoundTripper) {
+	t.Helper()
+	rt := &kimiModelsRoundTripper{body: body}
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, rt)
+	return FetchKimiModels(ctx, kimiOAuthAuth(), nil), rt
+}
+
+func kimiModelsByID(models []*sdkmodelcatalog.ModelInfo) map[string]*sdkmodelcatalog.ModelInfo {
+	byID := make(map[string]*sdkmodelcatalog.ModelInfo, len(models))
+	for _, model := range models {
+		if model != nil {
+			byID[model.ID] = model
+		}
+	}
+	return byID
+}
+
+func TestFetchKimiModelsNamespacesUpstreamIDs(t *testing.T) {
+	resetKimiModelsCacheForTest()
+	t.Cleanup(resetKimiModelsCacheForTest)
+
+	models, rt := fetchKimiModelsWithBody(t, `{
+		"object": "list",
+		"data": [
+			{"id": "k2.5", "object": "model", "created": 1769472000, "owned_by": "moonshot"},
+			{"id": "kimi-k2", "object": "model", "owned_by": "moonshot"}
+		]
+	}`)
+
+	if rt.req == nil {
+		t.Fatal("expected models request to be issued")
+	}
+	wantURL := strings.TrimRight(kimiauth.KimiAPIBaseURL, "/") + kimiModelsPath
+	if got := rt.req.URL.String(); got != wantURL {
+		t.Fatalf("models URL = %q, want %q", got, wantURL)
+	}
+	if got := rt.req.Header.Get("Authorization"); got != "Bearer kimi-token" {
+		t.Fatalf("Authorization = %q, want Bearer kimi-token", got)
+	}
+	// The gateway rejects requests that do not look like kimi-cli, so discovery
+	// must carry the same identity headers as chat traffic.
+	if got := rt.req.Header.Get("X-Msh-Platform"); got != "kimi_cli" {
+		t.Fatalf("X-Msh-Platform = %q, want kimi_cli", got)
+	}
+	if got := rt.req.Header.Get("X-Msh-Device-Id"); got != "device-abc" {
+		t.Fatalf("X-Msh-Device-Id = %q, want the account device id", got)
+	}
+
+	byID := kimiModelsByID(models)
+	bare := byID["kimi-k2.5"]
+	if bare == nil {
+		t.Fatalf("models = %+v, want bare id namespaced to kimi-k2.5", models)
+	}
+	if bare.UpstreamModelID != "k2.5" {
+		t.Fatalf("kimi-k2.5 upstream = %q, want k2.5", bare.UpstreamModelID)
+	}
+	if bare.Type != "kimi" {
+		t.Fatalf("kimi-k2.5 type = %q, want kimi", bare.Type)
+	}
+	prefixed := byID["kimi-k2"]
+	if prefixed == nil {
+		t.Fatalf("models = %+v, want already-prefixed id kept as kimi-k2", models)
+	}
+	if prefixed.UpstreamModelID != "" {
+		t.Fatalf("kimi-k2 upstream = %q, want empty when the id needs no rewrite", prefixed.UpstreamModelID)
+	}
+}
+
+func TestFetchKimiModelsEnrichesKnownModelsFromStaticCatalog(t *testing.T) {
+	resetKimiModelsCacheForTest()
+	t.Cleanup(resetKimiModelsCacheForTest)
+
+	models, _ := fetchKimiModelsWithBody(t, `{"data":[{"id":"k2.6","object":"model"}]}`)
+
+	byID := kimiModelsByID(models)
+	model := byID["kimi-k2.6"]
+	if model == nil {
+		t.Fatalf("models = %+v, want kimi-k2.6", models)
+	}
+	// The listing carries ids only; reasoning support has to come from the catalog
+	// or ApplyThinking silently drops the client's reasoning_effort.
+	if model.Thinking == nil {
+		t.Fatal("kimi-k2.6 thinking support = nil, want the catalog definition")
+	}
+	if model.DisplayName != "Kimi K2.6" {
+		t.Fatalf("kimi-k2.6 display name = %q, want Kimi K2.6", model.DisplayName)
+	}
+	if model.ContextLength != 131072 {
+		t.Fatalf("kimi-k2.6 context length = %d, want the catalog value", model.ContextLength)
+	}
+	if model.OwnedBy != "moonshot" {
+		t.Fatalf("kimi-k2.6 owned_by = %q, want moonshot", model.OwnedBy)
+	}
+}
+
+func TestFetchKimiModelsKeepsUnknownModelWithoutGuessedCapabilities(t *testing.T) {
+	resetKimiModelsCacheForTest()
+	t.Cleanup(resetKimiModelsCacheForTest)
+
+	models, _ := fetchKimiModelsWithBody(t, `{"data":[{"id":"k9-preview","object":"model"}]}`)
+
+	byID := kimiModelsByID(models)
+	model := byID["kimi-k9-preview"]
+	if model == nil {
+		t.Fatalf("models = %+v, want an id the catalog has never seen to still be routable", models)
+	}
+	if model.Thinking != nil {
+		t.Fatalf("kimi-k9-preview thinking = %+v, want nil rather than a guessed budget", model.Thinking)
+	}
+	if model.DisplayName != "Kimi K9 Preview" {
+		t.Fatalf("kimi-k9-preview display name = %q, want a readable fallback", model.DisplayName)
+	}
+}
+
+func TestFetchKimiModelsFallsBackToCachedCatalog(t *testing.T) {
+	resetKimiModelsCacheForTest()
+	t.Cleanup(resetKimiModelsCacheForTest)
+
+	if ok := storeKimiModels([]*sdkmodelcatalog.ModelInfo{{ID: "kimi-cached", OwnedBy: "moonshot", Type: "kimi"}}); !ok {
+		t.Fatal("expected cache seed to store")
+	}
+
+	rt := &kimiModelsRoundTripper{status: http.StatusInternalServerError, body: `{"error":"boom"}`}
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, rt)
+	models := FetchKimiModels(ctx, kimiOAuthAuth(), nil)
+
+	if len(models) != 1 || models[0].ID != "kimi-cached" {
+		t.Fatalf("fallback models = %+v, want the cached list retained", models)
+	}
+}
+
+func TestFetchKimiModelsWithoutCredentialsDoesNotCallUpstream(t *testing.T) {
+	resetKimiModelsCacheForTest()
+	t.Cleanup(resetKimiModelsCacheForTest)
+
+	rt := &kimiModelsRoundTripper{body: `{"data":[{"id":"k2.5"}]}`}
+	ctx := context.WithValue(context.Background(), util.ContextKeyRoundTripper, rt)
+	models := FetchKimiModels(ctx, &cliproxyauth.Auth{Provider: "kimi"}, nil)
+
+	if rt.req != nil {
+		t.Fatal("expected no upstream request without a token")
+	}
+	if len(models) != 0 {
+		t.Fatalf("models = %+v, want empty so callers apply their own floor", models)
+	}
+}
+
+func TestParseKimiModelsRejectsEmptyAndInvalidPayloads(t *testing.T) {
+	if _, ok := parseKimiModels([]byte(`not json`), 1); ok {
+		t.Fatal("invalid JSON reported as a usable model list")
+	}
+	if _, ok := parseKimiModels([]byte(`{"data":[]}`), 1); ok {
+		t.Fatal("empty listing reported as a usable model list")
+	}
+	if _, ok := parseKimiModels([]byte(`{"data":[{"id":"   "}]}`), 1); ok {
+		t.Fatal("blank id reported as a usable model list")
+	}
+}

--- a/internal/storage/postgres/ip_access_migrations.go
+++ b/internal/storage/postgres/ip_access_migrations.go
@@ -9,8 +9,45 @@ func laterRuntimeMigrations() []Migration {
 		// Operator-managed IP allow/deny list, authentication attempt log, and
 		// source address on audit rows.
 		{Version: "202608100001_ip_access_control", SQL: ipAccessControlSQL},
+		// Drop model/channel scopes stranded on end users by an unbound permission
+		// profile. See endUserUnboundProfileScopeCleanupSQL.
+		{Version: "202608270001_end_user_unbound_profile_scope_cleanup", SQL: endUserUnboundProfileScopeCleanupSQL},
 	}
 }
+
+// endUserUnboundProfileScopeCleanupSQL clears model/channel scopes left on end
+// users that have no permission profile.
+//
+// Binding a profile copied its allowed-models / allowed-channels /
+// allowed-channel-groups onto the account row; unbinding cleared the quota
+// fields and left those three behind. The console renders them only while a
+// profile is attached, so the account showed "unrestricted" while a stale
+// channel-group whitelist kept every credential outside that group unreachable
+// — invisible in the UI, and with no way to clear it from there either.
+//
+// The unbind path now clears them, but that only helps the next unbind: an
+// account already in this state can no longer reach the code that would fix it.
+// Hence this one-off pass.
+//
+// Scope is deliberately narrow: only rows with no profile, and only the fields
+// a profile owns. A tenant that set these through the API without a profile is
+// outside what the console can express, and would have been equally invisible
+// there; the trade is a visible empty list over a silent unreachable one.
+const endUserUnboundProfileScopeCleanupSQL = `
+UPDATE end_users
+SET allowed_models         = '[]',
+    allowed_channels       = '[]',
+    allowed_channel_groups = '[]',
+    system_prompt          = '',
+    updated_at             = CURRENT_TIMESTAMP
+WHERE COALESCE(TRIM(permission_profile_id), '') = ''
+  AND (
+        COALESCE(allowed_models, '[]')         NOT IN ('[]', '')
+     OR COALESCE(allowed_channels, '[]')       NOT IN ('[]', '')
+     OR COALESCE(allowed_channel_groups, '[]') NOT IN ('[]', '')
+     OR COALESCE(system_prompt, '')            <> ''
+      );
+`
 
 // ipAccessControlSQL adds the operator-managed IP allow/deny list, the
 // authentication attempt log that makes an attack source identifiable, and the

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -11,14 +11,27 @@ import (
 
 func TestRuntimeMigrationsCoverCoreTables(t *testing.T) {
 	migrations := RuntimeMigrations()
-	if len(migrations) != 28 {
-		t.Fatalf("RuntimeMigrations len = %d, want 28", len(migrations))
+	if len(migrations) != 29 {
+		t.Fatalf("RuntimeMigrations len = %d, want 29", len(migrations))
 	}
-	// Latest: the IP allow/deny list, authentication attempt log, and source
-	// address on audit rows. Appended from laterRuntimeMigrations() because
-	// migrations.go sits at its structure-gate size ceiling.
+	// Appended from laterRuntimeMigrations() because migrations.go sits at its
+	// structure-gate size ceiling.
 	if migrations[27].Version != "202608100001_ip_access_control" {
-		t.Fatalf("latest migration version = %q", migrations[27].Version)
+		t.Fatalf("ip access migration version = %q", migrations[27].Version)
+	}
+	// Latest: clears model/channel scopes stranded on end users whose permission
+	// profile was unbound without them.
+	if migrations[28].Version != "202608270001_end_user_unbound_profile_scope_cleanup" {
+		t.Fatalf("latest migration version = %q", migrations[28].Version)
+	}
+	for _, fragment := range []string{
+		"UPDATE end_users",
+		"allowed_channel_groups = '[]'",
+		"COALESCE(TRIM(permission_profile_id), '') = ''",
+	} {
+		if !strings.Contains(migrations[28].SQL, fragment) {
+			t.Fatalf("scope cleanup migration missing %q", fragment)
+		}
 	}
 	for _, fragment := range []string{
 		"CREATE TABLE IF NOT EXISTS ip_access_rules",

--- a/sdk/cliproxy/auth/conductor_selector_service.go
+++ b/sdk/cliproxy/auth/conductor_selector_service.go
@@ -237,7 +237,7 @@ func (s selectorService) pickLocked(
 		candidates := s.buildCandidatesLocked(scope, selectorRouteGroup, tried, registryRef, includeCandidate)
 		if len(candidates) == 0 {
 			if diagnosis == nil {
-				diagnosis = s.diagnoseEmptyCandidates(scope, selectorRouteGroup, includeCandidate)
+				diagnosis = s.diagnoseEmptyCandidates(scope, selectorRouteGroup, registryRef, includeCandidate)
 			}
 			continue
 		}

--- a/sdk/cliproxy/auth/selection_diagnostics.go
+++ b/sdk/cliproxy/auth/selection_diagnostics.go
@@ -28,6 +28,16 @@ type selectionRejection struct {
 	// credential for the request's provider, which is what makes a model-scope
 	// rejection the likely explanation rather than "there are no accounts".
 	sawTenantCandidate bool
+	// sawServingCandidate records that some healthy tenant credential actually
+	// serves the requested model. Without it a scope rejection means nothing:
+	// the model may simply not be registered anywhere.
+	sawServingCandidate bool
+	// servingBlockedByChannels records that a serving credential was excluded by
+	// the caller's allowed-channels restriction.
+	servingBlockedByChannels bool
+	// servingBlockedByGroups records that a serving credential was excluded by
+	// the caller's allowed-channel-groups restriction.
+	servingBlockedByGroups bool
 }
 
 // diagnoseEmptyCandidates inspects the credentials the scope considered and
@@ -36,6 +46,7 @@ type selectionRejection struct {
 func (s selectorService) diagnoseEmptyCandidates(
 	scope selectionScope,
 	scopedRouteGroup string,
+	registryRef ModelRegistry,
 	includeCandidate func(candidate *Auth) bool,
 ) error {
 	if s.manager == nil || scope.modelKey == "" {
@@ -55,6 +66,26 @@ func (s selectorService) diagnoseEmptyCandidates(
 		}
 		rejection.sawTenantCandidate = true
 
+		// Everything below only makes sense for a credential that serves the model.
+		// A credential outside the caller's channel scope that could not serve it
+		// anyway is not the reason the request failed.
+		if !candidateServesModel(registryRef, candidate, scope.modelKey) {
+			continue
+		}
+		rejection.sawServingCandidate = true
+
+		// The caller's own restrictions come first: they exclude the credential
+		// before any group's model list is consulted, and they are what the
+		// operator has to change.
+		if !authAllowedByChannels(candidate, scope.allowedChannels) {
+			rejection.servingBlockedByChannels = true
+			continue
+		}
+		if !authAllowedByGroups(scope.cfg, candidate, scope.allowedGroups) {
+			rejection.servingBlockedByGroups = true
+			continue
+		}
+
 		// Re-run only the model-scope gate. A candidate that clears it was excluded
 		// for some other reason, which this diagnosis deliberately does not guess at.
 		groups := authGroups(scope.cfg, candidate)
@@ -66,7 +97,35 @@ func (s selectorService) diagnoseEmptyCandidates(
 		}
 	}
 
-	if !rejection.sawTenantCandidate || len(rejection.modelBlockedByGroups) == 0 {
+	if !rejection.sawTenantCandidate {
+		return nil
+	}
+
+	// A credential that serves the model exists but the caller may not reach it.
+	// This is the case the generic message hid worst: the panel lists the account,
+	// the model panel lists the model, and the request still says "no auth".
+	if rejection.sawServingCandidate {
+		if rejection.servingBlockedByGroups {
+			return &Error{
+				Code: "model_outside_allowed_channel_groups",
+				Message: fmt.Sprintf(
+					"model %q is served only by credentials outside the channel groups this credential may use (%s); add a serving account to one of those groups, or widen the allowed channel groups",
+					scope.modelKey, describeScopeNames(scope.allowedGroups),
+				),
+			}
+		}
+		if rejection.servingBlockedByChannels {
+			return &Error{
+				Code: "model_outside_allowed_channels",
+				Message: fmt.Sprintf(
+					"model %q is served only by credentials outside the channels this credential may use (%s); widen the allowed channels or use an account in one of them",
+					scope.modelKey, describeScopeNames(scope.allowedChannels),
+				),
+			}
+		}
+	}
+
+	if len(rejection.modelBlockedByGroups) == 0 {
 		return nil
 	}
 
@@ -83,6 +142,35 @@ func (s selectorService) diagnoseEmptyCandidates(
 			scope.modelKey, strings.Join(quoteAll(names), ", "),
 		),
 	}
+}
+
+// candidateServesModel reports whether a credential can serve a model, ignoring
+// every scope gate. It mirrors the registry half of candidateSupportsModelOpts so
+// the diagnosis agrees with the selector on what "serves" means.
+func candidateServesModel(registryRef ModelRegistry, auth *Auth, modelID string) bool {
+	if auth == nil {
+		return false
+	}
+	if registryRef == nil {
+		return true
+	}
+	if len(registryRef.GetModelsForClient(auth.ID)) == 0 {
+		return !authHasDisableAllModelsRule(auth)
+	}
+	return registryRef.ClientSupportsModel(auth.ID, modelID)
+}
+
+// describeScopeNames renders a restriction set for an operator-facing message.
+func describeScopeNames(scope map[string]struct{}) string {
+	if len(scope) == 0 {
+		return "none"
+	}
+	names := make([]string, 0, len(scope))
+	for name := range scope {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(quoteAll(names), ", ")
 }
 
 // blockingRouteGroups lists the groups whose allowed-models list rejected a model.

--- a/sdk/cliproxy/auth/selection_diagnostics.go
+++ b/sdk/cliproxy/auth/selection_diagnostics.go
@@ -38,6 +38,11 @@ type selectionRejection struct {
 	// servingBlockedByGroups records that a serving credential was excluded by
 	// the caller's allowed-channel-groups restriction.
 	servingBlockedByGroups bool
+	// servingGroups holds the channel groups the excluded serving credentials
+	// actually belong to. Naming the allowed set alone left the operator guessing
+	// which group to add: the model list they had already edited lived in a group
+	// they could not reach.
+	servingGroups map[string]struct{}
 }
 
 // diagnoseEmptyCandidates inspects the credentials the scope considered and
@@ -53,7 +58,10 @@ func (s selectorService) diagnoseEmptyCandidates(
 		return nil
 	}
 
-	rejection := selectionRejection{modelBlockedByGroups: map[string]struct{}{}}
+	rejection := selectionRejection{
+		modelBlockedByGroups: map[string]struct{}{},
+		servingGroups:        map[string]struct{}{},
+	}
 	for _, candidate := range s.manager.auths {
 		if candidate == nil || candidate.Disabled || candidate.Status == StatusDisabled {
 			continue
@@ -83,6 +91,9 @@ func (s selectorService) diagnoseEmptyCandidates(
 		}
 		if !authAllowedByGroups(scope.cfg, candidate, scope.allowedGroups) {
 			rejection.servingBlockedByGroups = true
+			for group := range authGroups(scope.cfg, candidate) {
+				rejection.servingGroups[group] = struct{}{}
+			}
 			continue
 		}
 
@@ -109,8 +120,8 @@ func (s selectorService) diagnoseEmptyCandidates(
 			return &Error{
 				Code: "model_outside_allowed_channel_groups",
 				Message: fmt.Sprintf(
-					"model %q is served only by credentials outside the channel groups this credential may use (%s); add a serving account to one of those groups, or widen the allowed channel groups",
-					scope.modelKey, describeScopeNames(scope.allowedGroups),
+					"model %q is served by credentials in channel group %s, which this credential may not use (allowed: %s); add a serving group to the allowed channel groups, or move a serving account into an allowed one",
+					scope.modelKey, describeScopeNames(rejection.servingGroups), describeScopeNames(scope.allowedGroups),
 				),
 			}
 		}

--- a/sdk/cliproxy/auth/selection_diagnostics_test.go
+++ b/sdk/cliproxy/auth/selection_diagnostics_test.go
@@ -237,6 +237,11 @@ func TestModelOutsideAllowedChannelGroupsIsNamed(t *testing.T) {
 	if !strings.Contains(selectionErr.Message, "group") {
 		t.Errorf("message does not name the allowed channel group: %q", selectionErr.Message)
 	}
+	// Naming only the allowed set left the operator guessing which group to add:
+	// they had already edited the model list of a group they could not reach.
+	if !strings.Contains(selectionErr.Message, "default") {
+		t.Errorf("message does not name the group that actually serves the model: %q", selectionErr.Message)
+	}
 }
 
 // TestReachableModelStillSelectableUnderChannelGroupScope pins that the diagnosis

--- a/sdk/cliproxy/auth/selection_diagnostics_test.go
+++ b/sdk/cliproxy/auth/selection_diagnostics_test.go
@@ -7,6 +7,7 @@ import (
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
 )
 
 // restrictedGroupManager reproduces the production shape that made this bug so hard
@@ -132,5 +133,143 @@ func TestUnrestrictedGroupDoesNotClaimBlocking(t *testing.T) {
 		if asErr, ok := err.(*Error); ok && asErr.Code == "model_not_allowed_by_channel_group" {
 			t.Errorf("a group without an allowed-models list must not be reported as blocking: %v", asErr.Message)
 		}
+	}
+}
+
+// pickWithScope drives selection with the caller-side restrictions an API key or
+// end user carries, which is where the misleading message came from in production.
+func pickWithScope(manager *Manager, model string, meta map[string]any) error {
+	_, _, _, err := manager.pickNextMixed(
+		context.Background(),
+		[]string{"xai", "kimi"},
+		model,
+		cliproxyexecutor.Options{Metadata: meta},
+		map[string]struct{}{},
+	)
+	return err
+}
+
+// scopedModelRegistry serves each model from exactly one credential, which is what
+// makes "the account that serves this model is out of scope" distinguishable from
+// "nothing serves this model".
+type scopedModelRegistry struct {
+	byClient map[string][]string
+}
+
+func (r *scopedModelRegistry) ClearModelQuotaExceeded(string, string)    {}
+func (r *scopedModelRegistry) SetModelQuotaExceeded(string, string)      {}
+func (r *scopedModelRegistry) SuspendClientModel(string, string, string) {}
+func (r *scopedModelRegistry) ResumeClientModel(string, string)          {}
+
+func (r *scopedModelRegistry) ClientSupportsModel(clientID, modelID string) bool {
+	for _, model := range r.byClient[clientID] {
+		if strings.EqualFold(model, modelID) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *scopedModelRegistry) GetModelsForClient(clientID string) []*sdkmodelcatalog.ModelInfo {
+	out := make([]*sdkmodelcatalog.ModelInfo, 0, len(r.byClient[clientID]))
+	for _, model := range r.byClient[clientID] {
+		out = append(out, &sdkmodelcatalog.ModelInfo{ID: model})
+	}
+	return out
+}
+
+// twoChannelManager mirrors the reported deployment: two healthy accounts, only one
+// of them inside the channel group the caller is restricted to.
+func twoChannelManager(t *testing.T) *Manager {
+	t.Helper()
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []internalconfig.RoutingChannelGroup{
+				{Name: "group", Match: internalconfig.ChannelGroupMatch{Channels: []string{"Grok Account"}}},
+			},
+		},
+	})
+	manager.RegisterExecutor(&stubExecutor{id: "xai"})
+	manager.RegisterExecutor(&stubExecutor{id: "kimi"})
+
+	for _, auth := range []*Auth{
+		{ID: "xai-auth", Label: "Grok Account", Provider: "xai", Status: StatusActive},
+		{ID: "kimi-auth", Label: "kimi", Provider: "kimi", Status: StatusActive},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", auth.ID, err)
+		}
+	}
+	manager.SetModelRegistry(&scopedModelRegistry{byClient: map[string][]string{
+		"xai-auth":  {"grok-4.5"},
+		"kimi-auth": {"kimi-k3"},
+	}})
+	return manager
+}
+
+// TestModelOutsideAllowedChannelGroupsIsNamed is the fix for the reported case: the
+// kimi account was healthy, the model was registered on it, and the request still
+// said "no auth available" because the caller could only use one channel group.
+func TestModelOutsideAllowedChannelGroupsIsNamed(t *testing.T) {
+	manager := twoChannelManager(t)
+
+	err := pickWithScope(manager, "kimi-k3", map[string]any{
+		"allowed-channel-groups": []string{"group"},
+	})
+	if err == nil {
+		t.Fatal("a credential outside the allowed channel groups must not be selectable")
+	}
+	selectionErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("error type = %T, want *Error", err)
+	}
+	if selectionErr.Code != "model_outside_allowed_channel_groups" {
+		t.Fatalf("code = %q, want model_outside_allowed_channel_groups (message: %s)", selectionErr.Code, selectionErr.Message)
+	}
+	// Both halves have to be named: the model the caller asked for and the scope
+	// that excluded it, because the fix is to edit one of them.
+	if !strings.Contains(selectionErr.Message, "kimi-k3") {
+		t.Errorf("message does not name the model: %q", selectionErr.Message)
+	}
+	if !strings.Contains(selectionErr.Message, "group") {
+		t.Errorf("message does not name the allowed channel group: %q", selectionErr.Message)
+	}
+}
+
+// TestReachableModelStillSelectableUnderChannelGroupScope pins that the diagnosis
+// changed no routing: the account inside the allowed group still serves.
+func TestReachableModelStillSelectableUnderChannelGroupScope(t *testing.T) {
+	manager := twoChannelManager(t)
+
+	if err := pickWithScope(manager, "grok-4.5", map[string]any{
+		"allowed-channel-groups": []string{"group"},
+	}); err != nil {
+		t.Fatalf("an account inside the allowed group must still be selectable: %v", err)
+	}
+}
+
+// TestModelOutsideAllowedChannelsIsNamed covers the per-channel restriction, which
+// produced the same unhelpful message.
+func TestModelOutsideAllowedChannelsIsNamed(t *testing.T) {
+	manager := twoChannelManager(t)
+
+	err := pickWithScope(manager, "kimi-k3", map[string]any{
+		"allowed-channels": []string{"Grok Account"},
+	})
+	if err == nil {
+		t.Fatal("a credential outside the allowed channels must not be selectable")
+	}
+	selectionErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("error type = %T, want *Error", err)
+	}
+	if selectionErr.Code != "model_outside_allowed_channels" {
+		t.Fatalf("code = %q, want model_outside_allowed_channels (message: %s)", selectionErr.Code, selectionErr.Message)
+	}
+	if !strings.Contains(selectionErr.Message, "kimi-k3") {
+		t.Errorf("message does not name the model: %q", selectionErr.Message)
 	}
 }

--- a/sdk/cliproxy/service_model_kimi.go
+++ b/sdk/cliproxy/service_model_kimi.go
@@ -1,0 +1,30 @@
+package cliproxy
+
+import (
+	"context"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+	serviceapp "github.com/router-for-me/CLIProxyAPI/v6/sdkbridge/service"
+)
+
+// fetchKimiRegistryModels resolves the models a Kimi account can route.
+//
+// Discovery comes first so a newly released id is routable the moment the coding
+// gateway advertises it, instead of waiting for a catalog release. The compiled-in
+// catalog stays as the floor: a gateway outage or a credential that cannot list
+// models must not deregister every model on an otherwise working account.
+func (s *Service) fetchKimiRegistryModels(ctx context.Context, auth *coreauth.Auth, excluded []string) []*ModelInfo {
+	fetchCtx := ctx
+	if fetchCtx == nil {
+		fetchCtx = context.Background()
+	}
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(fetchCtx), 15*time.Second)
+	defer cancel()
+	models := serviceapp.FetchKimiModels(fetchCtx, auth, s.cfg)
+	if len(models) == 0 {
+		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("kimi")
+	}
+	return applyExcludedModels(models, excluded)
+}

--- a/sdk/cliproxy/service_model_registration.go
+++ b/sdk/cliproxy/service_model_registration.go
@@ -240,7 +240,12 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("iflow")
 		models = applyExcludedModels(models, excluded)
 	case "kimi":
-		models = sdkmodelcatalog.StaticModelDefinitionsByChannel("kimi")
+		// Live discovery so a model Moonshot ships today is routable today; the
+		// tenant model library still supplements it, because the coding gateway
+		// lists what this account is entitled to rather than the full catalog.
+		models = s.fetchKimiRegistryModels(ctx, a, excluded)
+		catalogRows, mappedOwners := oauthCatalogScope(a)
+		models = appendOAuthProviderModelConfigs(models, provider, authKind, catalogRows, mappedOwners)
 		models = applyExcludedModels(models, excluded)
 	default:
 		if s.registerOpenAICompatModels(a, provider, compatProviderKey, compatDisplayName, compatDetected) {

--- a/sdk/cliproxy/service_model_registry_helpers.go
+++ b/sdk/cliproxy/service_model_registry_helpers.go
@@ -336,6 +336,10 @@ func modelConfigOwnerAliases(provider string) map[string]struct{} {
 		values = append(values, "anthropic", "claude-code")
 	case "gemini", "gemini-cli", "vertex":
 		values = append(values, "google")
+	case "kimi":
+		// Kimi models are owned by Moonshot in the catalog, so a library row added
+		// under the vendor name has to resolve back to the kimi channel.
+		values = append(values, "moonshot", "moonshotai")
 	}
 	out := make(map[string]struct{}, len(values))
 	for _, value := range values {

--- a/sdkbridge/service/bridge.go
+++ b/sdkbridge/service/bridge.go
@@ -119,6 +119,10 @@ func FetchCodexModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Conf
 	return internalserviceapp.FetchCodexModels(ctx, auth, cfg)
 }
 
+func FetchKimiModels(ctx context.Context, auth *coreauth.Auth, cfg *config.Config) []*sdkmodelcatalog.ModelInfo {
+	return internalserviceapp.FetchKimiModels(ctx, auth, cfg)
+}
+
 func RegisterExecutorForAuth(coreManager *coreauth.Manager, cfg *config.Config, auth *coreauth.Auth, forceReplace bool, gateway WebsocketGateway) {
 	internalserviceapp.RegisterExecutorForAuth(coreManager, cfg, auth, forceReplace, gateway)
 }


### PR DESCRIPTION
Release v0.4.30: Kimi live model discovery and identity fingerprint, management-side model probe, and honest routing diagnosis when a credential is out of scope.

Pairs with codeProxy v0.4.30.