### PR TITLE
fix(config): 移除 SQLite VACUUM 遗留并清理运行时表述

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,56 +309,11 @@ auto-update:
 
 ### 🗄️ Runtime Data Stack
 
-CliRelay now uses PostgreSQL 15+, Redis 7+, and Ent ORM exclusively at runtime. PostgreSQL is the only source of truth for business data; Redis is limited to cache, locks, rate limits, queues, and rebuildable state. SQLite is no longer a runtime database and is not part of normal startup, health checks, or OTA updates.
+CliRelay uses PostgreSQL 15+, Redis 7+, and Ent ORM exclusively at runtime. PostgreSQL is the only source of truth for business data; Redis is limited to cache, locks, rate limits, queues, and rebuildable state.
 
-The standard Docker Compose stack starts `clirelay-init`, PostgreSQL, Redis, the application container, and the updater sidecar. A normal `docker compose up -d` or management-panel update **does not scan for `usage.db`, run SQLite inventory, import SQLite, or expose SQLite migration stages in update progress**. Stack upgrades remove stale `clirelay-migrate` services and `CLIRELAY_SQLITE_AUTO_*` startup settings, while leaving any original SQLite files untouched.
+The standard Docker Compose stack starts `clirelay-init`, PostgreSQL, Redis, the application container, and the updater sidecar.
 
 The updater sidecar owns OTA task state and publishes it through SSE. The management panel renders only the updater-provided run ID, actual stage, completed steps, current and target backend/UI versions, target image, latest Release metadata, and final result; it no longer advances a timer-based percentage. If the API container restarts, the page reloads, or SSE disconnects briefly, the panel reconnects and receives the latest updater snapshot. Compose persists that snapshot in `.clirelay-updater-status.json`; if the updater itself restarts during a task, the interrupted task is explicitly marked failed instead of remaining stuck as running. After the application passes its health check, the current updater launches a detached helper from the target image; that helper safely recreates the updater sidecar so later OTA runs use the target updater implementation.
-
-#### Manual SQLite import for legacy users only
-
-The repository and Docker image still include `scripts/migrate-sqlite-to-postgres.sh` solely for manually importing an old SQLite `usage.db` into PostgreSQL. It is an independent migration tool and **is never invoked by CliRelay startup or OTA updates**. Fresh installs, deployments already using PostgreSQL, and users who do not need old SQLite history should not run it.
-
-Before importing:
-
-1. Back up the original `usage.db` and keep a read-only copy. Do not let an old release continue writing to it during migration.
-2. Start PostgreSQL 15+ and Redis 7+, and verify that `CLIRELAY_POSTGRES_DSN` points to the intended target database.
-3. Run the SQLite inventory and PostgreSQL dry-run first, then review tables, row counts, ID/time ranges, checksums, and planned inserts.
-4. Apply only after reviewing the dry-run, and validate PostgreSQL again afterward. The script never deletes, moves, or writes the SQLite file; PostgreSQL import records and an advisory lock protect repeated or concurrent runs.
-
-For a non-Docker deployment:
-
-```bash
-CLIRELAY_BIN=/opt/clirelay2/clirelay2 \
-CLIRELAY_POSTGRES_DSN='postgres://user:pass@127.0.0.1:5432/cliproxy?sslmode=disable' \
-./scripts/migrate-sqlite-to-postgres.sh /path/to/usage.db
-```
-
-For Docker Compose, start PostgreSQL/Redis and mount the old database read-only into a one-off container:
-
-```bash
-docker compose up -d postgres redis
-
-docker compose run --rm --no-deps \
-  -e CLIRELAY_BIN=/CLIProxyAPI/CLIProxyAPI \
-  -v /absolute/path/to/usage.db:/migration/usage.db:ro \
-  cli-proxy-api \
-  /usr/local/bin/migrate-sqlite-to-postgres.sh /migration/usage.db
-```
-
-The script runs read-only SQLite inventory, PostgreSQL import dry-run, and apply in that order. Add `-e CLIRELAY_SQLITE_AUTO_IMPORT=false` to stop after dry-run. The binary commands can also be run separately:
-
-```bash
-./cli-proxy-api -sqlite-dry-run /path/to/usage.db
-
-CLIRELAY_POSTGRES_DSN='postgres://user:pass@127.0.0.1:5432/cliproxy?sslmode=disable' \
-./cli-proxy-api -sqlite-import /path/to/usage.db
-
-CLIRELAY_POSTGRES_DSN='postgres://user:pass@127.0.0.1:5432/cliproxy?sslmode=disable' \
-./cli-proxy-api -sqlite-import /path/to/usage.db -sqlite-import-dry-run=false
-```
-
-If an old Docker deployment still uses a SQLite-only compose file, replace it with the latest `docker-compose.yml`, run `docker compose up -d postgres redis clirelay-updater`, and then import data manually. A sidecar from a release that predates updater SSE must be recreated once with `docker compose up -d --force-recreate clirelay-updater`; subsequent OTA runs can then use real-time progress and reconnect recovery. See [`docs/postgres-redis-migration.md`](docs/postgres-redis-migration.md) for the full migration boundary.
 
 For large installations, tune `request-log-storage` in `config.yaml` to control full request/response body retention. Full body storage is disabled by default. When `store-content` is enabled, bodies are compressed, kept for 30 days, and capped at ~1GB (1024MB), while lightweight request metadata and request details remain available for statistics and troubleshooting. Set `content-retention-days: 0` to keep full bodies indefinitely. Disabling body storage from the management panel also clears historical input and output bodies while preserving request details and request records.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -312,56 +312,11 @@ auto-update:
 
 ### 🗄️ 运行时数据栈
 
