### PR TITLE
fix(antigravity): stop learning caller User-Agents as the account identity

### DIFF
--- a/internal/identityfingerprint/antigravity_test.go
+++ b/internal/identityfingerprint/antigravity_test.go
@@ -51,3 +51,62 @@ func TestAntigravityObservationAndResolution(t *testing.T) {
 		t.Errorf("expected UserAgent source to be learned, got %v", eff.Fields[FieldUserAgent].Source)
 	}
 }
+
+// Any client can reach the proxy, and most send a User-Agent of their own: a
+// Node SDK sends a bare "node". Learning one of those pinned the account to an
+// identity Antigravity refuses, taking every later request to 403 (#3501).
+func TestAntigravityObservationRejectsForeignUserAgents(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	for _, ua := range []string{"", "node", "curl/8.7.1", "python-requests/2.32.3", "vscode/1.96.0"} {
+		headers := http.Header{}
+		if ua != "" {
+			headers.Set("User-Agent", ua)
+		}
+		obs, ok := ExtractObservation(LearnInput{
+			Provider:      ProviderAntigravity,
+			AccountKey:    "test-account",
+			AuthSubjectID: "sub-123",
+			Headers:       headers,
+			ObservedAt:    now,
+		})
+		if ok {
+			t.Errorf("ExtractObservation learned non-Antigravity User-Agent %q as %+v", ua, obs.Fields)
+		}
+	}
+}
+
+// Records written before the observation guard was tightened still hold foreign
+// identities, and a restored backup can reintroduce one at any time. Resolution
+// must ignore them rather than send them upstream.
+func TestResolveAntigravityIgnoresForeignLearnedUserAgent(t *testing.T) {
+	learned := &LearnedRecord{
+		Provider:   ProviderAntigravity,
+		AccountKey: "test-account",
+		ProfileKey: ProfileKeyDefault,
+		Fields:     map[string]string{FieldUserAgent: "node"},
+	}
+
+	resolved, eff := ResolveAntigravity(config.AntigravityIdentityFingerprintConfig{Enabled: true}, learned)
+	if resolved.UserAgent != config.DefaultAntigravityFingerprintUserAgent {
+		t.Errorf("resolved.UserAgent = %q, want built-in default %q", resolved.UserAgent, config.DefaultAntigravityFingerprintUserAgent)
+	}
+	if got := eff.Fields[FieldUserAgent].Source; got != FieldSourceBuiltinDefault {
+		t.Errorf("UserAgent source = %v, want %v", got, FieldSourceBuiltinDefault)
+	}
+	if resolved.Version != config.DefaultAntigravityFingerprintVersion {
+		t.Errorf("resolved.Version = %q, want %q", resolved.Version, config.DefaultAntigravityFingerprintVersion)
+	}
+
+	// An operator-configured identity still outranks the built-in default.
+	preset := config.AntigravityIdentityFingerprintConfig{
+		Enabled:   true,
+		UserAgent: "vscode/1.99.0 (Antigravity/4.9.1)",
+	}
+	resolved, eff = ResolveAntigravity(preset, learned)
+	if resolved.UserAgent != preset.UserAgent {
+		t.Errorf("resolved.UserAgent = %q, want preset %q", resolved.UserAgent, preset.UserAgent)
+	}
+	if got := eff.Fields[FieldUserAgent].Source; got != FieldSourcePreset {
+		t.Errorf("UserAgent source = %v, want %v", got, FieldSourcePreset)
+	}
+}

--- a/internal/identityfingerprint/extract.go
+++ b/internal/identityfingerprint/extract.go
@@ -288,22 +288,30 @@ func extractKimiObservation(input LearnInput, headers http.Header, observedAt ti
 	}, true
 }
 
