### PR TITLE
fix(codex): stop repeating generated image bytes across the SSE stream

### DIFF
--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -30,11 +30,10 @@ var (
 	// Hosted image_generation tool payload.
 	//
 	// The field set mirrors the request that /v1/images/generations already sends to
-	// chatgpt.com/backend-api/codex/responses and that is verified to produce images
-	// (see buildCodexImageResponsesRequest): `action` and `model` are both required there.
-	// A bare {"type":"image_generation"} is accepted by the endpoint without an error, but
-	// the model never invokes it, so image requests silently degrade into "I have no image
-	// tool" text replies.
+	// chatgpt.com/backend-api/codex/responses (see buildCodexImageResponsesRequest). A bare
+	// {"type":"image_generation"} is also invoked by the model, but it cannot express the edit
+	// action, and it leaves the image model up to whatever the backend defaults to — pinning
+	// both keeps the conversation path and the /v1/images endpoints on the same model.
 	imageGenToolJSON      = []byte(codexHostedImageGenerateTool)
 	imageGenToolArrayJSON = []byte(`[` + codexHostedImageGenerateTool + `]`)
 

--- a/internal/runtime/executor/codex_image_generation_bridge_test.go
+++ b/internal/runtime/executor/codex_image_generation_bridge_test.go
@@ -174,7 +174,8 @@ func TestCodexImageStreamRewritesMntDataMarkdownAfterHostedImage(t *testing.T) {
 		t.Fatalf("cached images = %d, want 1", len(n.images))
 	}
 
-	// Desktop-visible path: model writes ChatGPT sandbox markdown.
+	// output_text.done repeats the text that output_item.done carries below, so it only gets
+	// the unreachable sandbox ref flattened — inlining here too would send the image twice.
 	textDone := []byte(`data: {"type":"response.output_text.done","item_id":"msg_1","text":"给你画好了：\n\n![小猫](/mnt/data/0.png)\n"}`)
 	rewritten := normalizeCodexImageGenerationOutboundEventWithState(n, textDone)
 	if len(rewritten) != 1 {
@@ -182,13 +183,13 @@ func TestCodexImageStreamRewritesMntDataMarkdownAfterHostedImage(t *testing.T) {
 	}
 	body := bytes.TrimSpace(rewritten[0][len(dataTag):])
 	got := gjson.GetBytes(body, "text").String()
-	if !strings.Contains(got, "data:image/png;base64,iVBORw0KGgo=") {
-		t.Fatalf("text not rewritten to data url: %s", got)
+	if strings.Contains(got, "data:image/png;base64,") {
+		t.Fatalf("output_text.done must not inline the image: %s", got)
 	}
 	if strings.Contains(got, "/mnt/data/") {
-		t.Fatalf("text still has /mnt/data: %s", got)
+		t.Fatalf("text still has a broken /mnt/data ref: %s", got)
 	}
-	if !strings.Contains(got, "![小猫](") {
+	if !strings.Contains(got, "小猫") {
 		t.Fatalf("alt text lost: %s", got)
 	}
 
@@ -232,8 +233,8 @@ func TestCodexImageStreamAppendsDataURLWhenModelOmitsMntPath(t *testing.T) {
 	if !strings.Contains(got, "给你一只小猫。") {
 		t.Fatalf("original text lost: %s", got)
 	}
-	if !strings.Contains(got, "data:image/png;base64,iVBORw0KGgo=") {
-		t.Fatalf("expected appended data url: %s", got)
+	if strings.Contains(got, "data:image/png;base64,") {
+		t.Fatalf("output_text.done must not inline the image: %s", got)
 	}
 
 	msgDone := []byte(`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"给你一只小猫。"}]}}`)
@@ -269,14 +270,78 @@ func TestCodexImageStreamRewritesLocalGeneratedImagesPathWithoutDouble(t *testin
 	body := bytes.TrimSpace(out[0][len(dataTag):])
 	got := gjson.GetBytes(body, "text").String()
 	if strings.Contains(got, "generated_images/") {
-		t.Fatalf("local path should be rewritten: %s", got)
+		t.Fatalf("invented local path should be flattened: %s", got)
 	}
+	if strings.Contains(got, "data:image/png;base64,") {
+		t.Fatalf("output_text.done must not inline the image: %s", got)
+	}
+
+	// The message item is where the single inlined copy belongs.
+	msgDone := []byte(`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":` + mustJSONString(text) + `}]}}`)
+	out = normalizeCodexImageGenerationOutboundEventWithState(n, msgDone)
+	body = bytes.TrimSpace(out[0][len(dataTag):])
+	got = gjson.GetBytes(body, "item.content.0.text").String()
 	if strings.Count(got, "data:image/png;base64,iVBORw0KGgo=") != 1 {
-		t.Fatalf("want exactly one data url, got %q", got)
+		t.Fatalf("want exactly one data url in the message item, got %q", got)
 	}
 	if !strings.Contains(got, "![可爱的小鱼](data:image/png;base64,iVBORw0KGgo=)") {
 		t.Fatalf("alt/path rewrite failed: %s", got)
 	}
+}
+
+// TestCodexImageStreamSendsImageBytesOnce walks a full hosted-image turn in the order the
+// upstream emits it. A 2.7MB picture repeated across every text-shaped event produced a 13MB
+// SSE response that did not finish over a slow link, so the whole stream may carry the pixels
+// exactly once.
+func TestCodexImageStreamSendsImageBytesOnce(t *testing.T) {
+	n := newCodexImageStreamNormalizer()
+	const b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+	stream := [][]byte{
+		[]byte(`data: {"type":"response.output_item.done","item":{"id":"ig_1","type":"image_generation_call","status":"completed","result":"` + b64 + `","output_format":"png"}}`),
+		[]byte(`data: {"type":"response.output_text.done","item_id":"msg_1","text":"画好了：\n\n![猫](/mnt/data/0.png)"}`),
+		[]byte(`data: {"type":"response.content_part.done","item_id":"msg_1","part":{"type":"output_text","text":"画好了：\n\n![猫](/mnt/data/0.png)"}}`),
+		[]byte(`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"画好了：\n\n![猫](/mnt/data/0.png)"}]}}`),
+		[]byte(`data: {"type":"response.completed","response":{"output":[{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"画好了：\n\n![猫](/mnt/data/0.png)"}]}]}}`),
+	}
+	occurrences := 0
+	for _, in := range stream {
+		for _, out := range normalizeCodexImageGenerationOutboundEventWithState(n, in) {
+			occurrences += strings.Count(string(out), b64)
+			if bytes.Contains(out, []byte("/mnt/data/")) {
+				t.Fatalf("broken sandbox ref reached the client: %s", firstBytes(out, 200))
+			}
+		}
+	}
+	// One native image_generation_call result plus one inlined data URL in the message item.
+	if occurrences != 2 {
+		t.Fatalf("image bytes appeared %d times in the stream, want 2", occurrences)
+	}
+}
+
+// TestCodexImageStreamFallsBackWhenNoAssistantMessage covers the turn where the model returns
+// only the picture: nothing inlines it, so the synthetic display item has to appear at the end.
+func TestCodexImageStreamFallsBackWhenNoAssistantMessage(t *testing.T) {
+	n := newCodexImageStreamNormalizer()
+	const b64 = "iVBORw0KGgo="
+	_ = normalizeCodexImageGenerationOutboundEventWithState(n,
+		[]byte(`data: {"type":"response.output_item.done","item":{"id":"ig_1","type":"image_generation_call","status":"completed","result":"`+b64+`","output_format":"png"}}`))
+	out := normalizeCodexImageGenerationOutboundEventWithState(n,
+		[]byte(`data: {"type":"response.completed","response":{"output":[{"id":"ig_1","type":"image_generation_call","status":"completed"}]}}`))
+	if len(out) != 2 {
+		t.Fatalf("events at completion = %d, want 2 (fallback + completed)", len(out))
+	}
+	body := bytes.TrimSpace(out[0][len(dataTag):])
+	got := gjson.GetBytes(body, "item.content.0.text").String()
+	if !strings.Contains(got, "data:image/png;base64,"+b64) {
+		t.Fatalf("fallback item missing the image: %s", got)
+	}
+}
+
+func firstBytes(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n])
 }
 
 func mustJSONString(s string) string {
@@ -345,10 +410,10 @@ func TestMaybeEnsureSkipsWhenBridgeExplicitlyDisabled(t *testing.T) {
 	}
 }
 
-func TestMaybeEnsureInjectsToolShapeThatUpstreamInvokes(t *testing.T) {
-	// action + model mirror buildCodexImageResponsesRequest, the request shape verified to
-	// return images from chatgpt.com/backend-api/codex/responses. A bare
-	// {"type":"image_generation"} is accepted upstream but never invoked by the model.
+func TestMaybeEnsureInjectsPinnedToolShape(t *testing.T) {
+	// action + model mirror buildCodexImageResponsesRequest, the shape verified to return
+	// images from chatgpt.com/backend-api/codex/responses. Pinning them keeps the conversation
+	// path on the same image model as /v1/images and leaves room for the edit action.
 	auth := &cliproxyauth.Auth{Provider: "codex"}
 	body := []byte(`{"model":"gpt-5.6-luna","tools":[{"type":"function","name":"shell"}]}`)
 	out := maybeEnsureCodexImageGenerationTool(body, auth, "gpt-5.6-luna", nil)

--- a/internal/runtime/executor/codex_image_stream.go
+++ b/internal/runtime/executor/codex_image_stream.go
@@ -36,6 +36,10 @@ type codexHostedImage struct {
 // assistant text events Desktop actually persists.
 type codexImageStreamNormalizer struct {
 	images []codexHostedImage
+	// inlined records that a data URL for these images already reached the client inside an
+	// assistant message. A 2.7MB image inlined into every text-shaped event turned one picture
+	// into a 13MB SSE stream, which does not finish over a slow link; one copy is enough.
+	inlined bool
 }
 
 func newCodexImageStreamNormalizer() *codexImageStreamNormalizer {
@@ -57,15 +61,48 @@ func normalizeCodexImageGenerationOutboundEventWithState(n *codexImageStreamNorm
 		return nil
 	}
 	normalized := normalizeCodexImageGenerationCallStatus(payload)
-	if n != nil {
-		n.observe(normalized)
-		normalized = n.rewriteAssistantMarkdown(normalized)
+	if n == nil {
+		// Stateless callers see one event at a time and have no later message to rewrite,
+		// so the fallback display item has to ride along with the image event itself.
+		out := [][]byte{normalized}
+		if msg := synthesizeCodexImageDisplayMessageEvent(normalized); len(msg) > 0 {
+			out = append(out, msg)
+		}
+		return out
 	}
-	out := [][]byte{normalized}
-	if msg := synthesizeCodexImageDisplayMessageEvent(normalized); len(msg) > 0 {
-		out = append(out, msg)
+	n.observe(normalized)
+	normalized = n.rewriteAssistantMarkdown(normalized)
+	// The fallback is only needed when the turn is ending and no assistant message ended up
+	// carrying the picture — emitting it next to every image event duplicated the payload.
+	if msg := n.displayFallbackFor(normalized); len(msg) > 0 {
+		return [][]byte{msg, normalized}
 	}
-	return out
+	return [][]byte{normalized}
+}
+
+// displayFallbackFor returns a synthetic assistant message carrying the generated images,
+// but only at the end of a response that never inlined them into real assistant text.
+func (n *codexImageStreamNormalizer) displayFallbackFor(payload []byte) []byte {
+	if n == nil || n.inlined || len(n.images) == 0 {
+		return nil
+	}
+	body := sseJSONBody(payload)
+	if !gjson.ValidBytes(body) {
+		return nil
+	}
+	switch gjson.GetBytes(body, "type").String() {
+	case "response.completed", "response.done":
+	default:
+		return nil
+	}
+	n.inlined = true
+	text := appendCodexHostedImageMarkdown("", n.images)
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	event := []byte(`{"type":"response.output_item.done","item":{"id":"msg_image_display","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":""}]}}`)
+	event, _ = sjson.SetBytes(event, "item.content.0.text", text)
+	return maybeWrapSSEData(bytes.HasPrefix(payload, dataTag), event)
 }
 
 func (n *codexImageStreamNormalizer) observe(payload []byte) {
@@ -126,11 +163,17 @@ func (n *codexImageStreamNormalizer) rewriteAssistantMarkdown(payload []byte) []
 	eventType := gjson.GetBytes(body, "type").String()
 	updated := body
 	changed := false
+	// Tracks a real data URL inlined by this event, as opposed to a text-only cleanup.
+	inlinedNow := false
 
 	switch eventType {
 	case "response.output_text.done":
+		// Same assistant text that response.output_item.done repeats below. Inlining the
+		// image in all three text-shaped events sent one 2.7MB picture as ~13MB of SSE, which
+		// does not finish over a slow link. Strip the model's unreachable sandbox refs so the
+		// text has no broken image, and let output_item.done carry the single inlined copy.
 		text := gjson.GetBytes(body, "text").String()
-		if next, ok := ensureCodexAssistantImageMarkdown(text, n.images); ok {
+		if next, ok := flattenCodexNonRenderableImageMarkdown(text); ok {
 			var err error
 			updated, err = sjson.SetBytes(updated, "text", next)
 			if err != nil {
@@ -142,7 +185,7 @@ func (n *codexImageStreamNormalizer) rewriteAssistantMarkdown(payload []byte) []
 		partType := strings.TrimSpace(gjson.GetBytes(body, "part.type").String())
 		if partType == "output_text" || partType == "text" {
 			text := gjson.GetBytes(body, "part.text").String()
-			if next, ok := ensureCodexAssistantImageMarkdown(text, n.images); ok {
+			if next, ok := flattenCodexNonRenderableImageMarkdown(text); ok {
 				var err error
 				updated, err = sjson.SetBytes(updated, "part.text", next)
 				if err != nil {
@@ -194,8 +237,12 @@ func (n *codexImageStreamNormalizer) rewriteAssistantMarkdown(payload []byte) []
 				return payload
 			}
 			changed = true
+			inlinedNow = true
 		}
 	case "response.completed", "response.done":
+		// The terminal snapshot repeats every output item. Inlining here after the streamed
+		// message already carried the data URL would double the payload for no new content —
+		// but the snapshot text still has to lose its unreachable sandbox refs.
 		output := gjson.GetBytes(body, "response.output")
 		if !output.IsArray() {
 			return payload
@@ -221,7 +268,14 @@ func (n *codexImageStreamNormalizer) rewriteAssistantMarkdown(payload []byte) []
 					continue
 				}
 				text := part.Get("text").String()
-				next, ok := ensureCodexAssistantImageMarkdown(text, n.images)
+				var next string
+				var ok bool
+				if n.inlined {
+					next, ok = flattenCodexNonRenderableImageMarkdown(text)
+				} else {
+					next, ok = ensureCodexAssistantImageMarkdown(text, n.images)
+					inlinedNow = inlinedNow || ok
+				}
 				if !ok {
 					continue
 				}
@@ -240,7 +294,40 @@ func (n *codexImageStreamNormalizer) rewriteAssistantMarkdown(payload []byte) []
 	if !changed {
 		return payload
 	}
+	if inlinedNow {
+		n.inlined = true
+	}
 	return maybeWrapSSEData(hadSSEPrefix, updated)
+}
+
+// flattenCodexNonRenderableImageMarkdown turns image refs the client cannot load into plain
+// text, without inlining any pixels.
+//
+// The model writes ChatGPT sandbox paths like ![cat](/mnt/data/0.png), which render as a broken
+// image anywhere outside ChatGPT. The picture itself travels once — inlined into the assistant
+// message item — so the duplicate text-shaped events only need the dead ref removed rather than
+// another multi-megabyte copy of the same data URL.
+func flattenCodexNonRenderableImageMarkdown(text string) (string, bool) {
+	if text == "" || !strings.Contains(text, "![") {
+		return text, false
+	}
+	changed := false
+	next := codexMarkdownAnyImageRef.ReplaceAllStringFunc(text, func(match string) string {
+		groups := codexMarkdownAnyImageRef.FindStringSubmatch(match)
+		if len(groups) < 3 || isCodexRenderableImageTarget(groups[2]) {
+			return match
+		}
+		changed = true
+		alt := strings.TrimSpace(groups[1])
+		if alt == "" {
+			alt = "generated image"
+		}
+		return alt
+	})
+	if !changed {
+		return text, false
+	}
+	return next, true
 }
 
 // ensureCodexAssistantImageMarkdown makes Desktop-visible assistant text show hosted images.


### PR DESCRIPTION
## 问题

一次 hosted `image_generation` 对话，把同一张图内联进了流里几乎每个文本事件。对线上 relay 实测（本地直连 8319，绕开 Cloudflare）：

| 事件 | payload | 图片数据 |
|------|---------|----------|
| `response.output_item.done`（image_generation_call） | 2.67M | 原生 result |
| `response.output_item.done`（合成 display message） | 2.67M | data URL |
| `response.output_text.done` | 2.67M | data URL |
| `response.content_part.done` | 2.67M | data URL |
| `response.output_item.done`（message） | 2.67M | data URL |
| **合计** | **13.35M** | 一张 2.67MB 的图 |

网关侧只用 25 秒就完整跑完，但客户端经 Cloudflare 拉这 13.35MB：300 秒只收到 2.9MB 就超时断开——**图已经生成好了，却送不到客户端**。

`codex_image_generation_bridge` 在 #952 改成默认开启后，这条路径对所有 Codex OAuth 账号生效，所以这个放大效应必须一并收掉。

## 改动

- 图片数据最多走两份：原生 `image_generation_call.result`，以及 Desktop 实际持久化的 assistant message item 里的一份内联 data URL。
- `output_text.done` / `content_part.done` 不再内联，但保留清理：模型写的 `/mnt/data/0.png`、臆造的 `~/.codex/generated_images/...` 会被压平成纯文本，避免留下破图。
- `response.completed` 快照在已内联时同样只做清理，不再重复内联（测试正是在这里抓到破图引用泄漏）。
- 合成 display message 从"每个图片事件旁都发"改为"整轮结束且没有任何消息带上图片时才发"。
- 修正 #952 里一句被实测推翻的注释：裸 `{"type":"image_generation"}` 上游**也会**调用；固定 `action` / `model` 的真实理由是表达 edit 动作、并与 `/v1/images` 用同一个图像模型。

## 验证

- `./scripts/ci-pr.sh` 全绿（gofmt / go vet / 全量 go test / golangci-lint / go build / 结构检查）。
- 新增 `TestCodexImageStreamSendsImageBytesOnce`：按上游真实事件顺序走完整轮，断言图片字节在整个流里恰好出现 2 次，且不残留 `/mnt/data/` 破图引用。
- 新增 `TestCodexImageStreamFallsBackWhenNoAssistantMessage`：模型只出图不说话时，结束前仍会发合成消息。
- 上游行为实证（线上 codex 账号，`chatgpt.com/backend-api/codex/responses`）：完整工具集 + `tool_choice:auto` 下模型会自主调用 `image_generation`；`gpt-5.6-luna` 与 `gpt-5.4-mini` 均出图成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)