### PR TITLE
feat(antigravity): isolate quota pools between Gemini and Claude/GPT families

### DIFF
--- a/sdk/cliproxy/auth/antigravity_quota_family.go
+++ b/sdk/cliproxy/auth/antigravity_quota_family.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"strings"
+)
+
+// AntigravityQuotaFamily identifies the quota pool family for Antigravity models.
+type AntigravityQuotaFamily string
+
+const (
+	AntigravityFamilyGemini AntigravityQuotaFamily = "gemini"
+	AntigravityFamilyClaude AntigravityQuotaFamily = "claude"
+	AntigravityFamilyOther  AntigravityQuotaFamily = "other"
+)
+
+// ModelAntigravityQuotaFamily returns the quota family for an Antigravity model ID.
+// Gemini models (gemini-*) share the Gemini quota pool.
+// Claude and GPT models (claude-*, gpt-*) share the 3rd-party quota pool.
+func ModelAntigravityQuotaFamily(model string) AntigravityQuotaFamily {
+	m := strings.ToLower(strings.TrimSpace(model))
+	switch {
+	case strings.Contains(m, "claude"),
+		strings.Contains(m, "opus"),
+		strings.Contains(m, "sonnet"),
+		strings.Contains(m, "haiku"),
+		strings.Contains(m, "gpt"):
+		return AntigravityFamilyClaude
+	case strings.HasPrefix(m, "gemini"),
+		strings.Contains(m, "image"),
+		strings.Contains(m, "imagen"):
+		return AntigravityFamilyGemini
+	default:
+		return AntigravityFamilyOther
+	}
+}
+
+// IsAntigravityAuth reports whether an Auth instance belongs to the Antigravity provider.
+func IsAntigravityAuth(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(auth.Provider), "antigravity") {
+		return true
+	}
+	if auth.Metadata != nil {
+		if typ, _ := auth.Metadata["type"].(string); strings.EqualFold(strings.TrimSpace(typ), "antigravity") {
+			return true
+		}
+	}
+	return false
+}
+
+// AreAntigravityModelsSameFamily reports whether two Antigravity models share the same quota pool.
+func AreAntigravityModelsSameFamily(modelA, modelB string) bool {
+	famA := ModelAntigravityQuotaFamily(modelA)
+	famB := ModelAntigravityQuotaFamily(modelB)
+	if famA == AntigravityFamilyOther || famB == AntigravityFamilyOther {
+		return strings.EqualFold(strings.TrimSpace(modelA), strings.TrimSpace(modelB))
+	}
+	return famA == famB
+}

--- a/sdk/cliproxy/auth/antigravity_quota_family_test.go
+++ b/sdk/cliproxy/auth/antigravity_quota_family_test.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestModelAntigravityQuotaFamily(t *testing.T) {
+	tests := []struct {
+		model string
+		want  AntigravityQuotaFamily
+	}{
+		{"gemini-2.5-pro", AntigravityFamilyGemini},
+		{"gemini-2.5-flash", AntigravityFamilyGemini},
+		{"gemini-3.1-pro-high", AntigravityFamilyGemini},
+		{"claude-3-7-sonnet", AntigravityFamilyClaude},
+		{"claude-3-5-sonnet", AntigravityFamilyClaude},
+		{"claude-opus-4-6-thinking", AntigravityFamilyClaude},
+		{"gpt-4o", AntigravityFamilyClaude},
+		{"unknown-model", AntigravityFamilyOther},
+	}
+
+	for _, tt := range tests {
+		got := ModelAntigravityQuotaFamily(tt.model)
+		if got != tt.want {
+			t.Errorf("ModelAntigravityQuotaFamily(%q) = %v, want %v", tt.model, got, tt.want)
+		}
+	}
+}
+
+func TestAreAntigravityModelsSameFamily(t *testing.T) {
+	if !AreAntigravityModelsSameFamily("gemini-2.5-pro", "gemini-2.5-flash") {
+		t.Error("expected gemini models to share family")
+	}
+	if !AreAntigravityModelsSameFamily("claude-3-7-sonnet", "gpt-4o") {
+		t.Error("expected claude and gpt to share family")
+	}
+	if AreAntigravityModelsSameFamily("gemini-2.5-pro", "claude-3-7-sonnet") {
+		t.Error("expected gemini and claude NOT to share family")
+	}
+}