-CliRelay 当前运行时数据栈已经完全统一为 PostgreSQL 15+、Redis 7+ 和 Ent ORM：PostgreSQL 是业务数据唯一事实源，Redis 只负责缓存、锁、限流、队列和可重建状态。SQLite 不再作为运行时数据库，也不参与正常启动、健康检查或 OTA 在线更新。
+CliRelay 运行时数据栈已经完全统一为 PostgreSQL 15+、Redis 7+ 和 Ent ORM：PostgreSQL 是业务数据唯一事实源，Redis 只负责缓存、锁、限流、队列和可重建状态。
 
-标准 Docker Compose 部署会启动 `clirelay-init`、PostgreSQL、Redis、业务容器和 updater sidecar。正常执行 `docker compose up -d` 或在管理面板中在线更新时，系统**不会扫描 `usage.db`、不会执行 SQLite inventory、不会自动导入 SQLite，也不会在更新进度中出现 SQLite 迁移阶段**。旧 compose 中残留的 `clirelay-migrate` 服务和 `CLIRELAY_SQLITE_AUTO_*` 启动配置会在部署栈升级时移除，但原始 SQLite 文件不会被删除或修改。
+标准 Docker Compose 部署会启动 `clirelay-init`、PostgreSQL、Redis、业务容器和 updater sidecar。
 
 OTA 更新状态由 updater sidecar 持有，并通过 SSE 实时发送。管理面板只展示 updater 返回的任务 ID、实际执行阶段、已完成步骤、当前/目标版本、管理面板版本、目标镜像、最新 Release 信息和最终结果，不再通过前端计时器模拟百分比。更新期间即使业务容器重启、页面刷新或 SSE 短暂断开，前端也会重新连接并读取 updater 的最新快照。Compose 默认把快照保存到 `.clirelay-updater-status.json`；更新器异常重启时，未完成任务会被明确标记为失败，不会继续显示为运行中。 业务容器通过健康检查后，当前 updater 会启动一个基于目标镜像的临时 helper，由 helper 安全重建 updater sidecar，使后续 OTA 继续使用目标版本的更新逻辑。
-
-#### 仅旧版本用户需要的 SQLite 手工迁移
-
-仓库和 Docker 镜像仍保留 `scripts/migrate-sqlite-to-postgres.sh`，只用于从旧版 SQLite `usage.db` 手工导入 PostgreSQL。该脚本是独立迁移工具，**不会被 CliRelay 启动流程或 OTA 自动调用**。全新安装、已经使用 PostgreSQL 的部署，以及不需要保留旧 SQLite 历史数据的用户都不应执行它。
-
-迁移前必须：
-
-1. 备份原始 `usage.db`，并保留只读副本；不要在迁移过程中让旧版本继续写入该文件。
-2. 先准备并启动 PostgreSQL 15+ 和 Redis 7+，确认 `CLIRELAY_POSTGRES_DSN` 指向正确的目标库。
-3. 先运行 inventory 和 PostgreSQL dry-run，检查表、行数、ID/时间范围、checksum 与计划写入数量。
-4. 只有核对 dry-run 后才执行 apply；完成后再次校验 PostgreSQL 数据。脚本不会删除、移动或写入 SQLite 文件，重复导入由 PostgreSQL 中的导入记录和 advisory lock 保护。
-
-非 Docker 部署可以直接执行：
-
-```bash
-CLIRELAY_BIN=/opt/clirelay2/clirelay2 \
-CLIRELAY_POSTGRES_DSN='postgres://user:pass@127.0.0.1:5432/cliproxy?sslmode=disable' \
-./scripts/migrate-sqlite-to-postgres.sh /path/to/usage.db
-```
-
-Docker Compose 部署先确保 PostgreSQL/Redis 已启动，再把旧库只读挂载到一次性容器中：
-
-```bash
-docker compose up -d postgres redis
-
-docker compose run --rm --no-deps \
-  -e CLIRELAY_BIN=/CLIProxyAPI/CLIProxyAPI \
-  -v /absolute/path/to/usage.db:/migration/usage.db:ro \
-  cli-proxy-api \
-  /usr/local/bin/migrate-sqlite-to-postgres.sh /migration/usage.db
-```
-
-脚本默认依次执行 SQLite 只读 inventory、PostgreSQL 导入 dry-run 和实际 apply。若只想检查而不写入 PostgreSQL，增加 `-e CLIRELAY_SQLITE_AUTO_IMPORT=false`。也可以分步使用二进制命令：
-
-```bash
-./cli-proxy-api -sqlite-dry-run /path/to/usage.db
-
-CLIRELAY_POSTGRES_DSN='postgres://user:pass@127.0.0.1:5432/cliproxy?sslmode=disable' \
-./cli-proxy-api -sqlite-import /path/to/usage.db
-
-CLIRELAY_POSTGRES_DSN='postgres://user:pass@127.0.0.1:5432/cliproxy?sslmode=disable' \
-./cli-proxy-api -sqlite-import /path/to/usage.db -sqlite-import-dry-run=false
-```
-
-如果旧 Docker 部署仍是 SQLite-only compose，应先替换为仓库最新版 `docker-compose.yml` 并执行 `docker compose up -d postgres redis clirelay-updater`，再手工迁移数据。对于不支持 updater SSE 的旧 sidecar，需要额外执行一次 `docker compose up -d --force-recreate clirelay-updater`，之后的 OTA 才能使用新的实时进度与断线恢复协议。完整迁移边界见 [`docs/postgres-redis-migration.md`](docs/postgres-redis-migration.md)。
 
 如果你的请求量较大，可以在 `config.yaml` 中调整 `request-log-storage`。全文请求/响应正文默认不保存；开启 `store-content` 后，正文会以压缩形式保留 30 天，并默认做约 1GB（1024MB）的总量上限，而轻量级请求元数据和请求详情仍可用于统计、筛选与排查。将 `content-retention-days: 0` 设为永久保留全文；在管理面板关闭正文存储时会同时清理已有输入与输出正文，但保留请求详情和请求记录；调整 `max-total-size-mb` 可让最老的全文在 retention 周期结束前提前裁剪。
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -223,9 +223,6 @@ request-log-storage:
   # Default is 1024 (≈1GB). Set to 0 to disable the size cap.
   max-total-size-mb: 1024
 
