### PR TITLE
fix(usage): merge overlapping subject status instead of rewriting ids

### DIFF
--- a/internal/usage/auth_subject_identity_migration.go
+++ b/internal/usage/auth_subject_identity_migration.go
@@ -19,20 +19,20 @@ var mergedLegacySubjects sync.Map
 // concurrently and would otherwise race to move the same legacy rows.
 var legacySubjectMergeMu sync.Mutex
 
-// subjectRewriteTables carry a subject reference whose primary key already
-// includes tenant_id (or is a surrogate id), so one account's rows from two
-// tenants cannot collide and a plain rewrite is enough.
+// subjectRewriteTables are the tables whose unique key does not include the
+// subject id, so a plain UPDATE cannot collide. Tables keyed by the subject
+// itself — status snapshots, daily/rollup counters, quota cycles — are merged
+// explicitly first. The previous blind rewrite hit Postgres 23505 as soon as
+// both halves already had a row for the same tenant, which is exactly the
+// account_id → account_user_id split (and the email merge after bool writes
+// started succeeding).
 var subjectRewriteTables = []struct{ table, column string }{
 	{"ai_account_tenant_bindings", "auth_subject_id"},
-	{"ai_account_status", "auth_subject_id"},
 	{"ai_account_subject_quota_points", "auth_subject_id"},
-	{"auth_subject_usage_daily", "auth_subject_id"},
-	{"auth_subject_quota_cycles", "subject_id"},
 	{"auth_file_quota_snapshots", "auth_subject_id"},
 	{"auth_file_quota_snapshot_points", "auth_subject_id"},
 	{"identity_fingerprints", "auth_subject_id"},
 	{"request_logs", "auth_subject_id"},
-	{"usage_rollup_buckets", "auth_subject_id"},
 }
 
 // subjectAccountKeyTables key fingerprint rows by account_key, which is defined
