### PR TITLE
fix(usage): add last-dash suffix stripping to pricing lookup fallback chain

### DIFF
--- a/internal/usage/pricing_db.go
+++ b/internal/usage/pricing_db.go
@@ -385,6 +385,16 @@ func modelPricingLookupModelIDs(modelID string) []string {
 			add(suffix)
 		}
 	}
+	// Strip the last dash-segment from the providerless ID so models with
+	// variant/tier suffixes like "-thinking", "-agent", "-high", "-low",
+	// "-medium", "-extra-low", "-tiered" can inherit pricing from the base model.
+	providerless := modelID
+	if idx := strings.Index(modelID, "/"); idx > 0 {
+		providerless = modelID[idx+1:]
+	}
+	if lastDash := strings.LastIndex(providerless, "-"); lastDash > 0 {
+		add(providerless[:lastDash])
+	}
 	return lookupIDs
 }
 

--- a/internal/usage/pricing_db_test.go
+++ b/internal/usage/pricing_db_test.go
@@ -545,3 +545,59 @@ func TestQueryTodayCostByKeyResetsDaily(t *testing.T) {
 		t.Fatalf("today cost = %v, want 4", got)
 	}
 }
+
+func TestCalculateCostSuffixStrippedFallback(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "claude-opus-4-6",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  15,
+		OutputPricePerMillion: 75,
+		Source:                "user",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+
+	// Models with variant/tier suffixes should fall back to the base via
+	// last-dash stripping: "claude-opus-4-6-thinking" → "claude-opus-4-6".
+	for _, modelID := range []string{
+		"claude-opus-4-6-thinking",
+		"claude-opus-4-6-agent",
+		"claude-opus-4-6-high",
+		"claude-opus-4-6-low",
+		"claude-opus-4-6-medium",
+		"claude-opus-4-6-tiered",
+	} {
+		wantCost := 15.0 + 75.0
+		cost := CalculateCostV2(modelID, TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
+		if math.Abs(cost-wantCost) > 1e-12 {
+			t.Fatalf("CalculateCostV2(%q) = %v, want %v", modelID, cost, wantCost)
+		}
+	}
+}
+
+func TestCalculateCostSuffixStrippedFallbackWithProvider(t *testing.T) {
+	initModelConfigTestDB(t)
+
+	if err := UpsertModelConfig(ModelConfigRow{
+		ModelID:               "gemini-2.5-flash",
+		Enabled:               true,
+		PricingMode:           "token",
+		InputPricePerMillion:  0.3,
+		OutputPricePerMillion: 2.5,
+		Source:                "openrouter",
+	}); err != nil {
+		t.Fatalf("UpsertModelConfig(base) error = %v", err)
+	}
+
+	// Provider-prefixed model with suffix should still fall back via
+	// providerless last-dash stripping: "ollama/gemini-2.5-flash-thinking"
+	// → providerless "gemini-2.5-flash-thinking" → last-dash "gemini-2.5-flash".
+	wantCost := 0.3 + 2.5
+	cost := CalculateCostV2("ollama/gemini-2.5-flash-thinking", TokenStats{InputTokens: 1_000_000, OutputTokens: 1_000_000})
+	if math.Abs(cost-wantCost) > 1e-12 {
+		t.Fatalf("CalculateCostV2(ollama/gemini-2.5-flash-thinking) = %v, want %v", cost, wantCost)
+	}
+}


### PR DESCRIPTION
## 问题

模型名包含 `-thinking`、`-agent`、`-high`、`-low`、`-medium`、`-extra-low`、`-tiered` 等后缀时，定价查找无法回退到基础模型，导致显示「未定价」。

## 根因

`modelPricingLookupModelIDs` 的回退候选链只有 prefix stripping（剥离第一个 `-` 前的部分），缺少 suffix stripping（剥离最后一个 `-` 后的部分）。

例如 `claude-opus-4-6-thinking`：
- 现有候选：`claude-opus-4-6-thinking`、`opus-4-6-thinking`
- 缺失候选：`claude-opus-4-6`（基础模型，有定价）

## 修复

在 lookup 链末尾新增最低优先级候选：从 providerless model ID 的最后一个 `-` 处截断。

- `claude-opus-4-6-thinking` → 新增候选 `claude-opus-4-6`
- `ollama/gemini-2.5-flash-thinking` → 新增候选 `gemini-2.5-flash`

候选顺序与 codeProxy `modelConfigLookupIds` 保持对齐。

## 验证

```
go test ./internal/usage/ -run TestCalculateCostSuffix -v   # 2 PASS
go test ./internal/usage/ -run TestCalculateCost            # 19 PASS (无回归)
```