### PR TITLE
fix(antigravity,gemini): normalize payload wrapping and preserve function output type

### DIFF
--- a/internal/runtime/executor/antigravity_payload.go
+++ b/internal/runtime/executor/antigravity_payload.go
@@ -20,16 +20,23 @@ var (
 )
 
 func geminiToAntigravity(modelName string, payload []byte, projectID string) []byte {
-	template, _ := sjson.Set(string(payload), "model", modelName)
-	template, _ = sjson.Set(template, "userAgent", "antigravity")
-	template, _ = sjson.Set(template, "requestType", "agent")
-
-	if projectID != "" {
-		template, _ = sjson.Set(template, "project", projectID)
+	var requestRaw string
+	if reqNode := gjson.GetBytes(payload, "request"); reqNode.IsObject() {
+		requestRaw = reqNode.Raw
 	} else {
-		template, _ = sjson.Set(template, "project", generateProjectID())
+		requestRaw = string(payload)
 	}
+
+	pid := projectID
+	if pid == "" {
+		pid = generateProjectID()
+	}
+
+	template := `{"project":"","model":"","userAgent":"antigravity","requestType":"agent","requestId":"","request":{}}`
+	template, _ = sjson.Set(template, "project", pid)
+	template, _ = sjson.Set(template, "model", modelName)
 	template, _ = sjson.Set(template, "requestId", generateRequestID())
+	template, _ = sjson.SetRaw(template, "request", requestRaw)
 	template, _ = sjson.Set(template, "request.sessionId", generateStableSessionID(payload))
 
 	template, _ = sjson.Delete(template, "request.safetySettings")
@@ -53,6 +60,9 @@ func generateSessionID() string {
 
 func generateStableSessionID(payload []byte) string {
 	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.Exists() {
+		contents = gjson.GetBytes(payload, "contents")
+	}
 	if contents.IsArray() {
 		for _, content := range contents.Array() {
 			if content.Get("role").String() == "user" {

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -285,8 +285,6 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 			case "function_call_output":
 				// Handle function call outputs - convert to function message with functionResponse
 				callID := item.Get("call_id").String()
-				// Use .Raw to preserve the JSON encoding (includes quotes for strings)
-				outputRaw := item.Get("output").Str
 
 				functionContent := `{"role":"function","parts":[]}`
 				functionResponse := `{"functionResponse":{"name":"","response":{}}}`
@@ -310,13 +308,21 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				functionResponse, _ = sjson.Set(functionResponse, "functionResponse.name", functionName)
 				functionResponse, _ = sjson.Set(functionResponse, "functionResponse.id", callID)
 
-				// Set the raw JSON output directly (preserves string encoding)
-				if outputRaw != "" && outputRaw != "null" {
-					output := gjson.Parse(outputRaw)
-					if output.Type == gjson.JSON {
-						functionResponse, _ = sjson.SetRaw(functionResponse, "functionResponse.response.result", output.Raw)
+				// Set the function response result safely
+				outputItem := item.Get("output")
+				if outputItem.IsObject() || outputItem.IsArray() {
+					functionResponse, _ = sjson.SetRaw(functionResponse, "functionResponse.response.result", outputItem.Raw)
+				} else if outputItem.Exists() {
+					val := outputItem.String()
+					if outputItem.Type == gjson.String && gjson.Valid(val) {
+						parsed := gjson.Parse(val)
+						if parsed.IsObject() || parsed.IsArray() {
+							functionResponse, _ = sjson.SetRaw(functionResponse, "functionResponse.response.result", parsed.Raw)
+						} else {
+							functionResponse, _ = sjson.Set(functionResponse, "functionResponse.response.result", val)
+						}
 					} else {
-						functionResponse, _ = sjson.Set(functionResponse, "functionResponse.response.result", outputRaw)
+						functionResponse, _ = sjson.Set(functionResponse, "functionResponse.response.result", val)
 					}
 				}
 				functionContent, _ = sjson.SetRaw(functionContent, "parts.-1", functionResponse)


### PR DESCRIPTION
### Summary
- Normalize Antigravity payload wrapping by extracting existing `request` object when already wrapped.
- Support robust fallback for `contents` in stable session ID derivation.
- Handle non-string / JSON object function call output gracefully in gemini openai-responses translator without invalid double-escaping.

### Validation
- Unit tests run and passed in `internal/runtime/executor` and `internal/translator/gemini/openai/responses`.