@@ -206,6 +206,18 @@ func mergeLegacyAuthSubjectDB(db *sql.DB, legacyID string, identity *AuthSubject
 		return err
 	}
 	if err := mergeLegacySubjectQuotaCyclesTx(tx, legacyID, identity.ID); err != nil {
+		return err
+	}
+	if err := mergeLegacyAccountStatusTx(tx, legacyID, identity.ID); err != nil {
+		return err
+	}
+	if err := mergeLegacyTenantQuotaCyclesTx(tx, legacyID, identity.ID); err != nil {
+		return err
+	}
+	if err := mergeLegacySubjectUsageDailyTx(tx, legacyID, identity.ID); err != nil {
+		return err
+	}
+	if err := mergeLegacyUsageRollupBucketsTx(tx, legacyID, identity.ID); err != nil {
 		return err
 	}
 	for _, target := range subjectRewriteTables {
@@ -404,6 +416,125 @@ func mergeLegacySubjectQuotaCyclesTx(tx *sql.Tx, legacyID, subjectID string) err
 		subjectID, legacyID,
 	); err != nil {
 		return fmt.Errorf("usage: rewrite legacy quota cycles: %w", err)
+	}
+	return nil
+}
+
+// mergeLegacyAccountStatusTx keeps the newer snapshot per tenant. PK is
+// (tenant_id, auth_subject_id), so rewriting the old id on top of a row the
+// new subject already has is 23505.
+func mergeLegacyAccountStatusTx(tx *sql.Tx, legacyID, subjectID string) error {
+	return mergeLegacyTenantSnapshotTx(
+		tx, "ai_account_status", "auth_subject_id", "updated_at", nil,
+		legacyID, subjectID, "account status",
+	)
+}
+
+// mergeLegacyTenantQuotaCyclesTx is the older per-tenant cycle table
+// (column subject_id). Same collision as ai_account_status.
+func mergeLegacyTenantQuotaCyclesTx(tx *sql.Tx, legacyID, subjectID string) error {
+	return mergeLegacyTenantSnapshotTx(
+		tx, "auth_subject_quota_cycles", "subject_id", "last_verified_at",
+		[]string{"quota_key"}, legacyID, subjectID, "tenant quota cycles",
+	)
+}
+
+func mergeLegacyTenantSnapshotTx(tx *sql.Tx, table, subjectCol, newerCol string, extraMatch []string, legacyID, subjectID, label string) error {
+	match := "legacy.tenant_id = " + table + ".tenant_id"
+	sharedMatch := "shared.tenant_id = " + table + ".tenant_id"
+	for _, column := range extraMatch {
+		match += " AND legacy." + column + " = " + table + "." + column
+		sharedMatch += " AND shared." + column + " = " + table + "." + column
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM `+table+` WHERE `+subjectCol+` = ? AND EXISTS (
+			SELECT 1 FROM `+table+` legacy
+			WHERE legacy.`+subjectCol+` = ? AND `+match+`
+			  AND legacy.`+newerCol+` > `+table+`.`+newerCol+`
+		)`, subjectID, legacyID,
+	); err != nil {
+		return fmt.Errorf("usage: drop stale shared %s: %w", label, err)
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM `+table+` WHERE `+subjectCol+` = ? AND EXISTS (
+			SELECT 1 FROM `+table+` shared
+			WHERE shared.`+subjectCol+` = ? AND `+sharedMatch+`
+		)`, legacyID, subjectID,
+	); err != nil {
+		return fmt.Errorf("usage: drop overlapping legacy %s: %w", label, err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE `+table+` SET `+subjectCol+` = ? WHERE `+subjectCol+` = ?`,
+		subjectID, legacyID,
+	); err != nil {
+		return fmt.Errorf("usage: rewrite legacy %s: %w", label, err)
+	}
+	return nil
+}
+
+func mergeLegacySubjectUsageDailyTx(tx *sql.Tx, legacyID, subjectID string) error {
+	if _, err := tx.Exec(`
+		INSERT INTO auth_subject_usage_daily (
+			tenant_id, auth_subject_id, day_key, request_count, success_count,
+			failure_count, cost_total, updated_at
+		)
+		SELECT tenant_id, ?, day_key, request_count, success_count,
+			failure_count, cost_total, updated_at
+		FROM auth_subject_usage_daily WHERE auth_subject_id = ?
+		ON CONFLICT(tenant_id, auth_subject_id, day_key) DO UPDATE SET
+			request_count = auth_subject_usage_daily.request_count + excluded.request_count,
+			success_count = auth_subject_usage_daily.success_count + excluded.success_count,
+			failure_count = auth_subject_usage_daily.failure_count + excluded.failure_count,
+			cost_total = auth_subject_usage_daily.cost_total + excluded.cost_total,
+			updated_at = CASE WHEN excluded.updated_at > auth_subject_usage_daily.updated_at
+				THEN excluded.updated_at ELSE auth_subject_usage_daily.updated_at END
+	`, subjectID, legacyID); err != nil {
+		return fmt.Errorf("usage: merge legacy subject usage daily: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM auth_subject_usage_daily WHERE auth_subject_id = ?`, legacyID); err != nil {
+		return fmt.Errorf("usage: drop legacy subject usage daily: %w", err)
+	}
+	return nil
+}
+
+func mergeLegacyUsageRollupBucketsTx(tx *sql.Tx, legacyID, subjectID string) error {
+	if _, err := tx.Exec(`
+		INSERT INTO usage_rollup_buckets (
+			tenant_id, bucket_kind, bucket_start, api_key_id, end_user_id, auth_subject_id,
+			model, source, channel_name, request_count, success_count, failure_count,
+			streaming_count, input_tokens, output_tokens, reasoning_tokens, cached_tokens,
+			effective_input_tokens, total_tokens, cost_total, latency_sum_ms, latency_count,
+			first_token_sum_ms, first_token_count, updated_at
+		)
+		SELECT tenant_id, bucket_kind, bucket_start, api_key_id, end_user_id, ?,
+			model, source, channel_name, request_count, success_count, failure_count,
+			streaming_count, input_tokens, output_tokens, reasoning_tokens, cached_tokens,
+			effective_input_tokens, total_tokens, cost_total, latency_sum_ms, latency_count,
+			first_token_sum_ms, first_token_count, updated_at
+		FROM usage_rollup_buckets WHERE auth_subject_id = ?
+		ON CONFLICT(tenant_id, bucket_kind, bucket_start, api_key_id, end_user_id, auth_subject_id, model, source, channel_name) DO UPDATE SET
+			request_count = usage_rollup_buckets.request_count + excluded.request_count,
+			success_count = usage_rollup_buckets.success_count + excluded.success_count,
+			failure_count = usage_rollup_buckets.failure_count + excluded.failure_count,
+			streaming_count = usage_rollup_buckets.streaming_count + excluded.streaming_count,
+			input_tokens = usage_rollup_buckets.input_tokens + excluded.input_tokens,
+			output_tokens = usage_rollup_buckets.output_tokens + excluded.output_tokens,
+			reasoning_tokens = usage_rollup_buckets.reasoning_tokens + excluded.reasoning_tokens,
+			cached_tokens = usage_rollup_buckets.cached_tokens + excluded.cached_tokens,
+			effective_input_tokens = usage_rollup_buckets.effective_input_tokens + excluded.effective_input_tokens,
+			total_tokens = usage_rollup_buckets.total_tokens + excluded.total_tokens,
+			cost_total = usage_rollup_buckets.cost_total + excluded.cost_total,
+			latency_sum_ms = usage_rollup_buckets.latency_sum_ms + excluded.latency_sum_ms,
+			latency_count = usage_rollup_buckets.latency_count + excluded.latency_count,
+			first_token_sum_ms = usage_rollup_buckets.first_token_sum_ms + excluded.first_token_sum_ms,
+			first_token_count = usage_rollup_buckets.first_token_count + excluded.first_token_count,
+			updated_at = CASE WHEN excluded.updated_at > usage_rollup_buckets.updated_at
+				THEN excluded.updated_at ELSE usage_rollup_buckets.updated_at END
+	`, subjectID, legacyID); err != nil {
+		return fmt.Errorf("usage: merge legacy usage rollup buckets: %w", err)
+	}
+	if _, err := tx.Exec(`DELETE FROM usage_rollup_buckets WHERE auth_subject_id = ?`, legacyID); err != nil {
+		return fmt.Errorf("usage: drop legacy usage rollup buckets: %w", err)
 	}
 	return nil
 }

--- a/internal/usage/auth_subject_identity_migration_test.go
+++ b/internal/usage/auth_subject_identity_migration_test.go
@@ -470,6 +470,91 @@ func TestMergeLegacyAccountIDSubjectFoldsPersonalCodexUsage(t *testing.T) {
 	}
 }
 
