### PR TITLE
feat(usage): add per-tenant throughput breakdown for platform admins

### DIFF
--- a/internal/api/handlers/management/dashboard_summary.go
+++ b/internal/api/handlers/management/dashboard_summary.go
@@ -106,6 +106,21 @@ func (h *Handler) GetDashboardSummary(c *gin.Context) {
 				trends.ThroughputSeries = series
 				throughputScope = "all_tenants"
 			}
+			tenantNames := make(map[string]string)
+			if service := h.identity(); service != nil {
+				if tenants, tErr := service.ListTenants(c.Request.Context()); tErr == nil {
+					for _, t := range tenants {
+						name := t.Name
+						if name == "" {
+							name = t.Slug
+						}
+						tenantNames[t.ID] = name
+					}
+				}
+			}
+			if items, bErr := usage.QueryDashboardTenantBreakdownThroughput(tenantNames); bErr == nil {
+				trends.Tenants = items
+			}
 		}
 		h.setDashboardSummaryCache(cacheKey, dashboardSummaryUsageCache{
 			kpi:             kpi,

--- a/internal/api/handlers/management/dashboard_summary_test.go
+++ b/internal/api/handlers/management/dashboard_summary_test.go
@@ -215,6 +215,13 @@ func TestGetDashboardSummaryThroughputScopeByPrincipal(t *testing.T) {
 		t.Fatalf("admin status %d body=%s", recAdmin.Code, recAdmin.Body.String())
 	}
 	var adminPayload struct {
+		Trends struct {
+			ThroughputSeries []struct{ RPM float64 } `json:"throughput_series"`
+			Tenants          []struct {
+				TenantID   string `json:"tenant_id"`
+				TenantName string `json:"tenant_name"`
+			} `json:"tenants"`
+		} `json:"trends"`
 		Meta struct {
 			ThroughputScope string `json:"throughput_scope"`
 		} `json:"meta"`

--- a/internal/usage/request_log_dashboard.go
+++ b/internal/usage/request_log_dashboard.go
@@ -33,12 +33,21 @@ type DashboardThroughputPoint struct {
 	TPM   float64 `json:"tpm"`
 }
 
-type DashboardTrends struct {
-	RequestVolume    []DashboardTrendPoint      `json:"request_volume"`
-	SuccessRate      []DashboardTrendPoint      `json:"success_rate"`
-	TotalTokens      []DashboardTrendPoint      `json:"total_tokens"`
-	FailedRequests   []DashboardTrendPoint      `json:"failed_requests"`
+type DashboardTenantThroughputItem struct {
+	TenantID         string                     `json:"tenant_id"`
+	TenantName       string                     `json:"tenant_name,omitempty"`
 	ThroughputSeries []DashboardThroughputPoint `json:"throughput_series"`
+	CurrentRPM       float64                    `json:"current_rpm"`
+	CurrentTPM       float64                    `json:"current_tpm"`
+}
+
+type DashboardTrends struct {
+	RequestVolume    []DashboardTrendPoint           `json:"request_volume"`
+	SuccessRate      []DashboardTrendPoint           `json:"success_rate"`
+	TotalTokens      []DashboardTrendPoint           `json:"total_tokens"`
+	FailedRequests   []DashboardTrendPoint           `json:"failed_requests"`
+	ThroughputSeries []DashboardThroughputPoint      `json:"throughput_series"`
+	Tenants          []DashboardTenantThroughputItem `json:"tenants,omitempty"`
 }
 
 type dashboardBucket struct {
@@ -179,6 +188,94 @@ func normalizeDashboardSQLBucketKey(raw string, days int) string {
 // tenant trends). Used by platform super-admins.
 func QueryDashboardThroughputAcrossTenants() ([]DashboardThroughputPoint, error) {
 	return queryDashboardThroughputSeriesAt("", time.Now(), getUsageLocation(), true)
+}
+
+// QueryDashboardTenantBreakdownThroughput returns the recent 7 RPM/TPM points
+// for each active tenant with traffic in the recent window or known tenants.
+// Only accessible by platform super-admins.
+func QueryDashboardTenantBreakdownThroughput(tenantNames map[string]string) ([]DashboardTenantThroughputItem, error) {
+	db := getReadDB()
+	if db == nil {
+		return nil, nil
+	}
+	loc := getUsageLocation()
+	now := time.Now().In(loc)
+	start := now.Truncate(time.Minute).Add(-time.Duration(dashboardThroughputBucketCount-1) * time.Minute)
+	fromMinute := start.Format("2006-01-02T15:04")
+	toMinute := now.Add(time.Minute).Format("2006-01-02T15:04")
+	fromUTC := now.Add(-time.Minute).UTC().Format(time.RFC3339Nano)
+	toUTC := now.UTC().Format(time.RFC3339Nano)
+
+	// 1. Identify distinct tenant IDs active in rollup window or rolling window
+	tenantSet := make(map[string]struct{})
+	for tid := range tenantNames {
+		if tid != "" {
+			tenantSet[normalizeTenantID(tid)] = struct{}{}
+		}
+	}
+
+	rows, err := db.Query(`
+		SELECT DISTINCT tenant_id
+		FROM usage_rollup_buckets
+		WHERE bucket_kind = ? AND bucket_start >= ? AND bucket_start < ?
+	`, rollupBucketMinute, fromMinute, toMinute)
+	if err == nil {
+		for rows.Next() {
+			var tid string
+			if scanErr := rows.Scan(&tid); scanErr == nil && tid != "" {
+				tenantSet[normalizeTenantID(tid)] = struct{}{}
+			}
+		}
+		_ = rows.Close()
+	}
+
+	wRows, wErr := db.Query(`
+		SELECT DISTINCT tenant_id
+		FROM request_logs
+		WHERE timestamp >= ? AND timestamp <= ?
+	`, fromUTC, toUTC)
+	if wErr == nil {
+		for wRows.Next() {
+			var tid string
+			if scanErr := wRows.Scan(&tid); scanErr == nil && tid != "" {
+				tenantSet[normalizeTenantID(tid)] = struct{}{}
+			}
+		}
+		_ = wRows.Close()
+	}
+
+	if len(tenantSet) == 0 {
+		tenantSet[systemTenantID] = struct{}{}
+	}
+
+	// 2. Query each tenant's throughput series
+	result := make([]DashboardTenantThroughputItem, 0, len(tenantSet))
+	for tid := range tenantSet {
+		series, sErr := queryDashboardThroughputSeriesAt(tid, now, loc, false)
+		if sErr != nil {
+			continue
+		}
+		var curRPM, curTPM float64
+		if len(series) > 0 {
+			curRPM = series[len(series)-1].RPM
+			curTPM = series[len(series)-1].TPM
+		}
+		name := tid
+		if tenantNames != nil {
+			if n, ok := tenantNames[tid]; ok && n != "" {
+				name = n
+			}
+		}
+		result = append(result, DashboardTenantThroughputItem{
+			TenantID:         tid,
+			TenantName:       name,
+			ThroughputSeries: series,
+			CurrentRPM:       curRPM,
+			CurrentTPM:       curTPM,
+		})
+	}
+
+	return result, nil
 }
 
 func emptyDashboardTrends(days int) DashboardTrends {

--- a/internal/usage/request_log_dashboard_tenant_test.go
+++ b/internal/usage/request_log_dashboard_tenant_test.go
@@ -95,6 +95,42 @@ func TestDashboardQueriesAreTenantScoped(t *testing.T) {
 	if latestThroughputRPM(allSeries) != 3 {
 		t.Fatalf("all-tenant latest RPM = %.0f, want 3", latestThroughputRPM(allSeries))
 	}
+
+	// Breakdown returns both tenants
+	breakdown, err := QueryDashboardTenantBreakdownThroughput(map[string]string{
+		tenantA: "Tenant Alpha",
+		tenantB: "Tenant Beta",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(breakdown) < 2 {
+		t.Fatalf("breakdown length = %d, want at least 2", len(breakdown))
+	}
+	var foundA, foundB bool
+	for _, item := range breakdown {
+		if item.TenantID == tenantA {
+			foundA = true
+			if item.TenantName != "Tenant Alpha" {
+				t.Errorf("tenant A name = %s, want Tenant Alpha", item.TenantName)
+			}
+			if item.CurrentRPM != 1 {
+				t.Errorf("tenant A current RPM = %.0f, want 1", item.CurrentRPM)
+			}
+		}
+		if item.TenantID == tenantB {
+			foundB = true
+			if item.TenantName != "Tenant Beta" {
+				t.Errorf("tenant B name = %s, want Tenant Beta", item.TenantName)
+			}
+			if item.CurrentRPM != 2 {
+				t.Errorf("tenant B current RPM = %.0f, want 2", item.CurrentRPM)
+			}
+		}
+	}
+	if !foundA || !foundB {
+		t.Fatalf("breakdown missing tenants: foundA=%v, foundB=%v", foundA, foundB)
+	}
 }
 
 func latestThroughputRPM(series []DashboardThroughputPoint) float64 {


### PR DESCRIPTION
### Summary
- Add `DashboardTenantThroughputItem` and `QueryDashboardTenantBreakdownThroughput` in backend usage package.
- Automatically populate and return per-tenant rolling and minute-bucket throughput series in `GetDashboardSummary` for platform admins.
- Add unit tests for tenant breakdown queries and dashboard summary handler scoping.

### Verification
- Tested locally: `go test ./internal/usage/... ./internal/api/handlers/management/...`
- Structure check: `python3 scripts/check-backend-structure.py`