### PR TITLE
feat(authfiles): support concurrency_limit field patch and entry serialization

### DIFF
--- a/internal/management/authfiles/entry.go
+++ b/internal/management/authfiles/entry.go
@@ -145,5 +145,8 @@ func BuildEntry(auth *coreauth.Auth, opts EntryOptions) map[string]any {
 	if xaiEndpoint := XAIEndpointPayload(auth); len(xaiEndpoint) > 0 {
 		entry["using_api"] = xaiEndpoint["using_api"]
 	}
+	if limit := auth.ConcurrencyLimit(); limit > 0 {
+		entry["concurrency_limit"] = limit
+	}
 	return entry
 }

--- a/internal/management/authfiles/entry_test.go
+++ b/internal/management/authfiles/entry_test.go
@@ -80,6 +80,25 @@ func TestBuildEntryUsesTenantLocalPublicName(t *testing.T) {
 	}
 }
 
+func TestBuildEntryIncludesConcurrencyLimit(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "runtime-concurrency",
+		Provider: "claude",
+		Attributes: map[string]string{
+			"runtime_only":      "true",
+			"concurrency_limit": "3",
+		},
+	}
+
+	entry := BuildEntry(auth, EntryOptions{})
+	if entry == nil {
+		t.Fatal("expected runtime-only entry")
+	}
+	if got, _ := entry["concurrency_limit"].(int); got != 3 {
+		t.Fatalf("concurrency_limit = %v, want 3", entry["concurrency_limit"])
+	}
+}
+
 func TestBuildEntryAllowsRuntimeOnlyAuthWithoutPath(t *testing.T) {
 	auth := &coreauth.Auth{
 		ID:       "runtime",

--- a/internal/management/authfiles/patch.go
+++ b/internal/management/authfiles/patch.go
@@ -30,6 +30,8 @@ type FieldPatch struct {
 	CodexImageGenerationBridge *bool `json:"codex_image_generation_bridge"`
 	// UsingAPI selects xAI official API vs Grok Build/CLI for OAuth accounts.
 	UsingAPI *bool `json:"using_api"`
+	// ConcurrencyLimit sets the max active concurrent requests for this account (0 = unlimited).
+	ConcurrencyLimit *int `json:"concurrency_limit"`
 }
 
 type FieldPatchOptions struct {
@@ -270,6 +272,30 @@ func ApplyFieldPatch(auth *coreauth.Auth, patch FieldPatch, opts FieldPatchOptio
 			attrs["using_api"] = "true"
 		} else {
 			attrs["using_api"] = "false"
+		}
+		changed = true
+	}
+	if patch.ConcurrencyLimit != nil {
+		limit := *patch.ConcurrencyLimit
+		if limit < 0 {
+			limit = 0
+		}
+		metadata := ensureMetadata(auth)
+		attrs := ensureAttributes(auth)
+		if limit == 0 {
+			delete(metadata, "concurrency_limit")
+			delete(metadata, "concurrency")
+			delete(metadata, "concurrency-limit")
+			delete(attrs, "concurrency_limit")
+			delete(attrs, "concurrency")
+			delete(attrs, "concurrency-limit")
+		} else {
+			delete(metadata, "concurrency")
+			delete(metadata, "concurrency-limit")
+			metadata["concurrency_limit"] = limit
+			delete(attrs, "concurrency")
+			delete(attrs, "concurrency-limit")
+			attrs["concurrency_limit"] = fmt.Sprintf("%d", limit)
 		}
 		changed = true
 	}

--- a/internal/management/authfiles/patch_test.go
+++ b/internal/management/authfiles/patch_test.go
@@ -419,6 +419,44 @@ func TestApplyFieldPatchRejectsUsingAPIForXAIAPIKey(t *testing.T) {
 	}
 }
 
+func TestApplyFieldPatchUpdatesConcurrencyLimit(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "account-concurrency",
+		Provider: "claude",
+	}
+
+	limit := 5
+	_, err := ApplyFieldPatch(auth, FieldPatch{ConcurrencyLimit: &limit}, FieldPatchOptions{})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	if got, _ := auth.Metadata["concurrency_limit"].(int); got != 5 {
+		t.Fatalf("metadata concurrency_limit = %v, want 5", got)
+	}
+	if got := auth.Attributes["concurrency_limit"]; got != "5" {
+		t.Fatalf("attributes concurrency_limit = %q, want 5", got)
+	}
+	if auth.ConcurrencyLimit() != 5 {
+		t.Fatalf("auth.ConcurrencyLimit() = %d, want 5", auth.ConcurrencyLimit())
+	}
+
+	// Setting to 0 should clear it (unlimited)
+	zeroLimit := 0
+	_, err = ApplyFieldPatch(auth, FieldPatch{ConcurrencyLimit: &zeroLimit}, FieldPatchOptions{})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() zero error = %v", err)
+	}
+	if _, ok := auth.Metadata["concurrency_limit"]; ok {
+		t.Fatalf("metadata concurrency_limit should be deleted, got %v", auth.Metadata["concurrency_limit"])
+	}
+	if _, ok := auth.Attributes["concurrency_limit"]; ok {
+		t.Fatalf("attributes concurrency_limit should be deleted, got %v", auth.Attributes["concurrency_limit"])
+	}
+	if auth.ConcurrencyLimit() != 0 {
+		t.Fatalf("auth.ConcurrencyLimit() = %d, want 0", auth.ConcurrencyLimit())
+	}
+}
+
 func TestApplyFieldPatchRejectsNoFields(t *testing.T) {
 	auth := &coreauth.Auth{ID: "empty", Provider: "codex"}
 


### PR DESCRIPTION
## Summary
- Adds `concurrency_limit` to `FieldPatch` in `internal/management/authfiles/patch.go`, allowing updating account concurrency limit via management API.
- Serializes `concurrency_limit` in `BuildEntry` so callers and frontends can display active account concurrency limits.
- Adds comprehensive unit tests covering update, clear (zeroing), and entry serialization.

## Verification
- Local unit tests in `internal/management/authfiles` pass.
- Backend structure check passed.