-// extractAntigravityObservation learns the identity an Antigravity client presents.
+// IsAntigravityClientUserAgent reports whether a User-Agent carries the
+// Antigravity client token. Antigravity's upstream refuses any caller it cannot
+// recognise with "You do not have a valid license of this product (#3501)", so a
+// User-Agent that fails this check must never be learned as, or resolved into,
+// an account's outbound identity.
+func IsAntigravityClientUserAgent(ua string) bool {
+	return antigravityUARe.MatchString(strings.TrimSpace(ua))
+}
+
+// extractAntigravityObservation learns the identity a real Antigravity client presents.
+//
+// A caller whose User-Agent does not identify the Antigravity client is not the
+// Antigravity client, and recording it would pin the account to a made-up
+// identity that the upstream then rejects. Generic SDK User-Agents reach this
+// path routinely — a Node client sends a bare "node" — so the client token, not
+// merely a non-empty header, is what makes an observation.
 func extractAntigravityObservation(input LearnInput, headers http.Header, observedAt time.Time) (Observation, bool) {
 	ua := strings.TrimSpace(headers.Get("User-Agent"))
 	matches := antigravityUARe.FindStringSubmatch(ua)
-	version := ""
-	product := "antigravity"
-	if len(matches) > 1 {
-		version = strings.TrimSpace(matches[1])
-	}
-	if ua == "" && version == "" {
+	if len(matches) == 0 {
 		return Observation{}, false
 	}
-	fields := map[string]string{}
-	if ua != "" {
-		fields[FieldUserAgent] = ua
-	}
+	version := strings.TrimSpace(matches[1])
+	fields := map[string]string{FieldUserAgent: ua}
 	if version != "" {
 		fields[FieldAntigravityVersion] = version
 	}
@@ -312,7 +320,7 @@ func extractAntigravityObservation(input LearnInput, headers http.Header, observ
 		AccountKey:      strings.TrimSpace(input.AccountKey),
 		ProfileKey:      ProfileKeyDefault,
 		AuthSubjectID:   strings.TrimSpace(input.AuthSubjectID),
-		ClientProduct:   product,
+		ClientProduct:   "antigravity",
 		ClientVariant:   "vscode",
 		Version:         version,
 		Fields:          fields,

--- a/internal/identityfingerprint/resolve.go
+++ b/internal/identityfingerprint/resolve.go
@@ -240,6 +240,15 @@ func KimiLearnedDeviceID(learned *LearnedRecord) string {
 
 // ResolveAntigravity blends the operator config with learned Antigravity observations.
 func ResolveAntigravity(cfg config.AntigravityIdentityFingerprintConfig, learned *LearnedRecord) (config.AntigravityIdentityFingerprintConfig, EffectiveFingerprint) {
+	// A learned record only counts while its User-Agent still identifies the
+	// Antigravity client. Records written before the observation guard was
+	// tightened hold whatever the calling SDK sent, and applying one of those
+	// costs the account every request. Storage purges them at startup; this
+	// guard covers the copies already cached in memory, and any that a restored
+	// backup or an older peer writes back later.
+	if !IsAntigravityClientUserAgent(learnedField(learned, FieldUserAgent)) {
+		learned = nil
+	}
 	clean := config.CleanAntigravityIdentityFingerprint(cfg)
 	defaults := config.DefaultAntigravityIdentityFingerprint()
 	fields := make(map[string]FieldValue, 4)

--- a/internal/runtime/executor/antigravity_identity_fingerprint_test.go
+++ b/internal/runtime/executor/antigravity_identity_fingerprint_test.go
@@ -1,0 +1,85 @@
+package executor
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	antigravityauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/antigravity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// The fingerprint default is a third copy of the client identity, and it is the
+// copy that overwrites the outgoing User-Agent. Pinned to the shared constant so
+// bumping the Antigravity client version in one place cannot leave the proxy
+// announcing two different clients for the same account.
+func TestAntigravityFingerprintDefaultMatchesTheSharedClientIdentity(t *testing.T) {
+	if config.DefaultAntigravityFingerprintUserAgent != antigravityauth.ClientUserAgent {
+		t.Fatalf("config default UA = %q, want the shared %q", config.DefaultAntigravityFingerprintUserAgent, antigravityauth.ClientUserAgent)
+	}
+	if config.DefaultAntigravityFingerprintVersion != antigravityauth.ClientVersion {
+		t.Fatalf("config default version = %q, want the shared %q", config.DefaultAntigravityFingerprintVersion, antigravityauth.ClientVersion)
+	}
+}
+
+// Regression: the caller's own User-Agent was learned as the account's identity
+// and replayed upstream, so every request from a Node client went out as "node"
+// and Antigravity answered 403 "no valid license (#3501)". What the client calls
+// itself must never reach Antigravity.
+func TestAntigravityBuildRequestKeepsClientUserAgentOutOfUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, clientUA := range []string{"node", "curl/8.7.1", "Mozilla/5.0"} {
+		ctx := contextWithClientUserAgent(clientUA)
+		executor := &AntigravityExecutor{cfg: newAntigravityFingerprintConfig(true)}
+		auth := &cliproxyauth.Auth{ID: "account-under-test"}
+
+		req, _, err := executor.buildRequest(ctx, auth, "token", "gemini-3.7-flash-high", []byte(`{"request":{}}`), false, "", "https://example.com")
+		if err != nil {
+			t.Fatalf("buildRequest error: %v", err)
+		}
+		if got := req.Header.Get("User-Agent"); got != antigravityauth.ClientUserAgent {
+			t.Errorf("client sent %q, upstream User-Agent = %q, want %q", clientUA, got, antigravityauth.ClientUserAgent)
+		}
+	}
+}
+
+// With the feature off the resolver still returns the built-in template, so the
+// executor has to skip it entirely rather than apply it — otherwise an identity
+// the credential carries of its own is silently overwritten and the switch does
+// nothing.
+func TestAntigravityBuildRequestHonoursDisabledFingerprint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const pinned = "vscode/1.98.0 (Antigravity/4.2.0)"
+	ctx := contextWithClientUserAgent("node")
+	executor := &AntigravityExecutor{cfg: newAntigravityFingerprintConfig(false)}
+	auth := &cliproxyauth.Auth{
+		ID:         "account-under-test",
+		Attributes: map[string]string{"user_agent": pinned},
+	}
+
+	req, _, err := executor.buildRequest(ctx, auth, "token", "gemini-3.7-flash-high", []byte(`{"request":{}}`), false, "", "https://example.com")
+	if err != nil {
+		t.Fatalf("buildRequest error: %v", err)
+	}
+	if got := req.Header.Get("User-Agent"); got != pinned {
+		t.Errorf("upstream User-Agent = %q, want the account's own %q", got, pinned)
+	}
+}
+
+func newAntigravityFingerprintConfig(enabled bool) *config.Config {
+	cfg := &config.Config{}
+	cfg.IdentityFingerprint.Antigravity = config.NormalizeAntigravityIdentityFingerprint(config.AntigravityIdentityFingerprintConfig{})
+	cfg.IdentityFingerprint.Antigravity.Enabled = enabled
+	return cfg
+}
+
+func contextWithClientUserAgent(ua string) context.Context {
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+	ginCtx.Request.Header.Set("User-Agent", ua)
+	return context.WithValue(context.Background(), util.ContextKeyGin, ginCtx)
+}

--- a/internal/runtime/executor/antigravity_request.go
+++ b/internal/runtime/executor/antigravity_request.go
@@ -103,8 +103,12 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("User-Agent", resolveUserAgent(auth))
 	if e != nil && e.cfg != nil {
-		fp, _, _ := antigravityIdentityFingerprint(e.cfg, auth, ctx)
-		applyAntigravityIdentityFingerprintHeaders(httpReq.Header, fp)
+		// Only apply the fingerprint when the feature is on: with it off the
+		// resolver still hands back the built-in template, and applying that
+		// would overwrite an identity the credential carries of its own.
+		if fp, _, enabled := antigravityIdentityFingerprint(e.cfg, auth, ctx); enabled {
+			applyAntigravityIdentityFingerprintHeaders(httpReq.Header, fp)
+		}
 	}
 	if stream {
 		httpReq.Header.Set("Accept", "text/event-stream")

--- a/internal/usage/identity_fingerprint_antigravity_purge_test.go
+++ b/internal/usage/identity_fingerprint_antigravity_purge_test.go
@@ -1,0 +1,73 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// Rows written before the observation guard was tightened hold whatever
+// User-Agent the calling SDK sent, and replaying one of those upstream costs the
+// account every request ("no valid license", #3501). Startup has to clear them;
+// a genuine client re-learns its own identity on the next request.
+func TestPurgeForeignAntigravityFingerprints(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+
+	seed := func(provider, accountKey, fieldsJSON string) {
+		t.Helper()
+		now := time.Now().UTC().Format(time.RFC3339Nano)
+		if _, err := getDB().Exec(`
+			INSERT INTO identity_fingerprints (
+				tenant_id, provider, account_key, profile_key, auth_subject_id,
+				client_product, client_variant, version, fields_json, observed_headers_json,
+				created_at, updated_at, last_seen_at
+			) VALUES (?, ?, ?, 'default', ?, '', '', '', ?, '{}', ?, ?, ?)
+		`, systemTenantID, provider, accountKey, accountKey, fieldsJSON, now, now, now); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	seed("antigravity", "acct-node", `{"user-agent":"node"}`)
+	seed("antigravity", "acct-curl", `{"user-agent":"curl/8.7.1"}`)
+	seed("antigravity", "acct-empty", `{}`)
+	seed("antigravity", "acct-corrupt", `not json`)
+	seed("antigravity", "acct-real", `{"user-agent":"vscode/1.96.0 (Antigravity/4.3.0)","antigravity-version":"4.3.0"}`)
+	// A foreign User-Agent on another provider is that provider's business.
+	seed("codex", "acct-codex", `{"user-agent":"node"}`)
+
+	purgeForeignAntigravityFingerprints(getDB())
+
+	survivors := map[string]bool{}
+	rows, err := getDB().Query(`SELECT provider, account_key FROM identity_fingerprints WHERE tenant_id = ?`, systemTenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var provider, accountKey string
+		if err = rows.Scan(&provider, &accountKey); err != nil {
+			t.Fatal(err)
+		}
+		survivors[provider+"/"+accountKey] = true
+	}
+	if err = rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, purged := range []string{
+		"antigravity/acct-node",
+		"antigravity/acct-curl",
+		"antigravity/acct-empty",
+		"antigravity/acct-corrupt",
+	} {
+		if survivors[purged] {
+			t.Errorf("%s survived, want it purged", purged)
+		}
+	}
+	for _, kept := range []string{"antigravity/acct-real", "codex/acct-codex"} {
+		if !survivors[kept] {
+			t.Errorf("%s was purged, want it kept", kept)
+		}
+	}
+}

--- a/internal/usage/identity_fingerprint_db.go
+++ b/internal/usage/identity_fingerprint_db.go
@@ -63,6 +63,69 @@ func initIdentityFingerprintsTable(db *sql.DB) {
 			log.Errorf("usage: recreate identity fingerprint indexes: %v", err)
 		}
 	}
+	purgeForeignAntigravityFingerprints(db)
+}
+
+type identityFingerprintKey struct {
+	accountKey string
+	profileKey string
+}
+
+// purgeForeignAntigravityFingerprints drops learned Antigravity identities whose
+// User-Agent does not identify the Antigravity client.
+//
+// Until the observation guard was tightened, any non-empty User-Agent was
+// learned and then replayed as that account's outbound identity — a Node client
+// sends a bare "node" — and Antigravity refuses every request from a client it
+// does not recognise with "You do not have a valid license of this product
+// (#3501)". Dropping the row falls the account back to the built-in default
+// identity, and a genuine client re-learns its own on the next request.
+func purgeForeignAntigravityFingerprints(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	stale, err := staleAntigravityFingerprints(db)
+	if err != nil {
+		log.Errorf("usage: scan learned antigravity identities: %v", err)
+		return
+	}
+	provider := string(identityfingerprint.ProviderAntigravity)
+	for _, key := range stale {
+		if _, err = db.Exec(`DELETE FROM identity_fingerprints WHERE tenant_id = ? AND provider = ? AND account_key = ? AND profile_key = ?`,
+			systemTenantID, provider, key.accountKey, key.profileKey); err != nil {
+			log.Errorf("usage: purge learned antigravity identity %s/%s: %v", key.accountKey, key.profileKey, err)
+			continue
+		}
+		notifyIdentityFingerprintInvalidated(identityfingerprint.ProviderAntigravity, key.accountKey)
+		log.Infof("usage: purged learned antigravity identity for account %s (profile %s): user-agent does not identify an antigravity client", key.accountKey, key.profileKey)
+	}
+}
+
+func staleAntigravityFingerprints(db *sql.DB) ([]identityFingerprintKey, error) {
+	rows, err := db.Query(`SELECT account_key, profile_key, fields_json FROM identity_fingerprints WHERE tenant_id = ? AND provider = ?`,
+		systemTenantID, string(identityfingerprint.ProviderAntigravity))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var stale []identityFingerprintKey
+	for rows.Next() {
+		var key identityFingerprintKey
+		var fieldsJSON string
+		if err = rows.Scan(&key.accountKey, &key.profileKey, &fieldsJSON); err != nil {
+			return nil, err
+		}
+		fields := map[string]string{}
+		if strings.TrimSpace(fieldsJSON) != "" {
+			// A payload that will not parse cannot be shown to hold a real
+			// client identity, so it is purged along with the rest.
+			_ = json.Unmarshal([]byte(fieldsJSON), &fields)
+		}
+		if !identityfingerprint.IsAntigravityClientUserAgent(fields[identityfingerprint.FieldUserAgent]) {
+			stale = append(stale, key)
+		}
+	}
+	return stale, rows.Err()
 }
 
 func migrateIdentityFingerprintTenantSchema(db *sql.DB) {


### PR DESCRIPTION
## 问题

线上三个 Antigravity 账号在 #960 部署（20:58）后一分钟内全部 403，上游原文：

> You do not have a valid license of this product... (#3501)

同账号、同上游 URL 的前后两次请求，唯一差异是发往上游的 `User-Agent`：

| 时间 | 版本 | 上游 UA | 结果 |
|---|---|---|---|
| 20:48 | `dev-21bd8f8` | `vscode/1.X.X (Antigravity/4.3.0)` | 200 |
| 21:06 | `dev-336e6eb` | `node` | 403 |

## 根因

`extractAntigravityObservation` 把 `ClientProduct` 写死成 `"antigravity"`，守卫退化成「只要 UA 非空就学」：

```go
product := "antigravity"          // 永远非空
if ua == "" && version == "" {    // 于是只要 UA 非空就学
    return Observation{}, false
}
```

而 `pickField` 的优先级是 **learned > preset > builtin default**，所以任何 SDK 的第一个请求就把该账号的对外身份钉成了调用方的 UA。Node 客户端发的是裸 `node`，上游随即拒绝所有请求。

其余 provider 都有正确守卫（gemini/kimi 均要求先识别出客户端，kimi 的注释写明了原因）。线上 DB 佐证：codex / xai 的记录全是真实客户端 UA，只有 antigravity 三条是 `{"user-agent":"node"}`。

## 修复

1. **观察层**：UA 匹配不到 Antigravity 客户端标识就不学习，与其他 provider 一致。
2. **解析层**：learned 记录的 UA 不合法时整条忽略，防止内存缓存残留、备份恢复或旧节点回写再次触发。
3. **数据修复**：启动时清理已落盘的异常记录，存量安装部署即自愈，无需手工改表。
4. **开关失效**：executor 此前丢弃了 `enabled` 返回值，关闭指纹后仍会用内置模板覆盖凭据自带的 UA，一并修正。

## 测试

- 观察层拒绝 `node` / `curl` / `python-requests` / `vscode/1.96.0`
- 解析层回退到 preset 与 builtin default
- 清理迁移保留真实身份与其他 provider 的记录
- buildRequest 回归：客户端 UA 不得出现在上游请求上
- 指纹默认常量与 `antigravityauth.ClientUserAgent` 一致性（该身份此前已漂移过一次）

回滚修复后上述测试确实失败（复现 `learned non-Antigravity User-Agent "node"`），确认非空转测试。

## 验证

本地完整 `./scripts/ci-pr.sh` 通过：结构检查、gofmt、go vet、`go test ./...`、golangci-lint v1.64.5、go build 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)