-  # Reclaim disk space after cleanup. This can be I/O intensive on very large databases.
-  vacuum-on-cleanup: true
-
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 proxy-url: ""
 

--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -33,7 +33,7 @@ func Register(cfg *sdkconfig.SDKConfig) {
 }
 
 // buildKeyConfigMap builds a map from API key to its full configuration.
-// Primary source: management/settings/apikey service backed by SQLite.
+// Primary source: management/settings/apikey service backed by PostgreSQL.
 // Fallback: legacy APIKeys and APIKeyEntries from YAML config.
 func buildKeyConfigMap(cfg *sdkconfig.SDKConfig) map[string]keyConfig {
 	result := make(map[string]keyConfig)

--- a/internal/api/handlers/management/api_key_settings.go
+++ b/internal/api/handlers/management/api_key_settings.go
@@ -19,7 +19,7 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
-// refreshAPIKeyCache rebuilds the in-memory access provider cache from SQLite.
+// refreshAPIKeyCache rebuilds the in-memory access provider cache from the database.
 // Must be called after every API key write operation.
 // Returns error when live access manager update fails (fail-closed for callers that care).
 func (h *Handler) refreshAPIKeyCache() error {
@@ -78,7 +78,7 @@ func (h *Handler) apiKeySettingsForTenant(tenantID string) *apikeysettings.Servi
 	)
 }
 
-// api-keys (legacy simple list — now backed by SQLite)
+// api-keys (legacy simple list — now backed by the database)
 func (h *Handler) GetAPIKeys(c *gin.Context) {
 	c.JSON(200, gin.H{"api-keys": h.apiKeySettings(c).EnabledKeys()})
 }
@@ -213,7 +213,7 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 	c.JSON(200, gin.H{"status": "ok", "applied_count": result.AppliedCount, "capped-keys": result.CappedKeys})
 }
 
