### PR TITLE
fix(usage): fold Codex account_id subjects onto account_user_id

### DIFF
--- a/internal/usage/auth_subject_identity.go
+++ b/internal/usage/auth_subject_identity.go
@@ -156,8 +156,9 @@ func LegacyTenantScopedAuthSubjectID(auth *coreauth.Auth) string {
 	if identity == nil {
 		return ""
 	}
-	// account_id and auth_index seeds never changed shape, so they have no legacy
-	// counterpart to migrate from.
+	// auth_index never changed shape. account_id did — Codex now prefers
+	// account_user_id — but that predecessor is LegacyAccountIDAuthSubjectID,
+	// not a tenant-scoped id.
 	seedValue := ""
 	switch identity.SeedKind {
 	case "email":
@@ -177,6 +178,23 @@ func LegacyTenantScopedAuthSubjectID(auth *coreauth.Auth) string {
 		coreauth.NormalizedTenantID(auth.TenantID),
 		seedValue,
 	)
+}
+
+// LegacyAccountIDAuthSubjectID is the subject this Codex credential used before
+// the seed became account_id+user_id. Personal Pro accounts kept their usage
+// there when the Team-collision fix started hashing the user id too, so the
+// card next to a still-correct WHAM bar read a few hours of traffic as "this
+// week". API keys and account-id-only auths have no such predecessor.
+func LegacyAccountIDAuthSubjectID(auth *coreauth.Auth) string {
+	identity := ResolveAuthSubjectIdentity(auth)
+	if identity == nil || identity.SeedKind != "account_user_id" {
+		return ""
+	}
+	accountID := strings.TrimSpace(identity.AccountID)
+	if accountID == "" {
+		return ""
+	}
+	return stableAuthSubjectID(identity.Provider, "account_id", accountID)
 }
 
 func BuildAuthSubjectMatcher(current *coreauth.Auth, auths []*coreauth.Auth) AuthSubjectMatcher {

--- a/internal/usage/auth_subject_identity_migration.go
+++ b/internal/usage/auth_subject_identity_migration.go
@@ -48,25 +48,65 @@ var subjectAccountKeyTables = []struct {
 	{"identity_fingerprint_account_policies", []string{"tenant_id", "provider"}, "updated_at"},
 }
 
-// MergeLegacySplitAuthSubject folds the rows an account accumulated while its
-// identity was tenant scoped onto the shared identity it has now.
+// MergeLegacySplitAuthSubject folds rows an account accumulated under an older
+// subject id onto the identity it has now.
 //
-// Every seed except auth_index used to carry tenant_id, so one upstream account
-// became a separate subject in each tenant holding a credential for it. Usage,
-// status and cycle rows were then split across those subjects while the quota
-// they sat next to described the whole account — a tenant that had not called
-// the account yet showed zeros beside a quota bar reading 87%.
+// Two predecessors exist:
+//
+//  1. Tenant-scoped email / auth_id seeds. Every seed except auth_index used to
+//     carry tenant_id, so one upstream account became a separate subject in each
+//     tenant. Usage sat on one half while the quota bar described the whole
+//     account — a tenant that had not called it yet showed zeros next to 87%.
+//  2. Codex account_id seeds. Distinguishing Team members required hashing
+//     chatgpt_user_id too, which minted a new subject for personal Pro accounts
+//     that already had a unique account_id. Bindings moved; history did not.
+//     The card then counted hours of traffic against a WHAM bar for the real
+//     week. Docker and native upgrades hit this the same way — it is an identity
+//     change, not a SQLite leftover.
 //
 // Called from the binding hook, so it runs with the authoritative auth in hand
-// rather than trying to reconstruct seeds from hashes on disk.
+// rather than trying to reconstruct seeds from hashes on disk. Native restarts
+// and Docker image upgrades both load every credential once, which is enough
+// to repair a split that already happened.
 func MergeLegacySplitAuthSubject(auth *coreauth.Auth, identity *AuthSubjectIdentity) error {
 	if auth == nil || identity == nil || strings.TrimSpace(identity.ID) == "" {
 		return nil
 	}
-	legacyID := LegacyTenantScopedAuthSubjectID(auth)
-	if legacyID == "" || legacyID == identity.ID {
+	if getDB() == nil {
 		return nil
 	}
+	var firstErr error
+	for _, legacyID := range predecessorAuthSubjectIDs(auth, identity) {
+		if err := mergeLegacyAuthSubjectIfPresent(legacyID, identity); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func predecessorAuthSubjectIDs(auth *coreauth.Auth, identity *AuthSubjectIdentity) []string {
+	if identity == nil {
+		return nil
+	}
+	seen := map[string]struct{}{strings.TrimSpace(identity.ID): {}}
+	out := make([]string, 0, 2)
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if _, exists := seen[id]; exists {
+			return
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	add(LegacyTenantScopedAuthSubjectID(auth))
+	add(LegacyAccountIDAuthSubjectID(auth))
+	return out
+}
+
+func mergeLegacyAuthSubjectIfPresent(legacyID string, identity *AuthSubjectIdentity) error {
 	if _, seen := mergedLegacySubjects.Load(legacyID); seen {
 		return nil
 	}
@@ -89,12 +129,41 @@ func MergeLegacySplitAuthSubject(auth *coreauth.Auth, identity *AuthSubjectIdent
 		mergedLegacySubjects.Store(legacyID, struct{}{})
 		return nil
 	}
+	skip, err := skipCrowdedAccountIDMerge(db, legacyID, identity)
+	if err != nil {
+		return err
+	}
+	if skip {
+		// Several credentials still share the old account_id subject — the Team
+		// collision the user-id seed was added to stop. Folding that pool onto
+		// this user would also rewrite the others' bindings onto this subject.
+		mergedLegacySubjects.Store(legacyID, struct{}{})
+		return nil
+	}
 
 	if err := mergeLegacyAuthSubjectDB(db, legacyID, identity); err != nil {
 		return err
 	}
 	mergedLegacySubjects.Store(legacyID, struct{}{})
 	return nil
+}
+
+// skipCrowdedAccountIDMerge reports whether the old account_id subject still has
+// more than one active binding. Personal Pro is 0 (already rebound after the
+// seed change) or 1 (first upgrade, merge runs before the binding upsert).
+func skipCrowdedAccountIDMerge(db *sql.DB, legacyID string, identity *AuthSubjectIdentity) (bool, error) {
+	if identity == nil || identity.SeedKind != "account_user_id" {
+		return false, nil
+	}
+	var n int
+	err := db.QueryRow(`
+		SELECT COUNT(*) FROM ai_account_tenant_bindings
+		WHERE auth_subject_id = ? AND binding_state = 'active'
+	`, legacyID).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("usage: count account_id subject bindings: %w", err)
+	}
+	return n > 1, nil
 }
 
 // legacyAuthSubjectHasRows is the cheap guard on the reload path: an account
@@ -175,10 +244,11 @@ func mergeLegacyAuthSubjectDB(db *sql.DB, legacyID string, identity *AuthSubject
 // ensureAuthSubjectRowTx creates the shared subject row, seeding its history
 // markers from the legacy row so a merged account does not look newly observed.
 func ensureAuthSubjectRowTx(tx *sql.Tx, legacyID string, identity *AuthSubjectIdentity) error {
-	shareEligible := 0
-	if identity.ShareEligible {
-		shareEligible = 1
-	}
+	// Use bool, not integer 0/1: Postgres share_eligible is BOOLEAN and pgx
+	// cannot encode a Go int into OID 16. That failure aborted every merge on
+	// a Postgres host — including Docker upgrades — while SQLite had accepted
+	// the integer. UpsertAIAccountSubject already writes a bool; this path
+	// has to match or the repair never lands.
 	if _, err := tx.Exec(`
 		INSERT INTO ai_account_subjects (
 			auth_subject_id, provider, subject_scope, seed_kind, seed_hash, share_eligible,
@@ -198,7 +268,7 @@ func ensureAuthSubjectRowTx(tx *sql.Tx, legacyID string, identity *AuthSubjectId
 			updated_at = CASE WHEN excluded.updated_at > ai_account_subjects.updated_at
 				THEN excluded.updated_at ELSE ai_account_subjects.updated_at END
 	`, identity.ID, identity.Provider, identity.SubjectScope, identity.SeedKind, identity.SeedHash,
-		shareEligible, legacyID); err != nil {
+		identity.ShareEligible, legacyID); err != nil {
 		return fmt.Errorf("usage: ensure shared auth subject: %w", err)
 	}
 	return nil

--- a/internal/usage/auth_subject_identity_migration_test.go
+++ b/internal/usage/auth_subject_identity_migration_test.go
@@ -370,3 +370,174 @@ func TestMergeLegacySplitSubjectKeepsDistinctAccountsApart(t *testing.T) {
 		t.Fatalf("account two = %+v, want 6 requests", got)
 	}
 }
+
+func TestLegacyAccountIDAuthSubjectIDOnlyForCodexUserSeed(t *testing.T) {
+	oauth := codexMemberTestAuth(sharedSubjectTenantA, "oauth", "acct-1", "user-1", "a@example.com")
+	identity := ResolveAuthSubjectIdentity(oauth)
+	legacyID := LegacyAccountIDAuthSubjectID(oauth)
+	if identity.SeedKind != "account_user_id" || legacyID == "" || legacyID == identity.ID {
+		t.Fatalf("oauth predecessor = %q current = %q kind = %s", legacyID, identity.ID, identity.SeedKind)
+	}
+
+	accountOnly := sharedSubjectTestAuth(sharedSubjectTenantA, "acct-only", "acct-1", "a@example.com")
+	if got := LegacyAccountIDAuthSubjectID(accountOnly); got != "" {
+		t.Fatalf("account_id-only predecessor = %q, want empty", got)
+	}
+
+	apiKey := &coreauth.Auth{
+		ID: sharedSubjectTenantA + "/codex:apikey:abc123", TenantID: sharedSubjectTenantA,
+		Provider: "codex", FileName: "key.json",
+	}
+	if got := LegacyAccountIDAuthSubjectID(apiKey); got != "" {
+		t.Fatalf("API key predecessor = %q, want empty", got)
+	}
+}
+
+func leftoverAuthSubjectRows(t *testing.T, subjectID string) int {
+	t.Helper()
+	var n int
+	if err := getDB().QueryRow(`
+		SELECT (SELECT COUNT(*) FROM ai_account_subjects WHERE auth_subject_id = ?)
+		     + (SELECT COUNT(*) FROM ai_account_subject_usage_buckets WHERE auth_subject_id = ?)
+		     + (SELECT COUNT(*) FROM ai_account_subject_status WHERE auth_subject_id = ?)
+		     + (SELECT COUNT(*) FROM request_logs WHERE auth_subject_id = ?)
+	`, subjectID, subjectID, subjectID, subjectID).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func seedActiveBindingOnSubject(t *testing.T, auth *coreauth.Auth, subjectID string, at time.Time) {
+	t.Helper()
+	stamp := at.UTC().Format(time.RFC3339Nano)
+	auth.EnsureIndex()
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_tenant_bindings (
+			tenant_id, auth_id, auth_index, provider, auth_subject_id,
+			binding_seed_kind, binding_seed_hash, share_eligible,
+			binding_state, binding_revision, bound_at, last_seen_at
+		) VALUES (?, ?, ?, ?, ?, 'account_id', 'legacy-hash', ?, 'active', 1, ?, ?)
+	`, auth.TenantID, auth.ID, auth.Index, auth.Provider, subjectID, true, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Production after the Team-collision seed change: a personal Pro account kept
+// its week of traffic on the old account_id subject while the card read the
+// new account_user_id row. Bindings had already moved, so the old subject had
+// zero active bindings — the same shape a Docker host sees on the next boot
+// after upgrading past that change.
+func TestMergeLegacyAccountIDSubjectFoldsPersonalCodexUsage(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	auth := codexMemberTestAuth(sharedSubjectTenantA, "jd7.json", "acct-jd7", "user-jd7", "jd7@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	legacyID := LegacyAccountIDAuthSubjectID(auth)
+	if legacyID == "" || legacyID == identity.ID {
+		t.Fatalf("expected a distinct account_id predecessor, got %q / %q", legacyID, identity.ID)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyAuthSubjectRow(t, legacyID, "codex", "account_id", now.Add(-48*time.Hour))
+	for i := 0; i < 40; i++ {
+		projectSubjectRequest(t, legacyID, now.Add(-24*time.Hour), 100)
+	}
+	if err := UpsertAIAccountSubject(identity); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		projectSubjectRequest(t, identity.ID, now.Add(-time.Hour), 20)
+	}
+
+	if err := MergeLegacySplitAuthSubject(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+	got := readSubjectSummary(t, identity.ID)
+	if got.RequestTotal != 45 || got.SuccessTotal != 45 {
+		t.Fatalf("merged personal Codex lifetime = %+v, want 45 requests", got)
+	}
+	if leftoverAuthSubjectRows(t, legacyID) != 0 {
+		t.Fatalf("legacy account_id subject left rows behind")
+	}
+
+	resetMergedLegacySubjects()
+	if err := MergeLegacySplitAuthSubject(auth, identity); err != nil {
+		t.Fatal(err)
+	}
+	if again := readSubjectSummary(t, identity.ID); again.RequestTotal != 45 {
+		t.Fatalf("re-running the account_id merge changed totals: %+v", again)
+	}
+}
+
+func TestBindingHookMergesLegacyAccountIDSubjectOnAuthLoad(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	auth := codexMemberTestAuth(sharedSubjectTenantA, "hook-codex.json", "acct-hook", "user-hook", "hook@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	legacyID := LegacyAccountIDAuthSubjectID(auth)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyAuthSubjectRow(t, legacyID, "codex", "account_id", now.Add(-time.Hour))
+	seedActiveBindingOnSubject(t, auth, legacyID, now.Add(-time.Hour))
+	for i := 0; i < 8; i++ {
+		projectSubjectRequest(t, legacyID, now.Add(-time.Hour), 25)
+	}
+
+	AIAccountBindingHook{}.OnAuthLoaded(context.Background(), auth)
+
+	if got := readSubjectSummary(t, identity.ID); got.RequestTotal != 8 || got.SuccessTotal != 8 {
+		t.Fatalf("hook did not migrate the Codex account_id subject: %+v", got)
+	}
+	bindings, err := ListAIAccountBindingsForTenantAuths(sharedSubjectTenantA, []string{auth.ID})
+	if err != nil || len(bindings) != 1 || bindings[0].AuthSubjectID != identity.ID {
+		t.Fatalf("binding=%+v err=%v, want it pointing at the account_user_id subject", bindings, err)
+	}
+}
+
+// Two Team members still bound to the shared account_id subject must not have
+// that pool folded onto whoever loads first — the rewrite would steal the
+// other member's binding. Native and Docker upgrades of a Team workspace
+// both look like this on first boot of the user-id seed.
+func TestMergeLegacyAccountIDSubjectSkipsCrowdedTeamBindings(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	authA := codexMemberTestAuth(sharedSubjectTenantA, "team-a.json", "acct-team", "user-a", "a@example.com")
+	authB := codexMemberTestAuth(sharedSubjectTenantA, "team-b.json", "acct-team", "user-b", "b@example.com")
+	identityA := ResolveAuthSubjectIdentity(authA)
+	identityB := ResolveAuthSubjectIdentity(authB)
+	legacyID := LegacyAccountIDAuthSubjectID(authA)
+	if legacyID == "" || legacyID != LegacyAccountIDAuthSubjectID(authB) {
+		t.Fatalf("team members must share the account_id predecessor: %q / %q", legacyID, LegacyAccountIDAuthSubjectID(authB))
+	}
+	if identityA.ID == identityB.ID {
+		t.Fatal("team members collapsed onto one account_user_id subject")
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyAuthSubjectRow(t, legacyID, "codex", "account_id", now.Add(-time.Hour))
+	seedActiveBindingOnSubject(t, authA, legacyID, now.Add(-time.Hour))
+	seedActiveBindingOnSubject(t, authB, legacyID, now.Add(-time.Hour))
+	for i := 0; i < 12; i++ {
+		projectSubjectRequest(t, legacyID, now.Add(-time.Hour), 10)
+	}
+
+	if err := MergeLegacySplitAuthSubject(authA, identityA); err != nil {
+		t.Fatal(err)
+	}
+	if err := MergeLegacySplitAuthSubject(authB, identityB); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readSubjectSummary(t, identityA.ID); got.RequestTotal != 0 {
+		t.Fatalf("member A swallowed the shared pool: %+v", got)
+	}
+	if got := readSubjectSummary(t, identityB.ID); got.RequestTotal != 0 {
+		t.Fatalf("member B swallowed the shared pool: %+v", got)
+	}
+	if got := readSubjectSummary(t, legacyID); got.RequestTotal != 12 {
+		t.Fatalf("crowded account_id subject = %+v, want the 12 shared requests left in place", got)
+	}
+}


### PR DESCRIPTION
## 范围

PR #927 为拆 Codex Team 串号，把 OAuth 身份种子从 `account_id` 改成 `account_user_id`。个人 Pro 账号的绑定切到了新 subject，历史用量仍躺在旧行上；卡片上的本周调用次数只剩升级后几小时，WHAM 额度条仍是对的。

这不是 SQLite 删库造成的。官方 Docker compose 和原生 Postgres 升过 #927 都会拆。已有的 subject 折并路径还把 `share_eligible` 写成整数 `0/1`，pgx 在 BOOLEAN 列上失败，所以 Postgres 上连旧的 email/`auth_id` 折并也写不进去。

- 加载凭据时把旧 `account_id` 主体折进当前 `account_user_id`（绑定已切走、N=0 的个人账号也能折）
- 多个成员仍挂在同一旧 `account_id` 上时跳过，避免把 Team 混合历史折到先加载的那个人
- `ensureAuthSubjectRowTx` 写入真正的 bool，Docker / 原生 Postgres 升级后迁移能落盘

进程起来扫一遍凭据就会修。Docker 用户升到这一版也会自愈。

## 验证

- `./scripts/ci-pr.sh` 本地通过（含 `gofmt`、结构检查、`go vet`、`go test ./...`、golangci-lint、`go build ./cmd/server`）