### PR TITLE
fix(proxy-pool): allow checking disabled proxies and fallback for private IPs

### DIFF
--- a/internal/api/handlers/management/proxy_pool.go
+++ b/internal/api/handlers/management/proxy_pool.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -224,12 +225,16 @@ func (h *Handler) PostProxyPoolCheck(c *gin.Context) {
 
 	proxyURL := strings.TrimSpace(body.URL)
 	if proxyURL == "" && proxypoolsettings.StoreAvailableForTenant(tenantID) {
-		if entry := proxypoolsettings.GetForTenant(tenantID, body.ID); entry != nil && entry.Enabled {
+		if entry := proxypoolsettings.GetForTenant(tenantID, body.ID); entry != nil {
 			proxyURL = strings.TrimSpace(entry.URL)
 		}
 	}
 	if proxyURL == "" && tenantID == identity.SystemTenantID && h != nil && h.cfg != nil {
-		proxyURL = h.cfg.ResolveProxyURL(body.ID, "")
+		if entry := h.cfg.FindProxyPoolEntry(body.ID); entry != nil {
+			proxyURL = strings.TrimSpace(entry.URL)
+		} else {
+			proxyURL = h.cfg.ResolveProxyURL(body.ID, "")
+		}
 	}
 	if err := config.ValidateProxyURL(proxyURL); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -307,7 +312,7 @@ func defaultProxyCheckURL(r *http.Request) string {
 	if host == "" {
 		host = strings.TrimSpace(r.Host)
 	}
-	if host == "" {
+	if host == "" || isPrivateOrLocalHost(host) {
 		return defaultProxyCheckFallbackURL
 	}
 
@@ -324,6 +329,30 @@ func defaultProxyCheckURL(r *http.Request) string {
 	}
 
 	return scheme + "://" + host + defaultProxyCheckPublicPath
+}
+
+func isPrivateOrLocalHost(rawHost string) bool {
+	host := strings.TrimSpace(rawHost)
+	if host == "" {
+		return true
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	lower := strings.ToLower(host)
+
+	if lower == "localhost" || strings.HasSuffix(lower, ".localhost") || strings.HasSuffix(lower, ".local") {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }
 
 func maskProxyPoolURL(raw string) string {

--- a/internal/api/handlers/management/proxy_pool_test.go
+++ b/internal/api/handlers/management/proxy_pool_test.go
@@ -189,6 +189,71 @@ func TestDefaultProxyCheckURLPrefersForwardedOrigin(t *testing.T) {
 	}
 }
 
+func TestDefaultProxyCheckURLFallbacksForPrivateOrLocalHost(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name string
+		host string
+	}{
+		{"IPv4 private 10.x", "10.126.126.7:8317"},
+		{"IPv4 private 172.16.x", "172.20.0.5:8080"},
+		{"IPv4 private 192.168.x", "192.168.1.100"},
+		{"IPv4 loopback", "127.0.0.1:8317"},
+		{"localhost", "localhost:8317"},
+		{"local domain", "my-server.local"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodPost, "/proxy-pool/check", nil)
+			req.Host = tc.host
+			if got, want := defaultProxyCheckURL(req), defaultProxyCheckFallbackURL; got != want {
+				t.Fatalf("defaultProxyCheckURL(%q) = %q, want fallback %q", tc.host, got, want)
+			}
+		})
+	}
+}
+
+func TestPostProxyPoolCheckAllowsDisabledProxy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer proxyServer.Close()
+
+	h := NewHandler(&config.Config{
+		ProxyPool: []config.ProxyPoolEntry{
+			{ID: "disabled-proxy", Name: "Disabled", URL: proxyServer.URL, Enabled: false},
+		},
+	}, "", nil)
+	defer h.Close()
+
+	payload := []byte(`{"id":"disabled-proxy","test_url":"http://target.example/generate_204"}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/proxy-pool/check", bytes.NewReader(payload))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PostProxyPoolCheck(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		OK         bool `json:"ok"`
+		StatusCode int  `json:"statusCode"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !body.OK || body.StatusCode != http.StatusNoContent {
+		t.Fatalf("check response = %#v, want successful probe for disabled entry", body)
+	}
+}
+
 func TestProxyPoolHandlersUseSQLiteWhenAvailable(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cleanup := usageTestProxyPoolDB(t)

--- a/internal/config/proxy_pool.go
+++ b/internal/config/proxy_pool.go
@@ -138,6 +138,23 @@ func (cfg *Config) ResolveProxyURL(proxyID string, fallbackURL string) string {
 	return ""
 }
 
+// FindProxyPoolEntry finds a proxy pool entry by ID regardless of whether it is enabled.
+func (cfg *Config) FindProxyPoolEntry(proxyID string) *ProxyPoolEntry {
+	if cfg == nil {
+		return nil
+	}
+	id := normalizeProxyID(proxyID)
+	if id == "" {
+		return nil
+	}
+	for i := range cfg.ProxyPool {
+		if normalizeProxyID(cfg.ProxyPool[i].ID) == id {
+			return &cfg.ProxyPool[i]
+		}
+	}
+	return nil
+}
+
 // NormalizeProxyID exposes the shared proxy ID normalization used by storage,
 // management handlers, and runtime resolution.
 func NormalizeProxyID(raw string) string {

--- a/internal/config/proxy_pool_test.go
+++ b/internal/config/proxy_pool_test.go
@@ -109,3 +109,24 @@ func TestResolveProxyURLUsesProxyIDBeforeFallback(t *testing.T) {
 		})
 	}
 }
+
+func TestFindProxyPoolEntry(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		ProxyPool: []ProxyPoolEntry{
+			{ID: "hk", Name: "HK", URL: "socks5://127.0.0.1:1080", Enabled: true},
+			{ID: "disabled", Name: "Disabled", URL: "http://disabled.example:7890", Enabled: false},
+		},
+	}
+
+	if entry := cfg.FindProxyPoolEntry("hk"); entry == nil || entry.URL != "socks5://127.0.0.1:1080" {
+		t.Fatalf("FindProxyPoolEntry(hk) = %#v, want enabled entry", entry)
+	}
+	if entry := cfg.FindProxyPoolEntry("disabled"); entry == nil || entry.URL != "http://disabled.example:7890" {
+		t.Fatalf("FindProxyPoolEntry(disabled) = %#v, want disabled entry", entry)
+	}
+	if entry := cfg.FindProxyPoolEntry("non-existent"); entry != nil {
+		t.Fatalf("FindProxyPoolEntry(non-existent) = %#v, want nil", entry)
+	}
+}


### PR DESCRIPTION
## Summary
- Allow connectivity checking for disabled proxy pool entries (supports testing before enabling or checking disabled proxies).
- Detect private/loopback/local hostnames in `defaultProxyCheckURL` and automatically fallback to public endpoint (`gstatic.com/generate_204`), preventing 8-second client timeouts when the management panel is accessed via LAN/private IPs.

## Test Plan
- Ran unit tests for `TestDefaultProxyCheckURLFallbacksForPrivateOrLocalHost` and `TestPostProxyPoolCheckAllowsDisabledProxy`.
- Ran backend structure scan and full package tests: `go test ./internal/api/handlers/management/... ./internal/config/... ./internal/api/routes/...`.