### PR TITLE
fix(antigravity): keep auth active and clear auth error when not all quota pools are exhausted

### DIFF
--- a/sdk/cliproxy/auth/antigravity_quota_isolation_test.go
+++ b/sdk/cliproxy/auth/antigravity_quota_isolation_test.go
@@ -36,6 +36,9 @@ func TestAntigravityQuotaPoolIsolation_Selector(t *testing.T) {
 	if auth.Quota.Exceeded {
 		t.Fatalf("auth.Quota.Exceeded = true, want false because Gemini pool is healthy")
 	}
+	if auth.Status == StatusError {
+		t.Fatalf("auth.Status = StatusError, want StatusActive when not all pools exhausted")
+	}
 
 	// Calling claude-3-7-sonnet should be BLOCKED
 	blockedClaude, reasonClaude, _ := isAuthBlockedForModel(auth, "claude-3-7-sonnet", now)

--- a/sdk/cliproxy/auth/conductor_result_state.go
+++ b/sdk/cliproxy/auth/conductor_result_state.go
@@ -99,6 +99,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	// For Antigravity, only set auth.Quota.Exceeded = true if ALL active families are exhausted.
 	// If only Gemini is exhausted while Claude is fine (or vice versa), the auth level quota
 	// is NOT globally exceeded, preventing global 429 lockout and top-level error badges.
+	// Also, clear auth-level Status / StatusMessage / LastError if they came from single-family quota exhaustion.
 	if IsAntigravityAuth(auth) {
 		famGeminiExceeded := false
 		famClaudeExceeded := false
@@ -131,6 +132,14 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 			allFamiliesExceeded = famClaudeExceeded
 		}
 		quotaExceeded = allFamiliesExceeded
+
+		// If not all families are exceeded, auth is still partially healthy.
+		// Clear auth-level error status so it does not report a global 429.
+		if !allFamiliesExceeded && auth.Status == StatusError && !allUnavailable {
+			auth.Status = StatusActive
+			auth.StatusMessage = ""
+			auth.LastError = nil
+		}
 	}
 
 	if quotaExceeded {


### PR DESCRIPTION
### Summary
- When an Antigravity account has only one quota pool exhausted (e.g. Gemini exhausted while Claude is active), keep `auth.Status = StatusActive` and clear `auth.LastError`.
- Prevents spurious global 429 status and errors on the account card while healthy pools remain usable.