+func seedTenantAccountStatus(t *testing.T, tenantID, subjectID, planType string, at time.Time) {
+	t.Helper()
+	stamp := at.UTC().Format(time.RFC3339Nano)
+	if _, err := getDB().Exec(`
+		INSERT INTO ai_account_status (
+			tenant_id, auth_subject_id, auth_index, provider, refresh_state, health_status,
+			plan_type, updated_at
+		) VALUES (?, ?, '', 'codex', 'idle', 'ok', ?, ?)
+	`, tenantID, subjectID, planType, stamp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedUsageRollup(t *testing.T, tenantID, subjectID, day string, requests int64, at time.Time) {
+	t.Helper()
+	stamp := at.UTC().Format(time.RFC3339Nano)
+	if _, err := getDB().Exec(`
+		INSERT INTO usage_rollup_buckets (
+			tenant_id, bucket_kind, bucket_start, api_key_id, end_user_id, auth_subject_id,
+			model, source, channel_name, request_count, success_count, updated_at
+		) VALUES (?, 'day', ?, '', '', ?, 'gpt-5', 'codex', '', ?, ?, ?)
+	`, tenantID, day, subjectID, requests, requests, stamp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Live after #970: both halves already had ai_account_status and rollup rows
+// for the same tenant. Blind UPDATE of auth_subject_id hit 23505, the
+// transaction rolled back, and the card kept reading a few hours of traffic.
+func TestMergeLegacyAccountIDSubjectFoldsWhenBothHalvesHaveStatus(t *testing.T) {
+	initSharedSubjectTestDB(t)
+	resetMergedLegacySubjects()
+
+	auth := codexMemberTestAuth(sharedSubjectTenantA, "lanlan.json", "acct-lanlan", "user-lanlan", "lanlan@example.com")
+	identity := ResolveAuthSubjectIdentity(auth)
+	legacyID := LegacyAccountIDAuthSubjectID(auth)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedLegacyAuthSubjectRow(t, legacyID, "codex", "account_id", now.Add(-48*time.Hour))
+	for i := 0; i < 20; i++ {
+		projectSubjectRequest(t, legacyID, now.Add(-24*time.Hour), 50)
+	}
+	if err := UpsertAIAccountSubject(identity); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		projectSubjectRequest(t, identity.ID, now.Add(-time.Hour), 10)
+	}
+	seedTenantAccountStatus(t, sharedSubjectTenantA, legacyID, "plus", now.Add(-24*time.Hour))
+	seedTenantAccountStatus(t, sharedSubjectTenantA, identity.ID, "pro", now.Add(-time.Minute))
+	seedUsageRollup(t, sharedSubjectTenantA, legacyID, "2026-09-01", 12, now.Add(-24*time.Hour))
+	seedUsageRollup(t, sharedSubjectTenantA, identity.ID, "2026-09-01", 4, now.Add(-time.Hour))
+
+	if err := MergeLegacySplitAuthSubject(auth, identity); err != nil {
+		t.Fatalf("merge collided on status/rollup: %v", err)
+	}
+	got := readSubjectSummary(t, identity.ID)
+	if got.RequestTotal != 23 {
+		t.Fatalf("merged lifetime = %+v, want 23", got)
+	}
+	var plan string
+	if err := getDB().QueryRow(
+		`SELECT plan_type FROM ai_account_status WHERE tenant_id = ? AND auth_subject_id = ?`,
+		sharedSubjectTenantA, identity.ID,
+	).Scan(&plan); err != nil {
+		t.Fatal(err)
+	}
+	if plan != "pro" {
+		t.Fatalf("kept plan %q, want the newer pro snapshot", plan)
+	}
+	var rollup int64
+	if err := getDB().QueryRow(`
+		SELECT request_count FROM usage_rollup_buckets
+		WHERE tenant_id = ? AND auth_subject_id = ? AND bucket_start = '2026-09-01'
+	`, sharedSubjectTenantA, identity.ID).Scan(&rollup); err != nil {
+		t.Fatal(err)
+	}
+	if rollup != 16 {
+		t.Fatalf("rollup = %d, want 12+4", rollup)
+	}
+	if leftoverAuthSubjectRows(t, legacyID) != 0 {
+		t.Fatalf("legacy account_id subject left rows behind")
+	}
+}
+
 func TestBindingHookMergesLegacyAccountIDSubjectOnAuthLoad(t *testing.T) {
 	initSharedSubjectTestDB(t)
 	resetMergedLegacySubjects()


### PR DESCRIPTION
## 范围

#970 已经能找到旧 `account_id` 主体，并且 `share_eligible` 能写进 Postgres。折并下一步对 `ai_account_status` / `usage_rollup_buckets` 做 `UPDATE auth_subject_id`，这两张表的主键包含该列。同一个租户在新旧 subject 上都有行时 Postgres 报 23505，整笔事务回滚。卡片继续只显示升级后几小时的调用。

线上 `dev-098fb23` 日志：

```
usage: rewrite ai_account_status.auth_subject_id: duplicate key value violates unique constraint "ai_account_status_pkey"
```

- 快照表（status、tenant quota cycles）保留较新的那一行
- 计数表（daily、rollup）做 SUM 再删旧行
- 主键不含 subject id 的表仍走原来的 rewrite

Docker / 原生 Postgres 升过 #927 后都会踩同一条路；#970 把 bool 修好之后，这条 23505 就是下一扇门。

codeProxy 没有改动：卡片读的就是后端 subject 用量。

## 验证

- 回归测试先在未修复代码上失败（`UNIQUE constraint failed: ai_account_status.tenant_id, ai_account_status.auth_subject_id`），修好后通过
- `./scripts/ci-pr.sh` 本地通过