### PR TITLE
feat(auth): add provider-agnostic account-level concurrency control

### DIFF
--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -141,6 +141,23 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 				}
 			}
 		}
+		// Read concurrency / concurrency_limit from auth file
+		for _, key := range []string{"concurrency_limit", "concurrency", "concurrency-limit"} {
+			if rawConcurrency, ok := metadata[key]; ok {
+				switch v := rawConcurrency.(type) {
+				case float64:
+					if int(v) >= 0 {
+						a.Attributes["concurrency_limit"] = strconv.Itoa(int(v))
+					}
+				case string:
+					concurrency := strings.TrimSpace(v)
+					if parsed, errAtoi := strconv.Atoi(concurrency); errAtoi == nil && parsed >= 0 {
+						a.Attributes["concurrency_limit"] = strconv.Itoa(parsed)
+					}
+				}
+				break
+			}
+		}
 		ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")
 		if provider == "gemini-cli" {
 			if virtuals := SynthesizeGeminiVirtualAuths(a, metadata, now); len(virtuals) > 0 {

--- a/sdk/cliproxy/auth/account_concurrency.go
+++ b/sdk/cliproxy/auth/account_concurrency.go
@@ -1,0 +1,135 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	// ErrAccountConcurrencyExceeded is returned when an auth credential has reached its max concurrency limit.
+	ErrAccountConcurrencyExceeded = errors.New("account concurrency limit exceeded")
+)
+
+// AccountConcurrencyLimiter manages in-flight request slots per auth ID.
+// It supports querying active load, checking availability, acquiring slots, and releasing slots.
+type AccountConcurrencyLimiter struct {
+	mu     sync.RWMutex
+	active map[string]int
+}
+
+// NewAccountConcurrencyLimiter creates a new thread-safe concurrency limiter.
+func NewAccountConcurrencyLimiter() *AccountConcurrencyLimiter {
+	return &AccountConcurrencyLimiter{
+		active: make(map[string]int),
+	}
+}
+
+// GetInFlight returns the number of active requests for the specified auth ID.
+func (l *AccountConcurrencyLimiter) GetInFlight(authID string) int {
+	if l == nil || authID == "" {
+		return 0
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.active[authID]
+}
+
+// GetLoadRate returns the load ratio (in-flight / maxLimit) between 0.0 and 1.0 (or >1.0 if overloaded).
+// If limit <= 0 (unlimited), it returns 0.0.
+func (l *AccountConcurrencyLimiter) GetLoadRate(authID string, maxLimit int) float64 {
+	if maxLimit <= 0 {
+		return 0.0
+	}
+	inFlight := l.GetInFlight(authID)
+	return float64(inFlight) / float64(maxLimit)
+}
+
+// HasAvailableSlot checks whether an auth candidate can accept another request.
+// If limit <= 0, concurrency is considered unlimited and returns true.
+func (l *AccountConcurrencyLimiter) HasAvailableSlot(auth *Auth) bool {
+	if l == nil || auth == nil {
+		return true
+	}
+	limit := auth.ConcurrencyLimit()
+	if limit <= 0 {
+		return true
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.active[auth.ID] < limit
+}
+
+// AcquireSlot attempts to acquire a concurrency slot for the given auth.
+// Returns a release function and an error. If acquired, the caller MUST call the returned release function.
+// If the limit is reached, it returns nil and ErrAccountConcurrencyExceeded.
+func (l *AccountConcurrencyLimiter) AcquireSlot(auth *Auth) (func(), error) {
+	if l == nil || auth == nil {
+		return func() {}, nil
+	}
+	authID := auth.ID
+	limit := auth.ConcurrencyLimit()
+
+	l.mu.Lock()
+	if limit > 0 {
+		current := l.active[authID]
+		if current >= limit {
+			l.mu.Unlock()
+			return nil, fmt.Errorf("%w: account %s active=%d max=%d", ErrAccountConcurrencyExceeded, authID, current, limit)
+		}
+	}
+	l.active[authID]++
+	l.mu.Unlock()
+
+	var once sync.Once
+	release := func() {
+		once.Do(func() {
+			l.ReleaseSlot(authID)
+		})
+	}
+	return release, nil
+}
+
+// ReleaseSlot decrements the in-flight count for the given auth ID.
+func (l *AccountConcurrencyLimiter) ReleaseSlot(authID string) {
+	if l == nil || authID == "" {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	current := l.active[authID]
+	if current <= 1 {
+		delete(l.active, authID)
+	} else {
+		l.active[authID] = current - 1
+	}
+}
+
+// FilterAvailableCandidates partitions candidates into available vs saturated by concurrency limit.
+// Candidates with reached limits (in-flight >= limit > 0) are filtered out if viable alternatives exist.
+func (l *AccountConcurrencyLimiter) FilterAvailableCandidates(candidates []*Auth) []*Auth {
+	if l == nil || len(candidates) <= 1 {
+		return candidates
+	}
+
+	available := make([]*Auth, 0, len(candidates))
+
+	l.mu.RLock()
+	for _, c := range candidates {
+		if c == nil {
+			continue
+		}
+		limit := c.ConcurrencyLimit()
+		inFlight := l.active[c.ID]
+		if limit <= 0 || inFlight < limit {
+			available = append(available, c)
+		}
+	}
+	l.mu.RUnlock()
+
+	if len(available) > 0 {
+		return available
+	}
+	// If all candidates are saturated, return all candidates so selector can fail or attempt fallback
+	return candidates
+}

--- a/sdk/cliproxy/auth/account_concurrency_stress_test.go
+++ b/sdk/cliproxy/auth/account_concurrency_stress_test.go
@@ -1,0 +1,161 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+func TestAccountConcurrency_HighConcurrencyStress(t *testing.T) {
+	mgr := NewManager(nil, &RoundRobinSelector{}, nil)
+
+	numAccounts := 5
+	limitPerAccount := 3
+	for i := 0; i < numAccounts; i++ {
+		auth := &Auth{
+			ID:         fmt.Sprintf("auth-stress-%d", i),
+			Provider:   "blocking",
+			Status:     StatusActive,
+			Attributes: map[string]string{"concurrency_limit": fmt.Sprintf("%d", limitPerAccount)},
+		}
+		_, _ = mgr.Register(context.Background(), auth)
+	}
+
+	exec := &stressDelayExecutor{
+		minDelay: 5 * time.Millisecond,
+		maxDelay: 20 * time.Millisecond,
+	}
+	mgr.RegisterExecutor(exec)
+
+	// Launch 50 concurrent requests
+	numWorkers := 50
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+
+	var successCount atomic.Int32
+	var rejectedCount atomic.Int32
+	var maxObservedInFlight [5]atomic.Int32
+
+	for i := 0; i < numWorkers; i++ {
+		go func(workerID int) {
+			defer wg.Done()
+			isStream := workerID%2 == 0
+			if isStream {
+				res, err := mgr.ExecuteStream(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "stress-model"}, cliproxyexecutor.Options{})
+				if err != nil {
+					rejectedCount.Add(1)
+					return
+				}
+				for range res.Chunks {
+				}
+				successCount.Add(1)
+			} else {
+				_, err := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "stress-model"}, cliproxyexecutor.Options{})
+				if err != nil {
+					rejectedCount.Add(1)
+					return
+				}
+				successCount.Add(1)
+			}
+		}(i)
+	}
+
+	// Concurrently monitor that in-flight NEVER exceeds limitPerAccount
+	stopMonitor := make(chan struct{})
+	go func() {
+		limiter := mgr.ConcurrencyLimiter()
+		for {
+			select {
+			case <-stopMonitor:
+				return
+			default:
+				for i := 0; i < numAccounts; i++ {
+					inFlight := limiter.GetInFlight(fmt.Sprintf("auth-stress-%d", i))
+					if inFlight > limitPerAccount {
+						t.Errorf("INVARIANT VIOLATION: auth-stress-%d in-flight=%d > limit=%d", i, inFlight, limitPerAccount)
+					}
+					for {
+						curMax := maxObservedInFlight[i].Load()
+						if int32(inFlight) <= curMax || maxObservedInFlight[i].CompareAndSwap(curMax, int32(inFlight)) {
+							break
+						}
+					}
+				}
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(stopMonitor)
+
+	// Ensure all accounts returned to 0 in-flight
+	limiter := mgr.ConcurrencyLimiter()
+	for i := 0; i < numAccounts; i++ {
+		if inFlight := limiter.GetInFlight(fmt.Sprintf("auth-stress-%d", i)); inFlight != 0 {
+			t.Fatalf("auth-stress-%d residual in-flight = %d, expected 0", i, inFlight)
+		}
+	}
+
+	t.Logf("Stress test finished: success=%d, rejected=%d", successCount.Load(), rejectedCount.Load())
+	for i := 0; i < numAccounts; i++ {
+		t.Logf("Auth %d peak in-flight: %d / %d", i, maxObservedInFlight[i].Load(), limitPerAccount)
+	}
+}
+
+type stressDelayExecutor struct {
+	minDelay time.Duration
+	maxDelay time.Duration
+}
+
+func (e *stressDelayExecutor) Identifier() string { return "blocking" }
+func (e *stressDelayExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	delay := e.minDelay
+	if diff := e.maxDelay - e.minDelay; diff > 0 {
+		delay += time.Duration(rand.Int64N(int64(diff)))
+	}
+	select {
+	case <-time.After(delay):
+		return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+	case <-ctx.Done():
+		return cliproxyexecutor.Response{}, ctx.Err()
+	}
+}
+
+func (e *stressDelayExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	chunks := make(chan cliproxyexecutor.StreamChunk, 2)
+	delay := e.minDelay
+	if diff := e.maxDelay - e.minDelay; diff > 0 {
+		delay += time.Duration(rand.Int64N(int64(diff)))
+	}
+	go func() {
+		defer close(chunks)
+		select {
+		case <-time.After(delay):
+			chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("data: chunk\n\n")}
+		case <-ctx.Done():
+			return
+		}
+	}()
+	return &cliproxyexecutor.StreamResult{
+		Headers: http.Header{},
+		Chunks:  chunks,
+	}, nil
+}
+
+func (e *stressDelayExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (e *stressDelayExecutor) CountTokens(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return e.Execute(ctx, auth, req, opts)
+}
+func (e *stressDelayExecutor) HttpRequest(ctx context.Context, auth *Auth, req *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/sdk/cliproxy/auth/account_concurrency_test.go
+++ b/sdk/cliproxy/auth/account_concurrency_test.go
@@ -1,0 +1,320 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+func TestAccountConcurrencyLimiter_AcquireAndRelease(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth := &Auth{
+		ID:         "auth-limit-2",
+		Attributes: map[string]string{"concurrency_limit": "2"},
+	}
+
+	if limit := auth.ConcurrencyLimit(); limit != 2 {
+		t.Fatalf("expected concurrency limit 2, got %d", limit)
+	}
+
+	if !limiter.HasAvailableSlot(auth) {
+		t.Fatal("expected slot available initially")
+	}
+
+	rel1, err1 := limiter.AcquireSlot(auth)
+	if err1 != nil {
+		t.Fatalf("failed to acquire slot 1: %v", err1)
+	}
+	if inFlight := limiter.GetInFlight(auth.ID); inFlight != 1 {
+		t.Fatalf("expected in-flight 1, got %d", inFlight)
+	}
+	if rate := limiter.GetLoadRate(auth.ID, 2); rate != 0.5 {
+		t.Fatalf("expected load rate 0.5, got %f", rate)
+	}
+
+	rel2, err2 := limiter.AcquireSlot(auth)
+	if err2 != nil {
+		t.Fatalf("failed to acquire slot 2: %v", err2)
+	}
+	if inFlight := limiter.GetInFlight(auth.ID); inFlight != 2 {
+		t.Fatalf("expected in-flight 2, got %d", inFlight)
+	}
+	if limiter.HasAvailableSlot(auth) {
+		t.Fatal("expected slot unavailable at capacity")
+	}
+
+	// Third attempt must fail
+	rel3, err3 := limiter.AcquireSlot(auth)
+	if err3 == nil {
+		if rel3 != nil {
+			rel3()
+		}
+		t.Fatal("expected 3rd acquire to fail due to concurrency limit")
+	}
+	if !errors.Is(err3, ErrAccountConcurrencyExceeded) {
+		t.Fatalf("expected ErrAccountConcurrencyExceeded, got %v", err3)
+	}
+
+	// Release one
+	rel1()
+	// Duplicate release should be safe
+	rel1()
+
+	if inFlight := limiter.GetInFlight(auth.ID); inFlight != 1 {
+		t.Fatalf("expected in-flight 1 after release, got %d", inFlight)
+	}
+	if !limiter.HasAvailableSlot(auth) {
+		t.Fatal("expected slot available after release")
+	}
+
+	// Now 3rd attempt can succeed
+	rel3, err3 = limiter.AcquireSlot(auth)
+	if err3 != nil {
+		t.Fatalf("expected slot to be acquirable after release: %v", err3)
+	}
+	defer rel3()
+	defer rel2()
+}
+
+func TestAccountConcurrencyLimiter_FilterAvailableCandidates(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth1 := &Auth{
+		ID:         "auth-1",
+		Attributes: map[string]string{"concurrency": "1"},
+	}
+	auth2 := &Auth{
+		ID:         "auth-2",
+		Attributes: map[string]string{"concurrency_limit": "2"},
+	}
+	auth3 := &Auth{
+		ID: "auth-unlimited",
+	}
+
+	candidates := []*Auth{auth1, auth2, auth3}
+
+	// All available initially
+	filtered := limiter.FilterAvailableCandidates(candidates)
+	if len(filtered) != 3 {
+		t.Fatalf("expected 3 candidates, got %d", len(filtered))
+	}
+
+	// Saturate auth1
+	rel1, err := limiter.AcquireSlot(auth1)
+	if err != nil {
+		t.Fatalf("acquire auth1: %v", err)
+	}
+	defer rel1()
+
+	filtered = limiter.FilterAvailableCandidates(candidates)
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 candidates (auth2, auth3), got %d", len(filtered))
+	}
+	if filtered[0].ID != "auth-2" || filtered[1].ID != "auth-unlimited" {
+		t.Fatalf("unexpected candidates: %v, %v", filtered[0].ID, filtered[1].ID)
+	}
+
+	// Saturate auth2 (2 slots)
+	rel2a, _ := limiter.AcquireSlot(auth2)
+	rel2b, _ := limiter.AcquireSlot(auth2)
+	defer rel2a()
+	defer rel2b()
+
+	filtered = limiter.FilterAvailableCandidates(candidates)
+	if len(filtered) != 1 || filtered[0].ID != "auth-unlimited" {
+		t.Fatalf("expected only auth-unlimited, got %v", filtered)
+	}
+}
+
+type blockingExecutor struct {
+	started   chan struct{}
+	release   chan struct{}
+	callCount atomic.Int32
+}
+
+func (e *blockingExecutor) Identifier() string { return "blocking" }
+func (e *blockingExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.callCount.Add(1)
+	if e.started != nil {
+		select {
+		case e.started <- struct{}{}:
+		default:
+		}
+	}
+	if e.release != nil {
+		select {
+		case <-e.release:
+		case <-ctx.Done():
+			return cliproxyexecutor.Response{}, ctx.Err()
+		}
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (e *blockingExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.callCount.Add(1)
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	if e.started != nil {
+		select {
+		case e.started <- struct{}{}:
+		default:
+		}
+	}
+	go func() {
+		defer close(chunks)
+		if e.release != nil {
+			select {
+			case <-e.release:
+			case <-ctx.Done():
+				return
+			}
+		}
+		chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("data: chunk\n\n")}
+	}()
+	return &cliproxyexecutor.StreamResult{
+		Headers: http.Header{},
+		Chunks:  chunks,
+	}, nil
+}
+
+func (e *blockingExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (e *blockingExecutor) CountTokens(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return e.Execute(ctx, auth, req, opts)
+}
+func (e *blockingExecutor) HttpRequest(ctx context.Context, auth *Auth, req *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestManagerExecute_AccountConcurrencyFailover(t *testing.T) {
+	mgr := NewManager(nil, &FillFirstSelector{}, nil)
+
+	auth1 := &Auth{
+		ID:         "auth-limited-1",
+		Provider:   "blocking",
+		Status:     StatusActive,
+		Attributes: map[string]string{"concurrency_limit": "1", "priority": "10"},
+	}
+	auth2 := &Auth{
+		ID:         "auth-fallback-2",
+		Provider:   "blocking",
+		Status:     StatusActive,
+		Attributes: map[string]string{"concurrency_limit": "5", "priority": "5"},
+	}
+
+	_, _ = mgr.Register(context.Background(), auth1)
+	_, _ = mgr.Register(context.Background(), auth2)
+
+	exec := &blockingExecutor{
+		started: make(chan struct{}, 10),
+		release: make(chan struct{}),
+	}
+	mgr.RegisterExecutor(exec)
+
+	// Launch 1st request on auth1
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+		if err != nil {
+			t.Errorf("req1 failed: %v", err)
+		}
+	}()
+
+	// Wait for 1st request to start
+	<-exec.started
+
+	// Verify auth1 has 1 in-flight
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight("auth-limited-1"); inFlight != 1 {
+		t.Fatalf("expected auth-limited-1 in-flight 1, got %d", inFlight)
+	}
+
+	// Launch 2nd request - auth1 is saturated, FillFirst should pick auth2
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+		if err != nil {
+			t.Errorf("req2 failed: %v", err)
+		}
+	}()
+
+	// Wait for 2nd request to start
+	<-exec.started
+
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight("auth-fallback-2"); inFlight != 1 {
+		t.Fatalf("expected auth-fallback-2 in-flight 1, got %d", inFlight)
+	}
+
+	// Release both
+	close(exec.release)
+	wg.Wait()
+
+	// Both in-flight counts should return to 0
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight("auth-limited-1"); inFlight != 0 {
+		t.Fatalf("expected auth-limited-1 in-flight 0, got %d", inFlight)
+	}
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight("auth-fallback-2"); inFlight != 0 {
+		t.Fatalf("expected auth-fallback-2 in-flight 0, got %d", inFlight)
+	}
+}
+
+func TestManagerExecuteStream_AccountConcurrencySlotLifecycle(t *testing.T) {
+	mgr := NewManager(nil, &FillFirstSelector{}, nil)
+
+	auth := &Auth{
+		ID:         "auth-stream-1",
+		Provider:   "blocking",
+		Status:     StatusActive,
+		Attributes: map[string]string{"concurrency_limit": "1"},
+	}
+	_, _ = mgr.Register(context.Background(), auth)
+
+	exec := &blockingExecutor{
+		started: make(chan struct{}, 10),
+		release: make(chan struct{}),
+	}
+	mgr.RegisterExecutor(exec)
+
+	res, err := mgr.ExecuteStream(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream failed: %v", err)
+	}
+
+	// Wait for stream to start
+	<-exec.started
+
+	// Slot must be held while stream is open
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight("auth-stream-1"); inFlight != 1 {
+		t.Fatalf("expected in-flight 1 during active stream, got %d", inFlight)
+	}
+
+	// Second request must fail with ErrAccountConcurrencyExceeded (or auth_not_found since only 1 saturated auth exists)
+	_, err2 := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+	if err2 == nil {
+		t.Fatal("expected second request to fail when account slot saturated")
+	}
+
+	// Release stream chunks
+	close(exec.release)
+
+	// Consume stream
+	for range res.Chunks {
+	}
+
+	// Small grace period for goroutine cleanup
+	time.Sleep(10 * time.Millisecond)
+
+	// Slot must be released after stream closes
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight("auth-stream-1"); inFlight != 0 {
+		t.Fatalf("expected in-flight 0 after stream closed, got %d", inFlight)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -188,6 +188,8 @@ type Manager struct {
 
 	requestModerator RequestModerator
 
+	concurrencyLimiter *AccountConcurrencyLimiter
+
 	// Auto refresh state
 	refreshCancel    context.CancelFunc
 	refreshSemaphore chan struct{}
@@ -225,6 +227,7 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 		hook:                  hook,
 		auths:                 make(map[string]*Auth),
 		providerOffsets:       make(map[string]int),
+		concurrencyLimiter:    NewAccountConcurrencyLimiter(),
 		refreshSemaphore:      make(chan struct{}, refreshMaxConcurrency),
 		quotaProbeAfter:       make(map[string]time.Time),
 	}
@@ -256,4 +259,19 @@ func (m *Manager) SetModelRegistry(registry ModelRegistry) {
 	m.mu.Lock()
 	m.modelRegistry = registry
 	m.mu.Unlock()
+}
+
+// ConcurrencyLimiter returns the manager's AccountConcurrencyLimiter instance.
+func (m *Manager) ConcurrencyLimiter() *AccountConcurrencyLimiter {
+	if m == nil {
+		return nil
+	}
+	return m.concurrencyLimiter
+}
+
+func (m *Manager) acquireAccountSlot(auth *Auth) (func(), error) {
+	if m == nil || m.concurrencyLimiter == nil || auth == nil {
+		return func() {}, nil
+	}
+	return m.concurrencyLimiter.AcquireSlot(auth)
 }

--- a/sdk/cliproxy/auth/conductor_execution_service.go
+++ b/sdk/cliproxy/auth/conductor_execution_service.go
@@ -101,7 +101,17 @@ func (s executionService) executeMixedOnce(ctx context.Context, providers []stri
 			return cliproxyexecutor.Response{}, errModeration
 		}
 
+		releaseSlot, errSlot := s.manager.acquireAccountSlot(candidate.auth)
+		if errSlot != nil {
+			if isRequestInvalidError(errSlot) || scope.singlePickRoute {
+				return cliproxyexecutor.Response{}, errSlot
+			}
+			lastErr = errSlot
+			continue
+		}
+
 		resp, errExec := candidate.executor.Execute(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)
+		releaseSlot()
 		result := Result{
 			AuthID:   candidate.auth.ID,
 			Provider: candidate.provider,
@@ -147,7 +157,17 @@ func (s executionService) executeCountMixedOnce(ctx context.Context, providers [
 			return cliproxyexecutor.Response{}, errModeration
 		}
 
+		releaseSlot, errSlot := s.manager.acquireAccountSlot(candidate.auth)
+		if errSlot != nil {
+			if isRequestInvalidError(errSlot) || scope.singlePickRoute {
+				return cliproxyexecutor.Response{}, errSlot
+			}
+			lastErr = errSlot
+			continue
+		}
+
 		resp, errExec := candidate.executor.CountTokens(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)
+		releaseSlot()
 		if errExec != nil {
 			if errCtx := candidate.execCtx.Err(); errCtx != nil {
 				return cliproxyexecutor.Response{}, errCtx
@@ -179,8 +199,18 @@ func (s executionService) executeStreamMixedOnce(ctx context.Context, providers 
 			return nil, errModeration
 		}
 
+		releaseSlot, errSlot := s.manager.acquireAccountSlot(candidate.auth)
+		if errSlot != nil {
+			if isRequestInvalidError(errSlot) || scope.singlePickRoute {
+				return nil, errSlot
+			}
+			lastErr = errSlot
+			continue
+		}
+
 		streamResult, errStream := candidate.executor.ExecuteStream(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)
 		if errStream != nil {
+			releaseSlot()
 			if errCtx := candidate.execCtx.Err(); errCtx != nil {
 				return nil, errCtx
 			}
@@ -202,7 +232,7 @@ func (s executionService) executeStreamMixedOnce(ctx context.Context, providers 
 			continue
 		}
 
-		return s.wrapStreamResult(candidate.execCtx, candidate.auth, candidate.provider, scope.routeModel, scope.opts.SourceFormat, streamResult), nil
+		return s.wrapStreamResult(candidate.execCtx, candidate.auth, candidate.provider, scope.routeModel, scope.opts.SourceFormat, streamResult, releaseSlot), nil
 	}
 }
 
@@ -266,11 +296,15 @@ func (s executionService) wrapStreamResult(
 	routeModel string,
 	sourceFormat sdktranslator.Format,
 	streamResult *cliproxyexecutor.StreamResult,
+	releaseSlot func(),
 ) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
 	streamHeaders := streamResult.Headers.Clone()
 	go func(streamCtx context.Context, streamAuth *Auth, streamProvider string, streamChunks <-chan cliproxyexecutor.StreamChunk, headers http.Header) {
 		defer close(out)
+		if releaseSlot != nil {
+			defer releaseSlot()
+		}
 		var failed bool
 		forward := true
 		completionTracker := newResponsesStreamCompletionTracker(sourceFormat)

--- a/sdk/cliproxy/auth/conductor_selector_service.go
+++ b/sdk/cliproxy/auth/conductor_selector_service.go
@@ -242,6 +242,9 @@ func (s selectorService) pickLocked(
 			continue
 		}
 		selector := s.manager.selectorForRoutingScopeLocked(scope.cfg, selectorRouteGroup, scope.allowedGroups)
+		if s.manager.concurrencyLimiter != nil {
+			candidates = s.manager.concurrencyLimiter.FilterAvailableCandidates(candidates)
+		}
 		selected, errPick := selector.Pick(ctx, selectorProvider, scope.model, optionsForSelectionRouteGroup(opts, selectorRouteGroup), candidates)
 		if errPick != nil {
 			return nil, "", errPick

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -298,6 +298,34 @@ func (a *Auth) RequestRetryOverride() (int, bool) {
 	return 0, false
 }
 
+// ConcurrencyLimit returns the max active concurrent requests allowed for this auth account.
+// If <= 0, concurrency is unlimited.
+// Looks up "concurrency_limit", "concurrency", or "concurrency-limit" in Attributes first, then Metadata.
+func (a *Auth) ConcurrencyLimit() int {
+	if a == nil {
+		return 0
+	}
+	if a.Attributes != nil {
+		for _, key := range []string{"concurrency_limit", "concurrency", "concurrency-limit"} {
+			if raw, ok := a.Attributes[key]; ok {
+				if parsed, okParse := parseIntAny(raw); okParse && parsed >= 0 {
+					return parsed
+				}
+			}
+		}
+	}
+	if a.Metadata != nil {
+		for _, key := range []string{"concurrency_limit", "concurrency", "concurrency-limit"} {
+			if raw, ok := a.Metadata[key]; ok {
+				if parsed, okParse := parseIntAny(raw); okParse && parsed >= 0 {
+					return parsed
+				}
+			}
+		}
+	}
+	return 0
+}
+
 func parseBoolAny(val any) (bool, bool) {
 	switch typed := val.(type) {
 	case bool:


### PR DESCRIPTION
Port sub2api account-level concurrency control into CliRelay auth manager across all providers (Codex, Claude, Gemini, OpenAI, etc.). Includes in-flight slot acquire/release lifecycle across streaming and non-streaming requests, candidate saturation filtering in selectors, and auth JSON synthesizer attributes support.