### PR TITLE
fix(logging): mark truncated streaming request logs when queues drop chunks

### DIFF
--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -170,6 +170,7 @@ func TestShouldCaptureRequestBody(t *testing.T) {
 type stubStreamingLogWriter struct{}
 
 func (stubStreamingLogWriter) WriteChunkAsync([]byte)                     {}
+func (stubStreamingLogWriter) NoteDroppedChunks(int)                      {}
 func (stubStreamingLogWriter) WriteStatus(int, map[string][]string) error { return nil }
 func (stubStreamingLogWriter) WriteAPIRequest([]byte) error               { return nil }
 func (stubStreamingLogWriter) WriteAPIResponse([]byte) error              { return nil }

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -38,6 +38,7 @@ type ResponseWriterWrapper struct {
 	streamWriter        logging.StreamingLogWriter // streamWriter is a writer for handling streaming log entries.
 	chunkChannel        chan []byte                // chunkChannel is a channel for asynchronously passing response chunks to the logger.
 	streamDone          chan struct{}              // streamDone signals when the streaming goroutine completes.
+	droppedChunks       int                        // droppedChunks counts chunks skipped when chunkChannel was full.
 	logger              logging.RequestLogger      // logger is the instance of the request logger service.
 	requestInfo         *RequestInfo               // requestInfo holds the details of the original request.
 	ginCtx              *gin.Context               // ginCtx allows propagating first-response timing into usage records.
@@ -94,6 +95,7 @@ func (w *ResponseWriterWrapper) Write(data []byte) (int, error) {
 		select {
 		case w.chunkChannel <- append([]byte(nil), data...):
 		default:
+			w.droppedChunks++
 		}
 		return n, err
 	}
@@ -143,6 +145,7 @@ func (w *ResponseWriterWrapper) WriteString(data string) (int, error) {
 		select {
 		case w.chunkChannel <- []byte(data):
 		default:
+			w.droppedChunks++
 		}
 		return n, err
 	}
@@ -346,6 +349,10 @@ func (w *ResponseWriterWrapper) finalizeStreamingLog(c *gin.Context, forceLog bo
 	if w.streamDone != nil {
 		<-w.streamDone
 		w.streamDone = nil
+	}
+
+	if w.droppedChunks > 0 {
+		writer.NoteDroppedChunks(w.droppedChunks)
 	}
 
 	w.streamWriter = nil

--- a/internal/api/middleware/response_writer_test.go
+++ b/internal/api/middleware/response_writer_test.go
@@ -100,6 +100,61 @@ func TestExtractRequestBodyPrefersOverride(t *testing.T) {
 	}
 }
 
+type recordingStreamingLogWriter struct {
+	dropped int
+	closed  bool
+}
+
+func (w *recordingStreamingLogWriter) WriteChunkAsync([]byte)                     {}
+func (w *recordingStreamingLogWriter) NoteDroppedChunks(n int)                    { w.dropped += n }
+func (w *recordingStreamingLogWriter) WriteStatus(int, map[string][]string) error { return nil }
+func (w *recordingStreamingLogWriter) WriteAPIRequest([]byte) error               { return nil }
+func (w *recordingStreamingLogWriter) WriteAPIResponse([]byte) error              { return nil }
+func (w *recordingStreamingLogWriter) SetFirstChunkTimestamp(time.Time)           {}
+func (w *recordingStreamingLogWriter) Close() error {
+	w.closed = true
+	return nil
+}
+
+func TestFinalizeStreamingLogNotesDroppedChunks(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	writer := &recordingStreamingLogWriter{}
+	wrapper := &ResponseWriterWrapper{
+		logger:        stubRequestLogger{},
+		streamWriter:  writer,
+		droppedChunks: 4,
+	}
+
+	if err := wrapper.finalizeStreamingLog(c, false); err != nil {
+		t.Fatalf("finalizeStreamingLog() error = %v", err)
+	}
+	if writer.dropped != 4 {
+		t.Fatalf("NoteDroppedChunks = %d, want 4", writer.dropped)
+	}
+	if !writer.closed {
+		t.Fatal("expected stream writer Close()")
+	}
+}
+
+func TestWriteCountsDroppedStreamingChunksWhenQueueIsFull(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	wrapper := NewResponseWriterWrapper(c.Writer, stubRequestLogger{}, &RequestInfo{}, c)
+	wrapper.isStreaming = true
+	wrapper.chunkChannel = make(chan []byte, 1)
+	wrapper.chunkChannel <- []byte("queued")
+
+	if _, err := wrapper.Write([]byte("dropped")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if wrapper.droppedChunks != 1 {
+		t.Fatalf("droppedChunks = %d, want 1", wrapper.droppedChunks)
+	}
+}
+
 func TestExtractRequestBodySupportsStringOverride(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()

--- a/internal/api/request_body_chain_test.go
+++ b/internal/api/request_body_chain_test.go
@@ -20,6 +20,7 @@ import (
 type chainStreamingLogWriter struct{}
 
 func (chainStreamingLogWriter) WriteChunkAsync([]byte)                     {}
+func (chainStreamingLogWriter) NoteDroppedChunks(int)                      {}
 func (chainStreamingLogWriter) WriteStatus(int, map[string][]string) error { return nil }
 func (chainStreamingLogWriter) WriteAPIRequest([]byte) error               { return nil }
 func (chainStreamingLogWriter) WriteAPIResponse([]byte) error              { return nil }

--- a/internal/api/sdkbridge/bridge.go
+++ b/internal/api/sdkbridge/bridge.go
@@ -161,6 +161,10 @@ func (a sdkStreamingLogWriterAdapter) WriteChunkAsync(chunk []byte) {
 	a.inner.WriteChunkAsync(chunk)
 }
 
+func (a sdkStreamingLogWriterAdapter) NoteDroppedChunks(n int) {
+	a.inner.NoteDroppedChunks(n)
+}
+
 func (a sdkStreamingLogWriterAdapter) WriteStatus(status int, headers map[string][]string) error {
 	return a.inner.WriteStatus(status, headers)
 }

--- a/internal/logging/request_logger_contracts.go
+++ b/internal/logging/request_logger_contracts.go
@@ -20,6 +20,10 @@ type RequestLogger interface {
 // StreamingLogWriter handles real-time logging of streaming response chunks.
 type StreamingLogWriter interface {
 	WriteChunkAsync(chunk []byte)
+	// NoteDroppedChunks records chunks that never reached WriteChunkAsync because
+	// an upstream log queue was full. Close must persist a truncated marker when
+	// any drops were noted, so a partial body is not mistaken for a complete log.
+	NoteDroppedChunks(n int)
 	WriteStatus(status int, headers map[string][]string) error
 	WriteAPIRequest(apiRequest []byte) error
 	WriteAPIResponse(apiResponse []byte) error

--- a/internal/logging/streaming_log_writer.go
+++ b/internal/logging/streaming_log_writer.go
@@ -4,11 +4,18 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/diagnostics"
 	log "github.com/sirupsen/logrus"
 )
+
+// StreamingLogTruncationNote is appended when async log queues dropped chunks.
+// The client still received the full stream; the persisted body did not.
+func StreamingLogTruncationNote(dropped int) string {
+	return fmt.Sprintf("\n\n[truncated: dropped %d streaming log chunks; persisted response body is incomplete]\n", dropped)
+}
 
 // FileStreamingLogWriter spools streaming response chunks to temporary files
 // and assembles the final human-readable log only when the stream closes.
@@ -30,6 +37,7 @@ type FileStreamingLogWriter struct {
 	apiRequest           []byte
 	apiResponse          []byte
 	apiResponseTimestamp time.Time
+	droppedChunks        atomic.Int64
 }
 
 func (w *FileStreamingLogWriter) WriteChunkAsync(chunk []byte) {
@@ -42,6 +50,13 @@ func (w *FileStreamingLogWriter) WriteChunkAsync(chunk []byte) {
 	select {
 	case w.chunkChan <- chunkCopy:
 	default:
+		w.droppedChunks.Add(1)
+	}
+}
+
+func (w *FileStreamingLogWriter) NoteDroppedChunks(n int) {
+	if n > 0 {
+		w.droppedChunks.Add(int64(n))
 	}
 }
 
@@ -92,6 +107,8 @@ func (w *FileStreamingLogWriter) Close() error {
 		<-w.closeChan
 		w.chunkChan = nil
 	}
+
+	w.appendTruncationNote()
 
 	select {
 	case errWrite := <-w.errorChan:
@@ -181,6 +198,25 @@ func (w *FileStreamingLogWriter) writeFinalLog(logFile *os.File) error {
 	return writeResponseSection(logFile, w.responseStatus, w.statusWritten, w.responseHeaders, responseBodyFile, nil, false)
 }
 
+func (w *FileStreamingLogWriter) appendTruncationNote() {
+	dropped := int(w.droppedChunks.Load())
+	if dropped <= 0 || w.responseBodyPath == "" {
+		return
+	}
+	log.WithField("dropped_chunks", dropped).Warn("streaming request log dropped chunks; persisted body is incomplete")
+	noteFile, errOpen := os.OpenFile(w.responseBodyPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if errOpen != nil {
+		log.WithError(errOpen).Warn("failed to append streaming log truncation note")
+		return
+	}
+	if _, errWrite := noteFile.WriteString(StreamingLogTruncationNote(dropped)); errWrite != nil {
+		log.WithError(errWrite).Warn("failed to write streaming log truncation note")
+	}
+	if errClose := noteFile.Close(); errClose != nil {
+		log.WithError(errClose).Warn("failed to close streaming log truncation note")
+	}
+}
+
 func (w *FileStreamingLogWriter) cleanupTempFiles() {
 	if w.requestBodyPath != "" {
 		if errRemove := os.Remove(w.requestBodyPath); errRemove != nil {
@@ -201,6 +237,8 @@ func (w *FileStreamingLogWriter) cleanupTempFiles() {
 type NoOpStreamingLogWriter struct{}
 
 func (w *NoOpStreamingLogWriter) WriteChunkAsync(_ []byte) {}
+
+func (w *NoOpStreamingLogWriter) NoteDroppedChunks(_ int) {}
 
 func (w *NoOpStreamingLogWriter) WriteStatus(_ int, _ map[string][]string) error {
 	return nil

--- a/internal/logging/streaming_log_writer_test.go
+++ b/internal/logging/streaming_log_writer_test.go
@@ -1,0 +1,69 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteChunkAsyncCountsDroppedChunksWhenQueueIsFull(t *testing.T) {
+	t.Parallel()
+
+	writer := &FileStreamingLogWriter{
+		chunkChan: make(chan []byte, 1),
+	}
+	writer.chunkChan <- []byte("queued")
+	writer.WriteChunkAsync([]byte("dropped"))
+	if got := writer.droppedChunks.Load(); got != 1 {
+		t.Fatalf("droppedChunks = %d, want 1", got)
+	}
+}
+
+func TestClosePersistsTruncationNoteForDroppedChunks(t *testing.T) {
+	t.Parallel()
+
+	logsDir := t.TempDir()
+	bodyFile, err := os.CreateTemp(logsDir, "response-body-*.tmp")
+	if err != nil {
+		t.Fatalf("create temp body: %v", err)
+	}
+	if _, err := bodyFile.WriteString("partial-body"); err != nil {
+		t.Fatalf("write temp body: %v", err)
+	}
+
+	logPath := filepath.Join(logsDir, "request.log")
+	writer := &FileStreamingLogWriter{
+		logFilePath:      logPath,
+		url:              "/v1/responses",
+		method:           "POST",
+		timestamp:        time.Unix(0, 0).UTC(),
+		requestHeaders:   map[string][]string{},
+		responseBodyPath: bodyFile.Name(),
+		responseBodyFile: bodyFile,
+		chunkChan:        make(chan []byte, 1),
+		closeChan:        make(chan struct{}),
+		errorChan:        make(chan error, 1),
+		responseStatus:   200,
+		statusWritten:    true,
+	}
+	go writer.asyncWriter()
+	writer.NoteDroppedChunks(3)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", logPath, err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "partial-body") {
+		t.Fatalf("log missing kept body:\n%s", text)
+	}
+	want := StreamingLogTruncationNote(3)
+	if !strings.Contains(text, strings.TrimSpace(want)) {
+		t.Fatalf("log missing truncation note %q:\n%s", strings.TrimSpace(want), text)
+	}
+}

--- a/sdk/logging/contracts.go
+++ b/sdk/logging/contracts.go
@@ -29,6 +29,10 @@ type RequestLogger interface {
 // StreamingLogWriter handles real-time logging of streaming response chunks.
 type StreamingLogWriter interface {
 	WriteChunkAsync(chunk []byte)
+	// NoteDroppedChunks records chunks that never reached WriteChunkAsync because
+	// an upstream log queue was full. Close must persist a truncated marker when
+	// any drops were noted, so a partial body is not mistaken for a complete log.
+	NoteDroppedChunks(n int)
 	WriteStatus(status int, headers map[string][]string) error
 	WriteAPIRequest(apiRequest []byte) error
 	WriteAPIResponse(apiResponse []byte) error

--- a/sdk/logging/streaming_log_writer.go
+++ b/sdk/logging/streaming_log_writer.go
@@ -4,10 +4,17 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 )
+
+// StreamingLogTruncationNote is appended when async log queues dropped chunks.
+// The client still received the full stream; the persisted body did not.
+func StreamingLogTruncationNote(dropped int) string {
+	return fmt.Sprintf("\n\n[truncated: dropped %d streaming log chunks; persisted response body is incomplete]\n", dropped)
+}
 
 // FileStreamingLogWriter spools streaming response chunks to temporary files
 // and assembles the final human-readable log only when the stream closes.
@@ -29,6 +36,7 @@ type FileStreamingLogWriter struct {
 	apiRequest           []byte
 	apiResponse          []byte
 	apiResponseTimestamp time.Time
+	droppedChunks        atomic.Int64
 }
 
 func (w *FileStreamingLogWriter) WriteChunkAsync(chunk []byte) {
@@ -41,6 +49,13 @@ func (w *FileStreamingLogWriter) WriteChunkAsync(chunk []byte) {
 	select {
 	case w.chunkChan <- chunkCopy:
 	default:
+		w.droppedChunks.Add(1)
+	}
+}
+
+func (w *FileStreamingLogWriter) NoteDroppedChunks(n int) {
+	if n > 0 {
+		w.droppedChunks.Add(int64(n))
 	}
 }
 
@@ -91,6 +106,8 @@ func (w *FileStreamingLogWriter) Close() error {
 		<-w.closeChan
 		w.chunkChan = nil
 	}
+
+	w.appendTruncationNote()
 
 	select {
 	case errWrite := <-w.errorChan:
@@ -180,6 +197,25 @@ func (w *FileStreamingLogWriter) writeFinalLog(logFile *os.File) error {
 	return writeResponseSection(logFile, w.responseStatus, w.statusWritten, w.responseHeaders, responseBodyFile, nil, false)
 }
 
+func (w *FileStreamingLogWriter) appendTruncationNote() {
+	dropped := int(w.droppedChunks.Load())
+	if dropped <= 0 || w.responseBodyPath == "" {
+		return
+	}
+	log.WithField("dropped_chunks", dropped).Warn("streaming request log dropped chunks; persisted body is incomplete")
+	noteFile, errOpen := os.OpenFile(w.responseBodyPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if errOpen != nil {
+		log.WithError(errOpen).Warn("failed to append streaming log truncation note")
+		return
+	}
+	if _, errWrite := noteFile.WriteString(StreamingLogTruncationNote(dropped)); errWrite != nil {
+		log.WithError(errWrite).Warn("failed to write streaming log truncation note")
+	}
+	if errClose := noteFile.Close(); errClose != nil {
+		log.WithError(errClose).Warn("failed to close streaming log truncation note")
+	}
+}
+
 func (w *FileStreamingLogWriter) cleanupTempFiles() {
 	if w.requestBodyPath != "" {
 		if errRemove := os.Remove(w.requestBodyPath); errRemove != nil {
@@ -200,6 +236,8 @@ func (w *FileStreamingLogWriter) cleanupTempFiles() {
 type NoOpStreamingLogWriter struct{}
 
 func (w *NoOpStreamingLogWriter) WriteChunkAsync(_ []byte) {}
+
+func (w *NoOpStreamingLogWriter) NoteDroppedChunks(_ int) {}
 
 func (w *NoOpStreamingLogWriter) WriteStatus(_ int, _ map[string][]string) error {
 	return nil

--- a/sdk/logging/streaming_log_writer_test.go
+++ b/sdk/logging/streaming_log_writer_test.go
@@ -1,0 +1,69 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteChunkAsyncCountsDroppedChunksWhenQueueIsFull(t *testing.T) {
+	t.Parallel()
+
+	writer := &FileStreamingLogWriter{
+		chunkChan: make(chan []byte, 1),
+	}
+	writer.chunkChan <- []byte("queued")
+	writer.WriteChunkAsync([]byte("dropped"))
+	if got := writer.droppedChunks.Load(); got != 1 {
+		t.Fatalf("droppedChunks = %d, want 1", got)
+	}
+}
+
+func TestClosePersistsTruncationNoteForDroppedChunks(t *testing.T) {
+	t.Parallel()
+
+	logsDir := t.TempDir()
+	bodyFile, err := os.CreateTemp(logsDir, "response-body-*.tmp")
+	if err != nil {
+		t.Fatalf("create temp body: %v", err)
+	}
+	if _, err := bodyFile.WriteString("partial-body"); err != nil {
+		t.Fatalf("write temp body: %v", err)
+	}
+
+	logPath := filepath.Join(logsDir, "request.log")
+	writer := &FileStreamingLogWriter{
+		logFilePath:      logPath,
+		url:              "/v1/responses",
+		method:           "POST",
+		timestamp:        time.Unix(0, 0).UTC(),
+		requestHeaders:   map[string][]string{},
+		responseBodyPath: bodyFile.Name(),
+		responseBodyFile: bodyFile,
+		chunkChan:        make(chan []byte, 1),
+		closeChan:        make(chan struct{}),
+		errorChan:        make(chan error, 1),
+		responseStatus:   200,
+		statusWritten:    true,
+	}
+	go writer.asyncWriter()
+	writer.NoteDroppedChunks(3)
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", logPath, err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "partial-body") {
+		t.Fatalf("log missing kept body:\n%s", text)
+	}
+	want := StreamingLogTruncationNote(3)
+	if !strings.Contains(text, strings.TrimSpace(want)) {
+		t.Fatalf("log missing truncation note %q:\n%s", strings.TrimSpace(want), text)
+	}
+}


### PR DESCRIPTION
## Summary
Streaming responses still write to the client first, but a full async log queue no longer silently drops bytes. Both log queues count dropped chunks, and Close appends an explicit truncated marker so a partial persisted body is not mistaken for a complete request log.

Fixes #964.

## Verification
- `go test ./internal/logging ./sdk/logging ./internal/api/middleware ./internal/api ./internal/api/sdkbridge -count=1`