### PR TITLE
fix(aiaccountstatus): isolate xAI weekly and monthly billing probe parsing

### DIFF
--- a/internal/management/aiaccountstatus/probe_test.go
+++ b/internal/management/aiaccountstatus/probe_test.go
@@ -274,6 +274,15 @@ func TestResolveXAIPlanUsesEntitlementWhenMonthlyLimitIsZero(t *testing.T) {
 	}
 }
 
+func TestProbeXAI_DoesNotCrossPolluteWeeklyFromMonthly(t *testing.T) {
+	// If weekly request fails or body is empty, monthly billing should NOT generate a weekly_limit window.
+	monthlyOnly := []byte(`{"config":{"monthlyLimit":{"val":15000},"used":{"val":15000},"billingPeriodEnd":"2026-09-01T00:00:00Z"}}`)
+	weeklyItems := parseXAIWeeklyBilling(monthlyOnly)
+	if len(weeklyItems) != 0 {
+		t.Fatalf("parseXAIWeeklyBilling on monthly payload produced items: %+v, want none", weeklyItems)
+	}
+}
+
 // One row per family, each carrying a single representative model's real quota.
 //
 // gemini-2.5-pro and gemini-3.1-pro-high are both "Gemini Pro" yet draw on

--- a/internal/management/aiaccountstatus/probe_xai.go
+++ b/internal/management/aiaccountstatus/probe_xai.go
@@ -45,13 +45,9 @@ func probeXAI(ctx context.Context, svc *managementapitools.Service, auth *coreau
 	quotas := make([]usage.QuotaWindowDTO, 0, 8)
 	if weeklyErr == nil {
 		quotas = append(quotas, parseXAIWeeklyBilling(weeklyBody)...)
-	} else if monthlyErr == nil {
-		quotas = append(quotas, parseXAIWeeklyBilling(monthlyBody)...)
 	}
 	if monthlyErr == nil {
 		quotas = append(quotas, parseXAIMonthlyBilling(monthlyBody)...)
-	} else if weeklyErr == nil {
-		quotas = append(quotas, parseXAIMonthlyBilling(weeklyBody)...)
 	}
 	if len(quotas) == 0 {
 		return ProbeResult{}, fmt.Errorf("empty_data")


### PR DESCRIPTION
### Summary
- Remove cross-endpoint body fallbacks in  where  was parsed with monthly parsing or  was parsed with weekly parsing on single-endpoint failures.
- Prevents monthly billing data from synthesizing or clearing weekly runtime quota blocks when weekly requests fail.
- Added regression test .

### Verification
- Ran structure ratchet  -> passed.
- Ran full test suite  -> passed.