### PR TITLE
fix(usage): return every weekly quota series in group overview

### DIFF
--- a/internal/api/handlers/management/usage_logs_group_trend_series_test.go
+++ b/internal/api/handlers/management/usage_logs_group_trend_series_test.go
@@ -1,0 +1,80 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestGetAuthFileGroupTrendReturnsEveryWeeklySeries(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dbPath := filepath.Join(t.TempDir(), "usage.db")
+	if err := usage.InitDB(dbPath, config.RequestLogStorageConfig{}, time.UTC); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		usage.CloseDB()
+		_ = os.Remove(dbPath)
+	})
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	auth, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID: "ag-trend", FileName: "ag.json", Provider: "antigravity", Label: "AG",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gemini, third, fiveHour := 40.0, 80.0, 10.0
+	week := usage.WeeklyQuotaWindowSeconds
+	now := time.Now().UTC()
+	if err := usage.RecordQuotaSnapshotPoints(auth.Index, "antigravity", []usage.QuotaSnapshotPoint{
+		{RecordedAt: now, QuotaKey: "antigravity:gemini_weekly", QuotaLabel: "Gemini Models", Percent: &gemini, WindowSeconds: week},
+		{RecordedAt: now, QuotaKey: "antigravity:3p_weekly", QuotaLabel: "Claude and GPT models", Percent: &third, WindowSeconds: week},
+		{RecordedAt: now, QuotaKey: "antigravity:gemini_5h", QuotaLabel: "Gemini Models", Percent: &fiveHour, WindowSeconds: 5 * 60 * 60},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := usage.RecordDailyQuotaSnapshot(auth.Index, "antigravity", map[string]*float64{
+		"antigravity:gemini_weekly": &gemini,
+		"antigravity:3p_weekly":     &third,
+		"antigravity:gemini_5h":     &fiveHour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/usage/auth-file-group-trend?group=antigravity&days=7", nil)
+	(&Handler{cfg: &config.Config{}, authManager: manager}).UsageLogs().GetAuthFileGroupTrend(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		QuotaSeries []struct {
+			QuotaKey string `json:"quota_key"`
+		} `json:"quota_series"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, len(payload.QuotaSeries))
+	for _, item := range payload.QuotaSeries {
+		got = append(got, item.QuotaKey)
+	}
+	if len(got) != 2 || got[0] == "antigravity:gemini_5h" || got[1] == "antigravity:gemini_5h" {
+		t.Fatalf("quota_series = %v, want both weeklies and no 5h", got)
+	}
+}

--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -22,14 +22,21 @@ func (s *Service) AuthFileGroupTrend(group string, days int) (AuthFileGroupTrend
 	if points == nil {
 		points = []usage.DailyCountPoint{}
 	}
-	quotaPoints, err := usage.QueryDailyQuotaByAuthIndexesForTenant(s.tenantID, authIndexes, "code_week", days)
+	quotaSeries, err := usage.QueryWeeklyQuotaSeriesByAuthIndexesForTenant(s.tenantID, authIndexes, days)
 	if err != nil {
 		return AuthFileGroupTrendResponse{}, err
 	}
-	if quotaPoints == nil {
-		quotaPoints = []usage.DailyQuotaPoint{}
+	if quotaSeries == nil {
+		quotaSeries = []usage.DailyQuotaSeries{}
 	}
-	return AuthFileGroupTrendResponse{Days: days, Group: group, Points: points, QuotaPoints: quotaPoints}, nil
+	quotaPoints := []usage.DailyQuotaPoint{}
+	if len(quotaSeries) > 0 && quotaSeries[0].Points != nil {
+		quotaPoints = quotaSeries[0].Points
+	}
+	return AuthFileGroupTrendResponse{
+		Days: days, Group: group, Points: points,
+		QuotaPoints: quotaPoints, QuotaSeries: quotaSeries,
+	}, nil
 }
 
 func (s *Service) AuthFileTrend(authIndex string, days int, hours int) (int, any) {

--- a/internal/management/usagelogs/types.go
+++ b/internal/management/usagelogs/types.go
@@ -41,10 +41,11 @@ type LogContentResponse struct {
 }
 
 type AuthFileGroupTrendResponse struct {
-	Days        int                     `json:"days"`
-	Group       string                  `json:"group"`
-	Points      []usage.DailyCountPoint `json:"points"`
-	QuotaPoints []usage.DailyQuotaPoint `json:"quota_points"`
+	Days        int                      `json:"days"`
+	Group       string                   `json:"group"`
+	Points      []usage.DailyCountPoint  `json:"points"`
+	QuotaPoints []usage.DailyQuotaPoint  `json:"quota_points"`
+	QuotaSeries []usage.DailyQuotaSeries `json:"quota_series"`
 }
 
 type AuthFileTrendResponse struct {

--- a/internal/usage/quota_snapshot_store.go
+++ b/internal/usage/quota_snapshot_store.go
@@ -114,6 +114,141 @@ func QueryDailyQuotaByAuthIndexesForTenant(tenantID string, authIndexes []string
 	return result, rows.Err()
 }
 
+type weeklyQuotaKey struct {
+	QuotaKey      string
+	QuotaLabel    string
+	WindowSeconds int64
+}
+
+// QueryWeeklyQuotaSeriesByAuthIndexesForTenant averages every weekly window
+// those credentials recorded, one series per quota_key. The old group-trend
+// path only asked for code_week, so Antigravity's gemini_weekly / 3p_weekly
+// (and Claude seven_day, extra Codex weeks) never reached the chart.
+func QueryWeeklyQuotaSeriesByAuthIndexesForTenant(tenantID string, authIndexes []string, days int) ([]DailyQuotaSeries, error) {
+	tenantID = normalizeTenantID(tenantID)
+	if days < 1 {
+		days = 7
+	}
+	normalized := uniqueAuthIndexes(authIndexes)
+	if len(normalized) == 0 {
+		return []DailyQuotaSeries{}, nil
+	}
+	keys, err := listWeeklyQuotaKeysForAuthIndexes(tenantID, normalized, days)
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		// Hosts that only ever wrote the Codex/Kimi daily snapshot still need a
+		// series, otherwise the chart goes blank after this path stopped
+		// hardcoding code_week.
+		points, err := QueryDailyQuotaByAuthIndexesForTenant(tenantID, normalized, "code_week", days)
+		if err != nil {
+			return nil, err
+		}
+		if len(points) == 0 {
+			return []DailyQuotaSeries{}, nil
+		}
+		return []DailyQuotaSeries{{
+			QuotaKey:      "code_week",
+			WindowSeconds: WeeklyQuotaWindowSeconds,
+			Points:        points,
+		}}, nil
+	}
+	out := make([]DailyQuotaSeries, 0, len(keys))
+	for _, key := range keys {
+		points, err := QueryDailyQuotaByAuthIndexesForTenant(tenantID, normalized, key.QuotaKey, days)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, DailyQuotaSeries{
+			QuotaKey:      key.QuotaKey,
+			QuotaLabel:    key.QuotaLabel,
+			WindowSeconds: key.WindowSeconds,
+			Points:        points,
+		})
+	}
+	return out, nil
+}
+
+func uniqueAuthIndexes(authIndexes []string) []string {
+	seen := make(map[string]struct{}, len(authIndexes))
+	out := make([]string, 0, len(authIndexes))
+	for _, idx := range authIndexes {
+		idx = strings.TrimSpace(idx)
+		if idx == "" {
+			continue
+		}
+		if _, ok := seen[idx]; ok {
+			continue
+		}
+		seen[idx] = struct{}{}
+		out = append(out, idx)
+	}
+	return out
+}
+
+func listWeeklyQuotaKeysForAuthIndexes(tenantID string, authIndexes []string, days int) ([]weeklyQuotaKey, error) {
+	db := getDB()
+	if db == nil {
+		return nil, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(authIndexes)), ",")
+	args := make([]interface{}, 0, len(authIndexes)+3)
+	args = append(args, tenantID, CutoffStartUTC(days).UTC().Format(time.RFC3339Nano), WeeklyQuotaWindowSeconds)
+	for _, idx := range authIndexes {
+		args = append(args, idx)
+	}
+	q := fmt.Sprintf(`
+		SELECT quota_key, MAX(quota_label), MAX(window_seconds)
+		FROM auth_file_quota_snapshot_points
+		WHERE tenant_id = ? AND recorded_at >= ? AND window_seconds >= ? AND auth_index IN (%s) AND percent IS NOT NULL
+		GROUP BY quota_key
+		ORDER BY quota_key ASC
+	`, placeholders)
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage: list weekly quota keys: %w", err)
+	}
+	defer rows.Close()
+	keys := make([]weeklyQuotaKey, 0)
+	for rows.Next() {
+		var key weeklyQuotaKey
+		var label sql.NullString
+		if err := rows.Scan(&key.QuotaKey, &label, &key.WindowSeconds); err != nil {
+			return nil, fmt.Errorf("usage: scan weekly quota keys: %w", err)
+		}
+		if label.Valid {
+			key.QuotaLabel = strings.TrimSpace(label.String)
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return preferPrimaryWeeklyQuotaKey(keys), nil
+}
+
+func preferPrimaryWeeklyQuotaKey(keys []weeklyQuotaKey) []weeklyQuotaKey {
+	if len(keys) < 2 {
+		return keys
+	}
+	primary := -1
+	for i, key := range keys {
+		if key.QuotaKey == "code_week" {
+			primary = i
+			break
+		}
+	}
+	if primary <= 0 {
+		return keys
+	}
+	out := make([]weeklyQuotaKey, 0, len(keys))
+	out = append(out, keys[primary])
+	out = append(out, keys[:primary]...)
+	out = append(out, keys[primary+1:]...)
+	return out
+}
+
 func QueryQuotaSnapshotPoints(authIndex string, start, end time.Time) ([]QuotaSnapshotPoint, error) {
 	return QueryQuotaSnapshotPointsForTenant(systemTenantID, authIndex, start, end)
 }

--- a/internal/usage/quota_snapshot_weekly_series_test.go
+++ b/internal/usage/quota_snapshot_weekly_series_test.go
@@ -1,0 +1,104 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func seedDailyQuotaSnapshot(t *testing.T, tenantID, dateKey, authIndex, quotaKey string, percent float64) {
+	t.Helper()
+	if _, err := getDB().Exec(`
+		INSERT INTO auth_file_quota_snapshots (
+			tenant_id, date_key, auth_index, auth_subject_id, provider, quota_key, percent, recorded_at
+		) VALUES (?, ?, ?, '', 'antigravity', ?, ?, ?)
+	`, tenantID, dateKey, authIndex, quotaKey, percent, time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestQueryWeeklyQuotaSeriesReturnsEveryWeeklyWindow(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	const tenantID = "00000000-0000-0000-0000-0000000000aa"
+	now := time.Now().UTC()
+	gemini, third := 51.0, 90.0
+	fiveHour := 72.0
+	week := WeeklyQuotaWindowSeconds
+	indexes := []string{"ag-1", "ag-2"}
+	for _, idx := range indexes {
+		if err := RecordQuotaSnapshotPointsIdentityForTenant(tenantID, idx, "sub-"+idx, "antigravity", []QuotaSnapshotPoint{
+			{RecordedAt: now, QuotaKey: "antigravity:gemini_weekly", QuotaLabel: "Gemini Models", Percent: &gemini, WindowSeconds: week},
+			{RecordedAt: now, QuotaKey: "antigravity:3p_weekly", QuotaLabel: "Claude and GPT models", Percent: &third, WindowSeconds: week},
+			{RecordedAt: now, QuotaKey: "antigravity:gemini_5h", QuotaLabel: "Gemini Models", Percent: &fiveHour, WindowSeconds: 5 * 60 * 60},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	today := localDayKeyAt(now)
+	seedDailyQuotaSnapshot(t, tenantID, today, "ag-1", "antigravity:gemini_weekly", 40)
+	seedDailyQuotaSnapshot(t, tenantID, today, "ag-2", "antigravity:gemini_weekly", 60)
+	seedDailyQuotaSnapshot(t, tenantID, today, "ag-1", "antigravity:3p_weekly", 80)
+	seedDailyQuotaSnapshot(t, tenantID, today, "ag-2", "antigravity:3p_weekly", 100)
+	seedDailyQuotaSnapshot(t, tenantID, today, "ag-1", "antigravity:gemini_5h", 10)
+
+	series, err := QueryWeeklyQuotaSeriesByAuthIndexesForTenant(tenantID, indexes, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(series) != 2 {
+		t.Fatalf("series = %+v, want gemini_weekly and 3p_weekly only", series)
+	}
+	byKey := map[string]DailyQuotaSeries{}
+	for _, item := range series {
+		byKey[item.QuotaKey] = item
+	}
+	geminiSeries, ok := byKey["antigravity:gemini_weekly"]
+	if !ok || geminiSeries.QuotaLabel != "Gemini Models" {
+		t.Fatalf("gemini series = %+v", geminiSeries)
+	}
+	thirdSeries, ok := byKey["antigravity:3p_weekly"]
+	if !ok {
+		t.Fatalf("missing 3p series: %+v", series)
+	}
+	avg := func(item DailyQuotaSeries) float64 {
+		for _, point := range item.Points {
+			if point.Date == today && point.Percent != nil {
+				return *point.Percent
+			}
+		}
+		t.Fatalf("no today point in %+v", item)
+		return 0
+	}
+	if got := avg(geminiSeries); got != 50 {
+		t.Fatalf("gemini avg = %v, want 50", got)
+	}
+	if got := avg(thirdSeries); got != 90 {
+		t.Fatalf("3p avg = %v, want 90", got)
+	}
+}
+
+func TestPreferPrimaryWeeklyQuotaKeyPutsCodeWeekFirst(t *testing.T) {
+	got := preferPrimaryWeeklyQuotaKey([]weeklyQuotaKey{
+		{QuotaKey: "antigravity:gemini_weekly"},
+		{QuotaKey: "code_week"},
+		{QuotaKey: "review_week"},
+	})
+	if len(got) != 3 || got[0].QuotaKey != "code_week" {
+		t.Fatalf("order = %+v, want code_week first", got)
+	}
+}
+
+func TestQueryWeeklyQuotaSeriesFallsBackToCodeWeekDailySnapshots(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	const tenantID = "00000000-0000-0000-0000-0000000000bb"
+	today := localDayKeyAt(time.Now().UTC())
+	seedDailyQuotaSnapshot(t, tenantID, today, "codex-1", "code_week", 70)
+	series, err := QueryWeeklyQuotaSeriesByAuthIndexesForTenant(tenantID, []string{"codex-1"}, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(series) != 1 || series[0].QuotaKey != "code_week" {
+		t.Fatalf("series = %+v, want code_week fallback", series)
+	}
+}

--- a/internal/usage/request_log_auth_trends.go
+++ b/internal/usage/request_log_auth_trends.go
@@ -24,6 +24,17 @@ type DailyQuotaPoint struct {
 	Samples int64    `json:"samples"`
 }
 
+// DailyQuotaSeries is one weekly window averaged across a group of credentials
+// for each local day. Group overview charts one line per series so providers
+// with two weeklies (Antigravity Gemini + 3P) are not collapsed into a single
+// code_week number that those accounts never wrote.
+type DailyQuotaSeries struct {
+	QuotaKey      string            `json:"quota_key"`
+	QuotaLabel    string            `json:"quota_label"`
+	WindowSeconds int64             `json:"window_seconds"`
+	Points        []DailyQuotaPoint `json:"points"`
+}
+
 type HourlyCountPoint struct {
 	Hour     string `json:"hour"`
 	Requests int64  `json:"requests"`


### PR DESCRIPTION
## Summary
Group overview trend previously hardcoded `quota_key = code_week`. Antigravity never writes that key (it stores `antigravity:gemini_weekly` and `antigravity:3p_weekly`), so the green weekly line was empty and hover on 09-01 showed `-`.

This expands `/usage/auth-file-group-trend` with `quota_series[]`: every weekly window (`window_seconds >= 604800`) averaged across the group, one series per key. `quota_points` stays as the primary series (`code_week` if present, else the first weekly) so older frontends keep working.

## Verification
- `./scripts/ci-pr.sh` (structure, gofmt, secret scan, `go test ./...`, golangci-lint, `go build`)
- `go test ./internal/usage/ ./internal/api/handlers/management/ -run 'TestQueryWeeklyQuotaSeries|TestPreferPrimaryWeeklyQuotaKey|TestGetAuthFileGroupTrend'`

Companion frontend PR in codeProxy: `feat/group-weekly-quota-series`.