### PR TITLE
feat(codex): support per-account fingerprint convergence mode override

### DIFF
--- a/internal/management/authfiles/codex_convergence_mode.go
+++ b/internal/management/authfiles/codex_convergence_mode.go
@@ -1,0 +1,42 @@
+package authfiles
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+const (
+	metadataKeyCodexConvergenceMode = "codex_convergence_mode"
+)
+
+// CodexConvergenceModePayload returns the configured per-account convergence mode if present and valid.
+func CodexConvergenceModePayload(auth *coreauth.Auth) string {
+	if !isCodexOAuthAdmissionAuth(auth) || auth.Metadata == nil {
+		return ""
+	}
+	for _, key := range []string{metadataKeyCodexConvergenceMode, "convergence_mode", "codex-convergence-mode"} {
+		if raw, ok := auth.Metadata[key]; ok {
+			if s, isStr := raw.(string); isStr {
+				trimmed := strings.TrimSpace(strings.ToLower(s))
+				if config.IsValidCodexFingerprintConvergenceMode(trimmed) {
+					return trimmed
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func ensureCodexConvergenceModeEditable(auth *coreauth.Auth, mode string) error {
+	if !isCodexOAuthAdmissionAuth(auth) {
+		return fmt.Errorf("codex convergence mode is only supported for Codex OAuth auth files")
+	}
+	trimmed := strings.TrimSpace(strings.ToLower(mode))
+	if trimmed != "" && !config.IsValidCodexFingerprintConvergenceMode(trimmed) {
+		return fmt.Errorf("invalid codex convergence mode %q: must be empty, off, device, session, or full", mode)
+	}
+	return nil
+}

--- a/internal/management/authfiles/entry.go
+++ b/internal/management/authfiles/entry.go
@@ -148,5 +148,8 @@ func BuildEntry(auth *coreauth.Auth, opts EntryOptions) map[string]any {
 	if limit := auth.ConcurrencyLimit(); limit > 0 {
 		entry["concurrency_limit"] = limit
 	}
+	if mode := CodexConvergenceModePayload(auth); mode != "" {
+		entry["codex_convergence_mode"] = mode
+	}
 	return entry
 }

--- a/internal/management/authfiles/patch.go
+++ b/internal/management/authfiles/patch.go
@@ -32,6 +32,8 @@ type FieldPatch struct {
 	UsingAPI *bool `json:"using_api"`
 	// ConcurrencyLimit sets the max active concurrent requests for this account (0 = unlimited).
 	ConcurrencyLimit *int `json:"concurrency_limit"`
+	// CodexConvergenceMode overrides the global identity fingerprint convergence mode for Codex accounts (off, device, session, full, or empty to inherit).
+	CodexConvergenceMode *string `json:"codex_convergence_mode"`
 }
 
 type FieldPatchOptions struct {
@@ -296,6 +298,30 @@ func ApplyFieldPatch(auth *coreauth.Auth, patch FieldPatch, opts FieldPatchOptio
 			delete(attrs, "concurrency")
 			delete(attrs, "concurrency-limit")
 			attrs["concurrency_limit"] = fmt.Sprintf("%d", limit)
+		}
+		changed = true
+	}
+	if patch.CodexConvergenceMode != nil {
+		mode := strings.TrimSpace(strings.ToLower(*patch.CodexConvergenceMode))
+		if err := ensureCodexConvergenceModeEditable(auth, mode); err != nil {
+			return result, err
+		}
+		metadata := ensureMetadata(auth)
+		attrs := ensureAttributes(auth)
+		if mode == "" {
+			delete(metadata, metadataKeyCodexConvergenceMode)
+			delete(metadata, "convergence_mode")
+			delete(metadata, "codex-convergence-mode")
+			delete(attrs, metadataKeyCodexConvergenceMode)
+			delete(attrs, "convergence_mode")
+			delete(attrs, "codex-convergence-mode")
+		} else {
+			delete(metadata, "convergence_mode")
+			delete(metadata, "codex-convergence-mode")
+			metadata[metadataKeyCodexConvergenceMode] = mode
+			delete(attrs, "convergence_mode")
+			delete(attrs, "codex-convergence-mode")
+			attrs[metadataKeyCodexConvergenceMode] = mode
 		}
 		changed = true
 	}

--- a/internal/management/authfiles/patch_test.go
+++ b/internal/management/authfiles/patch_test.go
@@ -457,6 +457,52 @@ func TestApplyFieldPatchUpdatesConcurrencyLimit(t *testing.T) {
 	}
 }
 
+func TestApplyFieldPatchUpdatesCodexConvergenceMode(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "codex-convergence",
+		Provider: "codex",
+		Metadata: map[string]any{},
+	}
+
+	mode := "session"
+	_, err := ApplyFieldPatch(auth, FieldPatch{CodexConvergenceMode: &mode}, FieldPatchOptions{})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	if got, _ := auth.Metadata["codex_convergence_mode"].(string); got != "session" {
+		t.Fatalf("metadata codex_convergence_mode = %v, want session", got)
+	}
+	if got := auth.Attributes["codex_convergence_mode"]; got != "session" {
+		t.Fatalf("attributes codex_convergence_mode = %q, want session", got)
+	}
+	if got := CodexConvergenceModePayload(auth); got != "session" {
+		t.Fatalf("CodexConvergenceModePayload() = %q, want session", got)
+	}
+
+	// Clearing it
+	emptyMode := ""
+	_, err = ApplyFieldPatch(auth, FieldPatch{CodexConvergenceMode: &emptyMode}, FieldPatchOptions{})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() clear error = %v", err)
+	}
+	if _, ok := auth.Metadata["codex_convergence_mode"]; ok {
+		t.Fatalf("metadata codex_convergence_mode should be deleted, got %v", auth.Metadata["codex_convergence_mode"])
+	}
+	if _, ok := auth.Attributes["codex_convergence_mode"]; ok {
+		t.Fatalf("attributes codex_convergence_mode should be deleted, got %v", auth.Attributes["codex_convergence_mode"])
+	}
+	if got := CodexConvergenceModePayload(auth); got != "" {
+		t.Fatalf("CodexConvergenceModePayload() = %q, want empty", got)
+	}
+
+	// Invalid mode should be rejected
+	invalidMode := "invalid_mode"
+	_, err = ApplyFieldPatch(auth, FieldPatch{CodexConvergenceMode: &invalidMode}, FieldPatchOptions{})
+	if err == nil {
+		t.Fatal("ApplyFieldPatch() want error for invalid mode, got nil")
+	}
+}
+
 func TestApplyFieldPatchRejectsNoFields(t *testing.T) {
 	auth := &coreauth.Auth{ID: "empty", Provider: "codex"}
 

--- a/internal/runtime/executor/codex_fingerprint_convergence.go
+++ b/internal/runtime/executor/codex_fingerprint_convergence.go
@@ -87,6 +87,8 @@ func codexConvergedIDsFromContext(ctx context.Context) *codexConvergedIDs {
 // codexConvergenceMode reports the effective convergence strength for this auth.
 // Convergence rides on the Codex identity fingerprint switch: turning that off
 // means "leave my outbound identity alone", which has to include device ids.
+// When an auth file explicitly specifies a convergence mode in its metadata or attributes,
+// that per-account override takes precedence over the global config.
 func codexConvergenceMode(cfg *config.Config, auth *cliproxyauth.Auth) string {
 	if cfg == nil || !cfg.IdentityFingerprint.Codex.Enabled {
 		return config.CodexFingerprintConvergenceOff
@@ -96,6 +98,29 @@ func codexConvergenceMode(cfg *config.Config, auth *cliproxyauth.Auth) string {
 	if auth != nil && auth.Attributes != nil {
 		if strings.TrimSpace(auth.Attributes["api_key"]) != "" {
 			return config.CodexFingerprintConvergenceOff
+		}
+	}
+	// Check per-account override first from attributes then metadata.
+	if auth != nil {
+		for _, key := range []string{"codex_convergence_mode", "convergence_mode", "codex-convergence-mode"} {
+			if auth.Attributes != nil {
+				if v, ok := auth.Attributes[key]; ok {
+					v = strings.TrimSpace(strings.ToLower(v))
+					if config.IsValidCodexFingerprintConvergenceMode(v) {
+						return v
+					}
+				}
+			}
+			if auth.Metadata != nil {
+				if raw, ok := auth.Metadata[key]; ok {
+					if s, isStr := raw.(string); isStr {
+						s = strings.TrimSpace(strings.ToLower(s))
+						if config.IsValidCodexFingerprintConvergenceMode(s) {
+							return s
+						}
+					}
+				}
+			}
 		}
 	}
 	mode := strings.TrimSpace(strings.ToLower(cfg.IdentityFingerprint.Codex.ConvergenceMode))

--- a/internal/runtime/executor/codex_fingerprint_convergence_test.go
+++ b/internal/runtime/executor/codex_fingerprint_convergence_test.go
@@ -364,4 +364,17 @@ func TestCodexConvergenceDefaultsToDeviceMode(t *testing.T) {
 	if got := codexConvergenceMode(cfg, codexConvergenceTestAuth("codex-bogus")); got != config.CodexFingerprintConvergenceDevice {
 		t.Fatalf("convergence mode = %q, want an unrecognised value to fall back to the default", got)
 	}
+
+	// Test per-account override
+	authWithOverride := codexConvergenceTestAuth("codex-override")
+	authWithOverride.Metadata["codex_convergence_mode"] = "full"
+	if got := codexConvergenceMode(cfg, authWithOverride); got != config.CodexFingerprintConvergenceFull {
+		t.Fatalf("convergence mode = %q, want overridden full", got)
+	}
+
+	authWithOff := codexConvergenceTestAuth("codex-off")
+	authWithOff.Attributes = map[string]string{"codex_convergence_mode": "off"}
+	if got := codexConvergenceMode(cfg, authWithOff); got != config.CodexFingerprintConvergenceOff {
+		t.Fatalf("convergence mode = %q, want overridden off", got)
+	}
 }


### PR DESCRIPTION
### Summary
- Allow configuring `codex_convergence_mode` (`off`, `device`, `session`, `full`) on a per-account basis in Codex auth files (or clear to inherit global setting).
- Read per-account `codex_convergence_mode` override during Codex fingerprint convergence resolution before falling back to global configuration.
- Exposed via auth files patch and entry endpoints.