--- a/sdk/cliproxy/auth/antigravity_quota_isolation_test.go
+++ b/sdk/cliproxy/auth/antigravity_quota_isolation_test.go
@@ -1,0 +1,114 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAntigravityQuotaPoolIsolation_Selector(t *testing.T) {
+	now := time.Now()
+	recoverAt := now.Add(2 * time.Hour)
+
+	// An Antigravity account where Claude is exhausted, but Gemini has not been exhausted
+	auth := &Auth{
+		ID:       "antigravity-test-1",
+		Provider: "antigravity",
+		ModelStates: map[string]*ModelState{
+			"claude-3-7-sonnet": {
+				Unavailable:    true,
+				NextRetryAfter: recoverAt,
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: recoverAt,
+				},
+			},
+			"gemini-2.5-pro": {
+				Status: StatusActive,
+			},
+		},
+	}
+
+	// Update aggregated availability
+	updateAggregatedAvailability(auth, now)
+
+	// Global auth quota exceeded should be FALSE because only Claude family is exhausted, Gemini is fine
+	if auth.Quota.Exceeded {
+		t.Fatalf("auth.Quota.Exceeded = true, want false because Gemini pool is healthy")
+	}
+
+	// Calling claude-3-7-sonnet should be BLOCKED
+	blockedClaude, reasonClaude, _ := isAuthBlockedForModel(auth, "claude-3-7-sonnet", now)
+	if !blockedClaude {
+		t.Errorf("claude-3-7-sonnet should be blocked")
+	}
+	if reasonClaude != blockReasonCooldown {
+		t.Errorf("reasonClaude = %v, want %v", reasonClaude, blockReasonCooldown)
+	}
+
+	// Calling another Claude model (e.g. claude-3-5-sonnet) should also be BLOCKED due to same family
+	blockedClaudeOther, _, _ := isAuthBlockedForModel(auth, "claude-3-5-sonnet", now)
+	if !blockedClaudeOther {
+		t.Errorf("claude-3-5-sonnet should be blocked because Claude family pool is exhausted")
+	}
+
+	// Calling gemini-2.5-pro should NOT be blocked!
+	blockedGemini, reasonGemini, _ := isAuthBlockedForModel(auth, "gemini-2.5-pro", now)
+	if blockedGemini {
+		t.Errorf("gemini-2.5-pro should NOT be blocked, got reason = %v", reasonGemini)
+	}
+
+	// Calling an uninitialized Gemini model (e.g. gemini-2.5-flash) should NOT be blocked!
+	blockedGeminiFlash, reasonGeminiFlash, _ := isAuthBlockedForModel(auth, "gemini-2.5-flash", now)
+	if blockedGeminiFlash {
+		t.Errorf("gemini-2.5-flash should NOT be blocked, got reason = %v", reasonGeminiFlash)
+	}
+}
+
+func TestAntigravityQuotaPoolIsolation_BothExhausted(t *testing.T) {
+	now := time.Now()
+	recoverAt := now.Add(2 * time.Hour)
+
+	// An Antigravity account where BOTH Gemini and Claude are exhausted
+	auth := &Auth{
+		ID:       "antigravity-test-both",
+		Provider: "antigravity",
+		ModelStates: map[string]*ModelState{
+			"claude-3-7-sonnet": {
+				Unavailable:    true,
+				NextRetryAfter: recoverAt,
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: recoverAt,
+				},
+			},
+			"gemini-2.5-pro": {
+				Unavailable:    true,
+				NextRetryAfter: recoverAt,
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: recoverAt,
+				},
+			},
+		},
+	}
+
+	updateAggregatedAvailability(auth, now)
+
+	// When both pools are exhausted, auth.Quota.Exceeded SHOULD be true
+	if !auth.Quota.Exceeded {
+		t.Fatalf("auth.Quota.Exceeded = false, want true because all families are exhausted")
+	}
+
+	// Both models should be blocked
+	blockedClaude, _, _ := isAuthBlockedForModel(auth, "claude-3-7-sonnet", now)
+	if !blockedClaude {
+		t.Errorf("claude-3-7-sonnet should be blocked")
+	}
+	blockedGemini, _, _ := isAuthBlockedForModel(auth, "gemini-2.5-pro", now)
+	if !blockedGemini {
+		t.Errorf("gemini-2.5-pro should be blocked")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_result_state.go
+++ b/sdk/cliproxy/auth/conductor_result_state.go
@@ -95,6 +95,44 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	} else {
 		auth.NextRetryAfter = time.Time{}
 	}