-// api-key-entries: backed by SQLite api_keys table
+// api-key-entries: backed by the api_keys table
 func (h *Handler) GetAPIKeyEntries(c *gin.Context) {
 	entries, err := h.apiKeySettings(c).ListEntriesWithDailySpending()
 	if err != nil {

--- a/internal/api/handlers/management/channel_rename.go
+++ b/internal/api/handlers/management/channel_rename.go
@@ -32,10 +32,10 @@ func (h *Handler) renameChannelReferencesForTenant(tenantID string, oldNames []s
 				return fmt.Errorf("failed to persist routing config: %w", err)
 			}
 		}
-		if err := renameSQLiteAPIKeyChannelsForTenant(tenantID, oldNameSet, newName); err != nil {
+		if err := renameStoredAPIKeyChannelsForTenant(tenantID, oldNameSet, newName); err != nil {
 			return err
 		}
-		if err := renameSQLiteAPIKeyPermissionProfileChannelsForTenant(tenantID, oldNameSet, newName); err != nil {
+		if err := renameStoredAPIKeyPermissionProfileChannelsForTenant(tenantID, oldNameSet, newName); err != nil {
 			return err
 		}
 		if h.authManager != nil {
@@ -66,10 +66,10 @@ func (h *Handler) renameChannelReferencesForTenant(tenantID string, oldNames []s
 			return fmt.Errorf("failed to persist routing config: %w", err)
 		}
 	}
-	if err := renameSQLiteAPIKeyChannels(oldNameSet, newName); err != nil {
+	if err := renameStoredAPIKeyChannels(oldNameSet, newName); err != nil {
 		return err
 	}
-	if err := renameSQLiteAPIKeyPermissionProfileChannels(oldNameSet, newName); err != nil {
+	if err := renameStoredAPIKeyPermissionProfileChannels(oldNameSet, newName); err != nil {
 		return err
 	}
 	if configChanged && h.cfg != nil && strings.TrimSpace(h.configFilePath) != "" {
@@ -102,10 +102,10 @@ func (h *Handler) removeChannelReferencesForTenant(tenantID string, oldNames []s
 				return fmt.Errorf("failed to persist routing config: %w", err)
 			}
 		}
-		if err := removeSQLiteAPIKeyChannelsForTenant(tenantID, oldNameSet); err != nil {
+		if err := removeStoredAPIKeyChannelsForTenant(tenantID, oldNameSet); err != nil {
 			return err
 		}
-		if err := removeSQLiteAPIKeyPermissionProfileChannelsForTenant(tenantID, oldNameSet); err != nil {
+		if err := removeStoredAPIKeyPermissionProfileChannelsForTenant(tenantID, oldNameSet); err != nil {
 			return err
 		}
 		if h.authManager != nil {
@@ -136,10 +136,10 @@ func (h *Handler) removeChannelReferencesForTenant(tenantID string, oldNames []s
 			return fmt.Errorf("failed to persist routing config: %w", err)
 		}
 	}
-	if err := removeSQLiteAPIKeyChannels(oldNameSet); err != nil {
+	if err := removeStoredAPIKeyChannels(oldNameSet); err != nil {
 		return err
 	}
-	if err := removeSQLiteAPIKeyPermissionProfileChannels(oldNameSet); err != nil {
+	if err := removeStoredAPIKeyPermissionProfileChannels(oldNameSet); err != nil {
 		return err
 	}
 	if configChanged && h.cfg != nil && strings.TrimSpace(h.configFilePath) != "" {
@@ -312,11 +312,11 @@ func removeConfigAPIKeyChannels(entries []config.APIKeyEntry, oldNameSet map[str
 	return changed
 }
 
-func renameSQLiteAPIKeyChannels(oldNameSet map[string]struct{}, newName string) error {
-	return renameSQLiteAPIKeyChannelsForTenant(identity.SystemTenantID, oldNameSet, newName)
+func renameStoredAPIKeyChannels(oldNameSet map[string]struct{}, newName string) error {
+	return renameStoredAPIKeyChannelsForTenant(identity.SystemTenantID, oldNameSet, newName)
 }
 
-func renameSQLiteAPIKeyChannelsForTenant(tenantID string, oldNameSet map[string]struct{}, newName string) error {
+func renameStoredAPIKeyChannelsForTenant(tenantID string, oldNameSet map[string]struct{}, newName string) error {
 	svc := apikeysettings.NewService(nil, apikeysettings.WithTenantID(tenantID))
 	if err := svc.RenameAllowedChannelRestrictions(oldNameSet, newName); err != nil {
 		return fmt.Errorf("failed to persist api key channel restrictions: %w", err)
@@ -324,11 +324,11 @@ func renameSQLiteAPIKeyChannelsForTenant(tenantID string, oldNameSet map[string]
 	return nil
 }
 
-func removeSQLiteAPIKeyChannels(oldNameSet map[string]struct{}) error {
-	return removeSQLiteAPIKeyChannelsForTenant(identity.SystemTenantID, oldNameSet)
+func removeStoredAPIKeyChannels(oldNameSet map[string]struct{}) error {
+	return removeStoredAPIKeyChannelsForTenant(identity.SystemTenantID, oldNameSet)
 }
 
-func removeSQLiteAPIKeyChannelsForTenant(tenantID string, oldNameSet map[string]struct{}) error {
+func removeStoredAPIKeyChannelsForTenant(tenantID string, oldNameSet map[string]struct{}) error {
 	svc := apikeysettings.NewService(nil, apikeysettings.WithTenantID(tenantID))
 	if err := svc.RemoveAllowedChannelRestrictions(oldNameSet); err != nil {
 		return fmt.Errorf("failed to persist api key channel restrictions: %w", err)
@@ -336,11 +336,11 @@ func removeSQLiteAPIKeyChannelsForTenant(tenantID string, oldNameSet map[string]
 	return nil
 }
 
-func renameSQLiteAPIKeyPermissionProfileChannels(oldNameSet map[string]struct{}, newName string) error {
-	return renameSQLiteAPIKeyPermissionProfileChannelsForTenant(identity.SystemTenantID, oldNameSet, newName)
+func renameStoredAPIKeyPermissionProfileChannels(oldNameSet map[string]struct{}, newName string) error {
+	return renameStoredAPIKeyPermissionProfileChannelsForTenant(identity.SystemTenantID, oldNameSet, newName)
 }
 
-func renameSQLiteAPIKeyPermissionProfileChannelsForTenant(tenantID string, oldNameSet map[string]struct{}, newName string) error {
+func renameStoredAPIKeyPermissionProfileChannelsForTenant(tenantID string, oldNameSet map[string]struct{}, newName string) error {
 	svc := apikeysettings.NewService(nil, apikeysettings.WithTenantID(tenantID))
 	if err := svc.RenamePermissionProfileChannelRestrictions(oldNameSet, newName); err != nil {
 		return fmt.Errorf("failed to persist api key permission profile channel restrictions: %w", err)
@@ -348,11 +348,11 @@ func renameSQLiteAPIKeyPermissionProfileChannelsForTenant(tenantID string, oldNa
 	return nil
 }
 
-func removeSQLiteAPIKeyPermissionProfileChannels(oldNameSet map[string]struct{}) error {
-	return removeSQLiteAPIKeyPermissionProfileChannelsForTenant(identity.SystemTenantID, oldNameSet)
+func removeStoredAPIKeyPermissionProfileChannels(oldNameSet map[string]struct{}) error {
+	return removeStoredAPIKeyPermissionProfileChannelsForTenant(identity.SystemTenantID, oldNameSet)
 }
 
-func removeSQLiteAPIKeyPermissionProfileChannelsForTenant(tenantID string, oldNameSet map[string]struct{}) error {
+func removeStoredAPIKeyPermissionProfileChannelsForTenant(tenantID string, oldNameSet map[string]struct{}) error {
 	svc := apikeysettings.NewService(nil, apikeysettings.WithTenantID(tenantID))
 	if err := svc.RemovePermissionProfileChannelRestrictions(oldNameSet); err != nil {
 		return fmt.Errorf("failed to persist api key permission profile channel restrictions: %w", err)

--- a/internal/api/handlers/management/dashboard_summary.go
+++ b/internal/api/handlers/management/dashboard_summary.go
@@ -70,7 +70,7 @@ func (h *Handler) GetDashboardSummary(c *gin.Context) {
 		providerTotal = authFileCount
 	}
 
-	// ── Usage KPIs (from SQLite — persists across restarts) ──
+	// ── Usage KPIs (persists across restarts) ──
 	daysStr := c.DefaultQuery("days", "7")
 	days := 7
 	if v, err := parsePositiveInt(daysStr); err == nil && v > 0 {

--- a/internal/api/handlers/management/routing_config.go
+++ b/internal/api/handlers/management/routing_config.go
@@ -25,7 +25,7 @@ func currentRoutingConfig(cfg *config.Config) config.RoutingConfig {
 	return currentRoutingConfigForTenant(cfg, identity.SystemTenantID)
 }
 
-func sqliteAPIKeyEntries(tenantID string) []config.APIKeyEntry {
+func storedAPIKeyEntries(tenantID string) []config.APIKeyEntry {
 	return apikeysettings.NewService(nil, apikeysettings.WithTenantID(tenantID)).ListEntries()
 }
 
@@ -59,7 +59,7 @@ func (h *Handler) PutRoutingConfig(c *gin.Context) {
 
 	candidate := &config.Config{
 		SDKConfig: config.SDKConfig{
-			APIKeyEntries: sqliteAPIKeyEntries(tenantID),
+			APIKeyEntries: storedAPIKeyEntries(tenantID),
 		},
 		Routing: body,
 	}

--- a/internal/api/handlers/management/usage_logs_handler.go
+++ b/internal/api/handlers/management/usage_logs_handler.go
@@ -65,7 +65,7 @@ type deleteUsageLogsRequest struct {
 	ClearRequestRecords bool `json:"clear_request_records"`
 }
 
-// GetUsageLogs returns paginated, filterable request log entries from SQLite.
+// GetUsageLogs returns paginated, filterable request log entries.
 func (h *UsageLogsHandler) GetUsageLogs(c *gin.Context) {
 	channelValues := queryStringListMulti(c, "channel", "channels")
 	if raw := strings.TrimSpace(c.Query("channel_name")); raw != "" {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -83,10 +83,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.RequestLogStorage.CleanupMaxRuntimeSeconds = 30
 	cfg.RequestLogStorage.MaxRows = 100000
 	cfg.RequestLogStorage.MaxMetadataSizeMB = 256
-	// Default cap for stored request/response bodies in usage.db.
+	// Default cap for stored request/response bodies.
 	// This controls the compressed body payloads only (metadata rows are separate).
 	cfg.RequestLogStorage.MaxTotalSizeMB = 128
-	cfg.RequestLogStorage.VacuumOnCleanup = false
 	cfg.DisableCooling = false
 	cfg.Routing.IncludeDefaultGroup = true
 	cfg.Pprof.Enable = false

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -98,10 +98,6 @@ type RequestLogStorageConfig struct {
 	// When the cap is exceeded, the oldest stored bodies are pruned before the
 	// normal retention window elapses. 0 disables the size cap.
 	MaxTotalSizeMB int `yaml:"max-total-size-mb,omitempty" json:"max-total-size-mb,omitempty"`
-
-	// VacuumOnCleanup triggers a database VACUUM after content pruning so disk space is reclaimed.
-	// PostgreSQL never runs VACUUM FULL from this flag.
-	VacuumOnCleanup bool `yaml:"vacuum-on-cleanup" json:"vacuum-on-cleanup"`
 }
 
 // StreamingConfig holds server streaming behavior configuration.

--- a/internal/storage/sqlite/proxypool/store.go
+++ b/internal/storage/sqlite/proxypool/store.go
@@ -213,7 +213,7 @@ func (s Store) MigrateFromConfig(cfg *config.Config) (migrated int, hadStored bo
 		log.Errorf("sqlite/proxypool: migrate proxy_pool: %v", err)
 		return 0, false, false
 	}
-	log.Infof("sqlite/proxypool: migrated %d proxy_pool entries from config to SQLite", len(normalized))
+	log.Infof("sqlite/proxypool: migrated %d proxy_pool entries from config to the database", len(normalized))
 	return len(normalized), false, true
 }
 

--- a/internal/usage/api_key_permission_profiles_db.go
+++ b/internal/usage/api_key_permission_profiles_db.go
@@ -104,7 +104,7 @@ func MigrateAPIKeyPermissionProfilesFromYAML(configFilePath string) int {
 	if backupConfigForMigration(configFilePath, apiKeyPermissionProfilesMigrationBackupSuffix) {
 		cleanAPIKeyPermissionProfilesFromYAML(configFilePath)
 	}
-	log.Infof("usage: migrated %d API key permission profile(s) from config to SQLite", len(profiles))
+	log.Infof("usage: migrated %d API key permission profile(s) from config to the database", len(profiles))
 	return len(profiles)
 }
 

--- a/internal/usage/apikey_db.go
+++ b/internal/usage/apikey_db.go
@@ -41,7 +41,7 @@ func backfillAPIKeyNames(db *sql.DB) {
 	sqlapikey.BackfillNames(db)
 }
 
-// MigrateAPIKeysFromConfig moves API key entries from YAML config into SQLite.
+// MigrateAPIKeysFromConfig moves API key entries from YAML config into the database.
 // It only migrates if the api_keys table is empty AND the config has entries.
 // After migration, it backs up config.yaml and re-saves it without the API key
 // fields so the YAML file stays clean.
@@ -117,7 +117,7 @@ func MigrateAPIKeysFromConfig(cfg *config.Config, configFilePath string) (int, e
 		return 0, err
 	}
 
-	log.Infof("usage: migrated %d API keys from config to SQLite", len(rows))
+	log.Infof("usage: migrated %d API keys from config to the database", len(rows))
 
 	cfg.APIKeys = nil
 	cfg.APIKeyEntries = nil

--- a/internal/usage/config_yaml_cleanup.go
+++ b/internal/usage/config_yaml_cleanup.go
@@ -40,14 +40,14 @@ var dbBackedConfigYAMLKeys = map[string]bool{
 	"payload":                     true,
 }
 
-// ConfigStoreAvailable reports whether the SQLite store that owns DB-backed
+// ConfigStoreAvailable reports whether the database store that owns DB-backed
 // config sections is ready. Callers must not remove YAML fallbacks when this is
 // false.
 func ConfigStoreAvailable() bool {
 	return getDB() != nil
 }
 
-// CleanDBBackedConfigFromYAML removes config sections now owned by SQLite from
+// CleanDBBackedConfigFromYAML removes config sections now owned by the database from
 // config.yaml. It is safe to call repeatedly after management saves, because it
 // only rewrites the file when one of the target root keys exists.
 func CleanDBBackedConfigFromYAML(configFilePath string) int {

--- a/internal/usage/log_content_cleanup.go
+++ b/internal/usage/log_content_cleanup.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -188,141 +186,17 @@ func compactLogContentStorage(db *sql.DB) {
 	if db == nil {
 		return
 	}
-	compactLogContentStorageInternal(context.Background(), db, true)
+	compactLogContentStorageInternal(context.Background(), db)
 }
 
-type sqliteSpaceStats struct {
-	PageSize      int64
-	PageCount     int64
-	FreeListCount int64
-}
-
-func querySQLiteSpaceStats(q logContentQuerier) (sqliteSpaceStats, error) {
-	if q == nil {
-		return sqliteSpaceStats{}, fmt.Errorf("usage: nil querier")
-	}
-	var pageSize int64
-	if err := q.QueryRow("PRAGMA page_size").Scan(&pageSize); err != nil {
-		return sqliteSpaceStats{}, err
-	}
-	var pageCount int64
-	if err := q.QueryRow("PRAGMA page_count").Scan(&pageCount); err != nil {
-		return sqliteSpaceStats{}, err
-	}
-	var freeListCount int64
-	if err := q.QueryRow("PRAGMA freelist_count").Scan(&freeListCount); err != nil {
-		return sqliteSpaceStats{}, err
-	}
-	return sqliteSpaceStats{
-		PageSize:      pageSize,
-		PageCount:     pageCount,
-		FreeListCount: freeListCount,
-	}, nil
-}
-
-func reclaimableBytes(stats sqliteSpaceStats) int64 {
-	if stats.PageSize <= 0 || stats.FreeListCount <= 0 {
-		return 0
-	}
-	return stats.PageSize * stats.FreeListCount
-}
-
-func shouldVacuum(stats sqliteSpaceStats) bool {
-	if stats.PageSize <= 0 || stats.PageCount <= 0 || stats.FreeListCount <= 0 {
-		return false
-	}
-
-	freeBytes := reclaimableBytes(stats)
-	if freeBytes < sqliteVacuumMinReclaimBytes {
-		ratio := float64(stats.FreeListCount) / float64(stats.PageCount)
-		return ratio >= sqliteVacuumMinReclaimRatio && freeBytes >= (sqliteVacuumMinReclaimBytes/2)
-	}
-	return true
-}
-
-func vacuumAllowedNow(now time.Time) bool {
-	lastNano := lastUsageVacuumUnixNano.Load()
-	if lastNano <= 0 {
-		return true
-	}
-	last := time.Unix(0, lastNano)
-	if last.IsZero() {
-		return true
-	}
-	return now.Sub(last) >= sqliteVacuumMinInterval
-}
-
-func markVacuumRan(now time.Time) {
-	if now.IsZero() {
-		now = time.Now()
-	}
-	lastUsageVacuumUnixNano.Store(now.UnixNano())
-}
-
-func usageWALPath() string {
-	if usageDBPath == "" {
-		return ""
-	}
-	return usageDBPath + "-wal"
-}
-
-func walBytesOnDisk() int64 {
-	path := usageWALPath()
-	if path == "" {
-		return 0
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return 0
-	}
-	return info.Size()
-}
-
-func compactLogContentStorageInternal(ctx context.Context, db *sql.DB, allowOptimize bool) {
+func compactLogContentStorageInternal(ctx context.Context, db *sql.DB) {
 	if db == nil {
 		return
 	}
-	if usageDriver == "postgres" {
-		if err := compactPostgresLogStorage(ctx, db); err != nil {
-			log.Warnf("usage: postgres log storage compact skipped: %v", err)
-		}
+	if usageDriver != "postgres" {
 		return
 	}
-
-	if _, err := db.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
-		log.Warnf("usage: wal checkpoint failed: %v", err)
-	}
-
-	stats, errStats := querySQLiteSpaceStats(db)
-	if errStats != nil {
-		if allowOptimize {
-			if _, err := db.Exec("PRAGMA optimize"); err != nil {
-				log.Warnf("usage: sqlite optimize failed: %v", err)
-			}
-		}
-		return
-	}
-
-	didVacuum := false
-	now := time.Now()
-	if currentRequestLogStorageConfig().VacuumOnCleanup && shouldVacuum(stats) && vacuumAllowedNow(now) {
-		freeBytes := reclaimableBytes(stats)
-		log.Infof("usage: reclaimable sqlite free space detected (freelist=%d pages, approx=%d bytes), running VACUUM", stats.FreeListCount, freeBytes)
-		if _, err := db.Exec("VACUUM"); err != nil {
-			log.Warnf("usage: vacuum failed: %v", err)
-		} else {
-			didVacuum = true
-			markVacuumRan(now)
-		}
-	}
-
-	if allowOptimize || didVacuum {
-		if _, err := db.Exec("PRAGMA optimize"); err != nil {
-			log.Warnf("usage: sqlite optimize failed: %v", err)
-		}
-	}
-
-	if walBytes := walBytesOnDisk(); walBytes > 0 && walBytes >= (64<<20) {
-		log.Warnf("usage: sqlite WAL remains large after checkpoint (%d bytes at %s); consider lowering cleanup-interval-minutes or checking long-lived transactions", walBytes, usageWALPath())
+	if err := compactPostgresLogStorage(ctx, db); err != nil {
+		log.Warnf("usage: postgres log storage compact skipped: %v", err)
 	}
 }

--- a/internal/usage/log_content_store.go
+++ b/internal/usage/log_content_store.go
@@ -19,17 +19,6 @@ import (
 // - Non-goals: human-readable file log formatting and transport-level request log orchestration.
 const requestLogContentCompression = "zstd"
 
-const (
-	// Avoid vacuuming too frequently; VACUUM can be expensive on large DBs.
-	sqliteVacuumMinInterval = 2 * time.Hour
-
-	// Only vacuum when there's enough reclaimable space to matter.
-	sqliteVacuumMinReclaimBytes = 64 << 20 // 64 MiB
-
-	// If reclaimable bytes are smaller, require a higher ratio to vacuum.
-	sqliteVacuumMinReclaimRatio = 0.20
-)
-
 type requestLogStorageRuntime struct {
 	RetentionDays            int
 	ContentRetentionDays     int
@@ -40,7 +29,6 @@ type requestLogStorageRuntime struct {
 	MaxRows                  int
 	MaxMetadataSizeMB        int
 	MaxTotalSizeMB           int
-	VacuumOnCleanup          bool
 }
 
 var (
@@ -50,7 +38,6 @@ var (
 	requestLogMaintenanceWG     sync.WaitGroup
 	requestLogMaintenanceWakeup atomic.Value // chan struct{}
 
-	lastUsageVacuumUnixNano atomic.Int64
 	requestLogContentBytes  atomic.Int64 // total compressed bytes; -1 means unknown
 	requestLogBodiesEnabled atomic.Bool
 
@@ -93,7 +80,6 @@ func defaultRequestLogStorageRuntime() requestLogStorageRuntime {
 		MaxRows:                  100000,
 		MaxMetadataSizeMB:        256,
 		MaxTotalSizeMB:           128,
-		VacuumOnCleanup:          false,
 	}
 }
 
@@ -142,7 +128,6 @@ func normalizeRequestLogStorageConfig(cfg config.RequestLogStorageConfig) reques
 		MaxRows:                  cfg.MaxRows,
 		MaxMetadataSizeMB:        cfg.MaxMetadataSizeMB,
 		MaxTotalSizeMB:           cfg.MaxTotalSizeMB,
-		VacuumOnCleanup:          cfg.VacuumOnCleanup,
 	}
 	if cfg.CleanupEnabled != nil {
 		runtimeCfg.CleanupEnabled = *cfg.CleanupEnabled
@@ -246,7 +231,7 @@ func startRequestLogMaintenance(db *sql.DB, driver string) {
 				}
 				// Compaction/config wakeups should remain lightweight. The next
 				// timer is rebuilt from the latest runtime policy.
-				compactLogContentStorageInternal(ctx, db, false)
+				compactLogContentStorageInternal(ctx, db)
 			case <-timer.C:
 				runRequestLogMaintenancePass(ctx, db, driver)
 			}
@@ -322,7 +307,7 @@ func runRequestLogMaintenancePass(ctx context.Context, db *sql.DB, driver string
 	// cleanup-enabled gates metadata and content retention/size cleanup only.
 	// Body purge when store-content=false still runs above (privacy, not retention).
 	if !currentRequestLogStorageConfig().CleanupEnabled {
-		compactLogContentStorageInternal(ctx, db, true)
+		compactLogContentStorageInternal(ctx, db)
 		return
 	}
 
@@ -362,10 +347,8 @@ func runRequestLogMaintenancePass(ctx context.Context, db *sql.DB, driver string
 		requestLogContentBytes.Store(-1)
 	}
 
-	// Always run checkpoint + conditional vacuum. This ensures:
-	// - WAL is periodically truncated (usage.db-wal doesn't grow unbounded)
-	// - Large amounts of free pages can be reclaimed even if no rows were changed in this pass
-	compactLogContentStorageInternal(ctx, db, true)
+	// PostgreSQL compaction stays online and asynchronous; never wait for VACUUM FULL.
+	compactLogContentStorageInternal(ctx, db)
 }
 
 func refreshRequestLogContentBytes(q logContentQuerier) {

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -103,13 +103,13 @@ func InitRedis(cfg config.RedisConfig) {
 		log.Infof("Successfully loaded usage statistics from Redis")
 	}
 
-	// Migrate existing in-memory data to SQLite (first run only)
+	// Migrate existing in-memory data to the database (first run only)
 	if defaultRequestStatistics != nil {
 		snapshot := defaultRequestStatistics.Snapshot()
 		if migrated, err := MigrateFromSnapshot(snapshot); err != nil {
 			log.Errorf("usage: migration from Redis snapshot failed: %v", err)
 		} else if migrated > 0 {
-			log.Infof("usage: migrated %d records from Redis to SQLite", migrated)
+			log.Infof("usage: migrated %d records from Redis to the database", migrated)
 		}
 	}
 
@@ -359,7 +359,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 		s.mu.Unlock()
 	}
 
-	// Persist request logs in the usage manager worker so SQLite writes stay
+	// Persist request logs in the usage manager worker so database writes stay
 	// serialized and do not spawn one goroutine per request.
 	// Use the request-start identity snapshot when available so key renames
 	// during in-flight requests do not orphan log records.

--- a/internal/usage/proxy_pool_db.go
+++ b/internal/usage/proxy_pool_db.go
@@ -24,12 +24,12 @@ func proxyPoolStoreForTenant(tenantID string) sqlproxypool.Store {
 	return sqlproxypool.NewTenantStore(getDB(), tenantID)
 }
 
-// ProxyPoolStoreAvailable reports whether the SQLite store is ready for proxy-pool operations.
+// ProxyPoolStoreAvailable reports whether the proxy-pool store is ready.
 func ProxyPoolStoreAvailable() bool {
 	return proxyPoolStore().Available()
 }
 
-// ListProxyPool retrieves all reusable proxies from SQLite.
+// ListProxyPool retrieves all reusable proxies from the database.
 func ListProxyPool() []config.ProxyPoolEntry {
 	return proxyPoolStore().List()
 }
@@ -39,7 +39,7 @@ func GetProxyPoolEntry(id string) *config.ProxyPoolEntry {
 	return proxyPoolStore().Get(id)
 }
 
-// ReplaceProxyPool atomically replaces all SQLite proxy entries after normalization.
+// ReplaceProxyPool atomically replaces all stored proxy entries after normalization.
 func ReplaceProxyPool(entries []config.ProxyPoolEntry) error {
 	return proxyPoolStore().Replace(entries)
 }
@@ -57,7 +57,7 @@ func ApplyStoredProxyPool(cfg *config.Config) bool {
 	return proxyPoolStore().ApplyToConfig(cfg)
 }
 
-// MigrateProxyPoolFromConfig moves legacy YAML proxy-pool entries into SQLite.
+// MigrateProxyPoolFromConfig moves legacy YAML proxy-pool entries into the database.
 func MigrateProxyPoolFromConfig(cfg *config.Config, configFilePath string) int {
 	if cfg == nil || !ProxyPoolStoreAvailable() {
 		return 0

--- a/internal/usage/request_log_dashboard.go
+++ b/internal/usage/request_log_dashboard.go
@@ -62,7 +62,7 @@ type dashboardBucket struct {
 
 const dashboardThroughputBucketCount = 7
 
-// QueryDashboardKPI returns aggregated KPI data from SQLite for the dashboard.
+// QueryDashboardKPI returns aggregated KPI data from PostgreSQL for the dashboard.
 // This replaces the old in-memory snapshot-based counting which lost data on restart.
 func QueryDashboardKPI(days int) (DashboardKPI, error) {
 	return QueryDashboardKPIForTenant(systemTenantID, days)

--- a/internal/usage/request_log_model_backfill.go
+++ b/internal/usage/request_log_model_backfill.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// providerEchoModelPattern is the SQLite LIKE pattern that marks request_logs.model
+// providerEchoModelPattern is the SQL LIKE pattern that marks request_logs.model
 // values that are upstream provider-internal paths echoed back in an
 // OpenAI-compatible response's "model" field (e.g. "accounts/fireworks/models/glm-5p2").
 // These are not valid model names for display, pricing lookup or filtering, and were

--- a/internal/usage/request_log_query.go
+++ b/internal/usage/request_log_query.go
@@ -26,7 +26,7 @@ func QueryLogs(params LogQueryParams) (LogQueryResult, error) {
 	}
 
 	// Read path: use the dedicated read-only pool so management log queries do not
-	// block on the single writer or maintenance ops (wal_checkpoint/VACUUM).
+	// block on the writer or background compaction.
 	db := getReadDB()
 	if db == nil {
 		// Never return nil slices in JSON responses (nil slice => null in JSON).
@@ -599,16 +599,9 @@ func clearRequestLogs(db *sql.DB, options ClearRequestLogsOptions) (ClearRequest
 	committed = true
 	refreshRequestLogContentBytes(db)
 
-	if usageDriver == "sqlite" {
-		_, err := db.Exec("VACUUM")
-		if err != nil {
-			log.Warnf("usage: vacuum after request log cleanup failed: %v", err)
-		}
-	} else {
-		// PostgreSQL maintenance is asynchronous and online; never make this
-		// management request wait for DDL or database maintenance.
-		triggerRequestLogCompaction()
-	}
+	// PostgreSQL maintenance is asynchronous and online; never make this
+	// management request wait for DDL or database maintenance.
+	triggerRequestLogCompaction()
 
 	if result.DeletedLogs > 0 || result.DeletedContents > 0 || result.ClearedBodyRows > 0 || result.ClearedDetailRows > 0 || result.ClearedLegacyRows > 0 {
 		log.Infof(
@@ -625,7 +618,7 @@ func clearRequestLogs(db *sql.DB, options ClearRequestLogsOptions) (ClearRequest
 }
 
 // ClearAllRequestLogs removes all request_logs and request_log_content rows
-// while leaving other SQLite-backed management data untouched.
+// while leaving other management data untouched.
 func ClearAllRequestLogs() (ClearRequestLogsResult, error) {
 	return ClearAllRequestLogsForTenant(systemTenantID)
 }

--- a/internal/usage/usage_db_test.go
+++ b/internal/usage/usage_db_test.go
@@ -1222,7 +1222,6 @@ func TestCleanupExpiredLogContentKeepsMetadataRows(t *testing.T) {
 		StoreContent:           true,
 		ContentRetentionDays:   30,
 		CleanupIntervalMinutes: 1440,
-		VacuumOnCleanup:        false,
 	})
 
 	db := getDB()
@@ -1336,7 +1335,6 @@ func TestMigrateLegacyContentBatchKeepsAllContentWhenRetentionUnlimited(t *testi
 		StoreContent:           true,
 		ContentRetentionDays:   0,
 		CleanupIntervalMinutes: 1440,
-		VacuumOnCleanup:        false,
 	})
 
 	db := getDB()
@@ -1384,7 +1382,6 @@ func TestMigrateLegacyContentBatchPreservesInlineContentWhenStorageDisabled(t *t
 		StoreContent:           false,
 		ContentRetentionDays:   30,
 		CleanupIntervalMinutes: 1440,
-		VacuumOnCleanup:        false,
 	})
 
 	db := getDB()
@@ -1457,7 +1454,6 @@ func TestCleanupExpiredLogContentSkipsWhenRetentionUnlimited(t *testing.T) {
 				StoreContent:           true,
 				ContentRetentionDays:   0,
 				CleanupIntervalMinutes: 1440,
-				VacuumOnCleanup:        false,
 			},
 		},
 	}
@@ -1530,7 +1526,6 @@ func TestCleanupOversizedLogContentPrunesOldestRows(t *testing.T) {
 		ContentRetentionDays:   30,
 		CleanupIntervalMinutes: 1440,
 		MaxTotalSizeMB:         1,
-		VacuumOnCleanup:        false,
 	})
 
 	db := getDB()
@@ -1623,7 +1618,6 @@ func TestInsertLogContentTxSkipsSingleRowLargerThanSizeCap(t *testing.T) {
 		ContentRetentionDays:   30,
 		CleanupIntervalMinutes: 1440,
 		MaxTotalSizeMB:         1,
-		VacuumOnCleanup:        false,
 	})
 
 	db := getDB()


### PR DESCRIPTION
## 摘要
- 删除 `vacuum-on-cleanup` 配置项，以及请求日志清理后的 SQLite VACUUM / WAL 回收路径
- 生产路径注释、函数名和日志不再把当前存储说成 SQLite
- README 不再把 SQLite 手工导入写成产品文档

运行时仍是 PostgreSQL。`internal/storage/sqlite` 包名和单测用的嵌入式数据库保留，那是 SQL 方言兼容层与测试基础设施，不是运行时 SQLite。

## 验证
- `gofmt` on changed files
- `go test ./internal/config ./internal/usage ./internal/api/handlers/management ./internal/access/config_access`

这是配置清理和注释/文档收口，未跑完整 `./scripts/ci-pr.sh`。