### PR TITLE
feat(codex): support per-account codex service tier policy (fast/priority, flex, pass, drop)

### DIFF
--- a/internal/management/authfiles/codex_service_tier.go
+++ b/internal/management/authfiles/codex_service_tier.go
@@ -1,0 +1,74 @@
+package authfiles
+
+import (
+	"fmt"
+	"strings"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+const (
+	metadataKeyCodexServiceTier = "codex_service_tier"
+)
+
+// ValidCodexServiceTier reports whether tier is a known service_tier action/value.
+// Supported values:
+//   - "auto" / "" (default): inherit / standard behavior (strip non-standard service_tier)
+//   - "pass": passthrough client-provided service_tier (normalize "fast" -> "priority")
+//   - "priority": force fast/priority tier (always inject service_tier="priority")
+//   - "flex": force flex tier (always inject service_tier="flex")
+//   - "drop": completely strip service_tier from outbound request
+func ValidCodexServiceTier(tier string) bool {
+	switch strings.TrimSpace(strings.ToLower(tier)) {
+	case "", "auto", "default", "pass", "priority", "fast", "flex", "drop":
+		return true
+	default:
+		return false
+	}
+}
+
+// NormalizeCodexServiceTier canonicalizes the configured service_tier option.
+func NormalizeCodexServiceTier(tier string) string {
+	switch strings.TrimSpace(strings.ToLower(tier)) {
+	case "priority", "fast":
+		return "priority"
+	case "pass":
+		return "pass"
+	case "flex":
+		return "flex"
+	case "drop":
+		return "drop"
+	case "default", "auto":
+		return "default"
+	default:
+		return ""
+	}
+}
+
+// CodexServiceTierPayload returns the configured per-account service_tier option if present.
+func CodexServiceTierPayload(auth *coreauth.Auth) string {
+	if !isCodexOAuthAdmissionAuth(auth) || auth.Metadata == nil {
+		return ""
+	}
+	for _, key := range []string{metadataKeyCodexServiceTier, "service_tier", "codex-service-tier"} {
+		if raw, ok := auth.Metadata[key]; ok {
+			if s, isStr := raw.(string); isStr {
+				if norm := NormalizeCodexServiceTier(s); norm != "" {
+					return norm
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func ensureCodexServiceTierEditable(auth *coreauth.Auth, tier string) error {
+	if !isCodexOAuthAdmissionAuth(auth) {
+		return fmt.Errorf("codex service tier is only supported for Codex OAuth auth files")
+	}
+	trimmed := strings.TrimSpace(strings.ToLower(tier))
+	if trimmed != "" && !ValidCodexServiceTier(trimmed) {
+		return fmt.Errorf("invalid codex service tier %q: must be empty, pass, priority (fast), flex, or drop", tier)
+	}
+	return nil
+}

--- a/internal/management/authfiles/entry.go
+++ b/internal/management/authfiles/entry.go
@@ -151,5 +151,8 @@ func BuildEntry(auth *coreauth.Auth, opts EntryOptions) map[string]any {
 	if mode := CodexConvergenceModePayload(auth); mode != "" {
 		entry["codex_convergence_mode"] = mode
 	}
+	if tier := CodexServiceTierPayload(auth); tier != "" {
+		entry["codex_service_tier"] = tier
+	}
 	return entry
 }

--- a/internal/management/authfiles/patch.go
+++ b/internal/management/authfiles/patch.go
@@ -34,6 +34,8 @@ type FieldPatch struct {
 	ConcurrencyLimit *int `json:"concurrency_limit"`
 	// CodexConvergenceMode overrides the global identity fingerprint convergence mode for Codex accounts (off, device, session, full, or empty to inherit).
 	CodexConvergenceMode *string `json:"codex_convergence_mode"`
+	// CodexServiceTier sets how service_tier (Fast/Priority/Flex) is handled for this account: "pass", "priority", "flex", "drop", or empty/default to inherit.
+	CodexServiceTier *string `json:"codex_service_tier"`
 }
 
 type FieldPatchOptions struct {
@@ -322,6 +324,31 @@ func ApplyFieldPatch(auth *coreauth.Auth, patch FieldPatch, opts FieldPatchOptio
 			delete(attrs, "convergence_mode")
 			delete(attrs, "codex-convergence-mode")
 			attrs[metadataKeyCodexConvergenceMode] = mode
+		}
+		changed = true
+	}
+	if patch.CodexServiceTier != nil {
+		rawTier := strings.TrimSpace(strings.ToLower(*patch.CodexServiceTier))
+		if err := ensureCodexServiceTierEditable(auth, rawTier); err != nil {
+			return result, err
+		}
+		tier := NormalizeCodexServiceTier(rawTier)
+		metadata := ensureMetadata(auth)
+		attrs := ensureAttributes(auth)
+		if tier == "" || tier == "default" {
+			delete(metadata, metadataKeyCodexServiceTier)
+			delete(metadata, "service_tier")
+			delete(metadata, "codex-service-tier")
+			delete(attrs, metadataKeyCodexServiceTier)
+			delete(attrs, "service_tier")
+			delete(attrs, "codex-service-tier")
+		} else {
+			delete(metadata, "service_tier")
+			delete(metadata, "codex-service-tier")
+			metadata[metadataKeyCodexServiceTier] = tier
+			delete(attrs, "service_tier")
+			delete(attrs, "codex-service-tier")
+			attrs[metadataKeyCodexServiceTier] = tier
 		}
 		changed = true
 	}

--- a/internal/management/authfiles/patch_test.go
+++ b/internal/management/authfiles/patch_test.go
@@ -503,6 +503,52 @@ func TestApplyFieldPatchUpdatesCodexConvergenceMode(t *testing.T) {
 	}
 }
 
+func TestApplyFieldPatchUpdatesCodexServiceTier(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "codex-tier",
+		Provider: "codex",
+		Metadata: map[string]any{},
+	}
+
+	tier := "priority"
+	_, err := ApplyFieldPatch(auth, FieldPatch{CodexServiceTier: &tier}, FieldPatchOptions{})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() error = %v", err)
+	}
+	if got, _ := auth.Metadata["codex_service_tier"].(string); got != "priority" {
+		t.Fatalf("metadata codex_service_tier = %v, want priority", got)
+	}
+	if got := auth.Attributes["codex_service_tier"]; got != "priority" {
+		t.Fatalf("attributes codex_service_tier = %q, want priority", got)
+	}
+	if got := CodexServiceTierPayload(auth); got != "priority" {
+		t.Fatalf("CodexServiceTierPayload() = %q, want priority", got)
+	}
+
+	// Clearing it
+	emptyTier := ""
+	_, err = ApplyFieldPatch(auth, FieldPatch{CodexServiceTier: &emptyTier}, FieldPatchOptions{})
+	if err != nil {
+		t.Fatalf("ApplyFieldPatch() clear error = %v", err)
+	}
+	if _, ok := auth.Metadata["codex_service_tier"]; ok {
+		t.Fatalf("metadata codex_service_tier should be deleted, got %v", auth.Metadata["codex_service_tier"])
+	}
+	if _, ok := auth.Attributes["codex_service_tier"]; ok {
+		t.Fatalf("attributes codex_service_tier should be deleted, got %v", auth.Attributes["codex_service_tier"])
+	}
+	if got := CodexServiceTierPayload(auth); got != "" {
+		t.Fatalf("CodexServiceTierPayload() = %q, want empty", got)
+	}
+
+	// Invalid tier should be rejected
+	invalidTier := "turbo"
+	_, err = ApplyFieldPatch(auth, FieldPatch{CodexServiceTier: &invalidTier}, FieldPatchOptions{})
+	if err == nil {
+		t.Fatal("ApplyFieldPatch() want error for invalid tier, got nil")
+	}
+}
+
 func TestApplyFieldPatchRejectsNoFields(t *testing.T) {
 	auth := &coreauth.Auth{ID: "empty", Provider: "codex"}
 

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -160,6 +160,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	})
 	body = maybeEnsureCodexImageGenerationTool(body, auth, execCtx.BaseModel, codexAdmissionHeadersFromContext(execCtx.Context))
 	body = applyCodexConvergenceClientMetadata(body, convergedIDs)
+	body = applyCodexServiceTierPolicy(body, execCtx.Request.Payload, auth)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(execCtx.Context, auth, execCtx.SourceFormat, url, req, body)
@@ -372,6 +373,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	body = ensureTranslatedCodexModel(body, execCtx.BaseModel)
 	body = maybeEnsureCodexImageGenerationTool(body, auth, execCtx.BaseModel, codexAdmissionHeadersFromContext(execCtx.Context))
 	body = applyCodexConvergenceClientMetadata(body, convergedIDs)
+	body = applyCodexServiceTierPolicy(body, execCtx.Request.Payload, auth)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(execCtx.Context, auth, execCtx.SourceFormat, url, req, body)

--- a/internal/runtime/executor/codex_service_tier.go
+++ b/internal/runtime/executor/codex_service_tier.go
@@ -1,0 +1,89 @@
+package executor
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
+)
+
+// applyCodexServiceTierPolicy adjusts the top-level "service_tier" on an outbound Codex request body
+// based on per-account settings (e.g. "pass", "priority", "flex", "drop") and incoming client payload.
+func applyCodexServiceTierPolicy(body []byte, originalClientPayload []byte, auth *cliproxyauth.Auth) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	tierPolicy := ""
+	if auth != nil {
+		for _, key := range []string{"codex_service_tier", "service_tier", "codex-service-tier"} {
+			if auth.Attributes != nil {
+				if v := strings.TrimSpace(strings.ToLower(auth.Attributes[key])); v != "" {
+					tierPolicy = v
+					break
+				}
+			}
+			if auth.Metadata != nil {
+				if raw, ok := auth.Metadata[key]; ok {
+					if s, isStr := raw.(string); isStr {
+						if v := strings.TrimSpace(strings.ToLower(s)); v != "" {
+							tierPolicy = v
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	switch tierPolicy {
+	case "priority", "fast":
+		// Force priority / fast mode on outbound body
+		return util.MutateTopLevelObject(body, map[string][]byte{
+			"service_tier": util.JSONString("priority"),
+		}, nil)
+
+	case "flex":
+		// Force flex mode on outbound body
+		return util.MutateTopLevelObject(body, map[string][]byte{
+			"service_tier": util.JSONString("flex"),
+		}, nil)
+
+	case "pass":
+		// Passthrough client's requested service_tier (if any), normalized:
+		// "fast" -> "priority", valid tiers kept, invalid dropped
+		clientTier := ""
+		if len(originalClientPayload) > 0 {
+			clientTier = strings.TrimSpace(strings.ToLower(gjson.GetBytes(originalClientPayload, "service_tier").String()))
+		}
+		if clientTier == "" {
+			clientTier = strings.TrimSpace(strings.ToLower(gjson.GetBytes(body, "service_tier").String()))
+		}
+
+		switch clientTier {
+		case "priority", "fast":
+			return util.MutateTopLevelObject(body, map[string][]byte{
+				"service_tier": util.JSONString("priority"),
+			}, nil)
+		case "flex":
+			return util.MutateTopLevelObject(body, map[string][]byte{
+				"service_tier": util.JSONString("flex"),
+			}, nil)
+		case "auto", "default", "scale":
+			return util.MutateTopLevelObject(body, map[string][]byte{
+				"service_tier": util.JSONString(clientTier),
+			}, nil)
+		default:
+			return util.MutateTopLevelObject(body, nil, []string{"service_tier"})
+		}
+
+	case "drop":
+		// Completely filter / strip service_tier
+		return util.MutateTopLevelObject(body, nil, []string{"service_tier"})
+
+	default:
+		// Default / auto / empty: standard safe behavior (strip service_tier from outbound body
+		// unless explicitly enabled, avoiding unexpected charges or 400 errors from upstream).
+		return util.MutateTopLevelObject(body, nil, []string{"service_tier"})
+	}
+}

--- a/internal/runtime/executor/codex_service_tier_test.go
+++ b/internal/runtime/executor/codex_service_tier_test.go
@@ -1,0 +1,73 @@
+package executor
+
+import (
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
+)
+
+func TestApplyCodexServiceTierPolicy(t *testing.T) {
+	baseBody := []byte(`{"model":"gpt-5.5","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}]}`)
+
+	t.Run("default strips service_tier", func(t *testing.T) {
+		clientBody := []byte(`{"model":"gpt-5.5","service_tier":"fast","input":"hello"}`)
+		out := applyCodexServiceTierPolicy(baseBody, clientBody, nil)
+		if gjson.GetBytes(out, "service_tier").Exists() {
+			t.Fatalf("expected service_tier to be stripped, got %v", gjson.GetBytes(out, "service_tier").String())
+		}
+	})
+
+	t.Run("drop explicitly strips service_tier", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Metadata: map[string]any{"codex_service_tier": "drop"},
+		}
+		clientBody := []byte(`{"model":"gpt-5.5","service_tier":"priority","input":"hello"}`)
+		out := applyCodexServiceTierPolicy(baseBody, clientBody, auth)
+		if gjson.GetBytes(out, "service_tier").Exists() {
+			t.Fatalf("expected service_tier to be stripped, got %v", gjson.GetBytes(out, "service_tier").String())
+		}
+	})
+
+	t.Run("priority forces priority tier", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Metadata: map[string]any{"codex_service_tier": "priority"},
+		}
+		out := applyCodexServiceTierPolicy(baseBody, nil, auth)
+		if got := gjson.GetBytes(out, "service_tier").String(); got != "priority" {
+			t.Fatalf("expected service_tier=priority, got %q", got)
+		}
+	})
+
+	t.Run("flex forces flex tier", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Attributes: map[string]string{"codex_service_tier": "flex"},
+		}
+		out := applyCodexServiceTierPolicy(baseBody, nil, auth)
+		if got := gjson.GetBytes(out, "service_tier").String(); got != "flex" {
+			t.Fatalf("expected service_tier=flex, got %q", got)
+		}
+	})
+
+	t.Run("pass passes client fast as priority", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Metadata: map[string]any{"codex_service_tier": "pass"},
+		}
+		clientBody := []byte(`{"model":"gpt-5.5","service_tier":"fast","input":"hello"}`)
+		out := applyCodexServiceTierPolicy(baseBody, clientBody, auth)
+		if got := gjson.GetBytes(out, "service_tier").String(); got != "priority" {
+			t.Fatalf("expected service_tier=priority when pass receives fast, got %q", got)
+		}
+	})
+
+	t.Run("pass drops unknown/invalid client tier", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{
+			Metadata: map[string]any{"codex_service_tier": "pass"},
+		}
+		clientBody := []byte(`{"model":"gpt-5.5","service_tier":"turbo","input":"hello"}`)
+		out := applyCodexServiceTierPolicy(baseBody, clientBody, auth)
+		if gjson.GetBytes(out, "service_tier").Exists() {
+			t.Fatalf("expected unknown tier to be dropped, got %v", gjson.GetBytes(out, "service_tier").String())
+		}
+	})
+}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -118,6 +118,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		body, _ = sjson.SetBytes(body, "instructions", "")
 	}
 	body = maybeEnsureCodexImageGenerationTool(body, auth, execCtx.BaseModel, codexAdmissionHeadersFromContext(execCtx.Context))
+	body = applyCodexServiceTierPolicy(body, execCtx.Request.Payload, auth)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -314,6 +315,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 
 	body = execCtx.ApplyPayloadConfig(body, body)
 	body = maybeEnsureCodexImageGenerationTool(body, auth, execCtx.BaseModel, codexAdmissionHeadersFromContext(execCtx.Context))
+	body = applyCodexServiceTierPolicy(body, execCtx.Request.Payload, auth)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)


### PR DESCRIPTION
### Summary
- Add `codex_service_tier` field to Codex auth files to configure Fast (priority), Flex, Pass (client passthrough with normalization), or Drop (strip service_tier).
- In `CodexExecutor` and `CodexWebsocketsExecutor`, apply `applyCodexServiceTierPolicy` before sending outbound requests.
- Does not modify restricted `internal/translator` files.