+
+	// For Antigravity, only set auth.Quota.Exceeded = true if ALL active families are exhausted.
+	// If only Gemini is exhausted while Claude is fine (or vice versa), the auth level quota
+	// is NOT globally exceeded, preventing global 429 lockout and top-level error badges.
+	if IsAntigravityAuth(auth) {
+		famGeminiExceeded := false
+		famClaudeExceeded := false
+		hasGemini := false
+		hasClaude := false
+		for m, state := range auth.ModelStates {
+			if state == nil {
+				continue
+			}
+			fam := ModelAntigravityQuotaFamily(m)
+			if fam == AntigravityFamilyGemini {
+				hasGemini = true
+				if state.Quota.Exceeded && activeModelQuotaCooldown(state, now) {
+					famGeminiExceeded = true
+				}
+			} else if fam == AntigravityFamilyClaude {
+				hasClaude = true
+				if state.Quota.Exceeded && activeModelQuotaCooldown(state, now) {
+					famClaudeExceeded = true
+				}
+			}
+		}
+		// If both exist, both must be exceeded; if only one exists, that one must be exceeded
+		allFamiliesExceeded := false
+		if hasGemini && hasClaude {
+			allFamiliesExceeded = famGeminiExceeded && famClaudeExceeded
+		} else if hasGemini {
+			allFamiliesExceeded = famGeminiExceeded
+		} else if hasClaude {
+			allFamiliesExceeded = famClaudeExceeded
+		}
+		quotaExceeded = allFamiliesExceeded
+	}
+
 	if quotaExceeded {
 		auth.Quota.Exceeded = true
 		auth.Quota.RecoveryRequired = quotaRecoveryRequired

--- a/sdk/cliproxy/auth/selector_availability.go
+++ b/sdk/cliproxy/auth/selector_availability.go
@@ -304,7 +304,9 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	// we should block *all* model requests for that auth until recovery, even if per-model
 	// state hasn't been initialized yet. This prevents clients from burning extra upstream
 	// requests by switching models during the same quota window.
-	if auth.Quota.Exceeded {
+	// Exception: Antigravity has separate quota pools for Gemini vs Claude/GPT.
+	// A quota exhaustion on one pool should NOT block requests for the other pool.
+	if auth.Quota.Exceeded && (!IsAntigravityAuth(auth) || isAntigravityExhaustedForModel(auth, model, now)) {
 		next := auth.Quota.NextRecoverAt
 		if quotaNeedsConfirmedRecovery(auth.Quota, now) || (!next.IsZero() && next.After(now)) {
 			if auth.NextRetryAfter.After(now) && (next.IsZero() || auth.NextRetryAfter.Before(next)) {
@@ -360,6 +362,22 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 				}
 				return false, blockReasonNone, time.Time{}
 			}
+			// If this specific model has no state yet, check if other models in the same Antigravity family are in cooldown
+			if IsAntigravityAuth(auth) {
+				fam := ModelAntigravityQuotaFamily(model)
+				for m, s := range auth.ModelStates {
+					if s == nil || !s.Quota.Exceeded {
+						continue
+					}
+					if ModelAntigravityQuotaFamily(m) == fam && activeModelQuotaCooldown(s, now) {
+						next := s.Quota.NextRecoverAt
+						if s.NextRetryAfter.After(now) && (next.IsZero() || s.NextRetryAfter.Before(next)) {
+							next = s.NextRetryAfter
+						}
+						return true, blockReasonCooldown, next
+					}
+				}
+			}
 		}
 		return false, blockReasonNone, time.Time{}
 	}
@@ -377,4 +395,30 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 		return true, blockReasonOther, next
 	}
 	return false, blockReasonNone, time.Time{}
+}
+
+func isAntigravityExhaustedForModel(auth *Auth, model string, now time.Time) bool {
+	if model == "" {
+		// No specific model requested: if any model has quota left, don't block auth-wide
+		hasRemaining := false
+		for _, s := range auth.ModelStates {
+			if s != nil && !activeModelQuotaCooldown(s, now) {
+				hasRemaining = true
+				break
+			}
+		}
+		return !hasRemaining
+	}
+	targetFamily := ModelAntigravityQuotaFamily(model)
+	// If any model in the target family has an active quota cooldown, block it
+	for m, s := range auth.ModelStates {
+		if s == nil || !s.Quota.Exceeded {
+			continue
+		}
+		if ModelAntigravityQuotaFamily(m) == targetFamily && activeModelQuotaCooldown(s, now) {
+			return true
+		}
+	}
+	// Target family has no active cooldown -> not exhausted
+	return false
 }


### PR DESCRIPTION
### Summary
- Antigravity separates quotas into distinct pools: Gemini models and 3rd-party models (Claude/GPT).
- Do not set `auth.Quota.Exceeded = true` on Antigravity accounts unless *all* active families are exhausted.
- In `isAuthBlockedForModel`, check family-level cooldowns so an exhausted Claude quota only blocks Claude/GPT models while leaving Gemini models active and routeable (and vice versa).
- Add unit tests verifying selection and quota isolation.