### PR TITLE
feat(warmup): add batch warmup endpoint and account inclusions/exclusions in policies

### DIFF
--- a/internal/api/handlers/management/auth_files_warmup.go
+++ b/internal/api/handlers/management/auth_files_warmup.go
@@ -45,6 +45,26 @@ func (h *Handler) PostWarmupAccount(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"result": res})
 }
 
+// PostWarmupBatch triggers a staggered warmup for multiple accounts.
+func (h *Handler) PostWarmupBatch(c *gin.Context) {
+	var req struct {
+		AuthIDs []string `json:"auth_ids" binding:"required"`
+		PoolID  string   `json:"pool_id"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	count, err := h.warmupService().WarmupBatchAccounts(c.Request.Context(), req.AuthIDs, req.PoolID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"dispatched": count})
+}
+
 // GetWarmupPolicies returns all configured warmup policies.
 func (h *Handler) GetWarmupPolicies(c *gin.Context) {
 	tenantID := effectiveTenantID(c)

--- a/internal/api/routes/management_auth_routes.go
+++ b/internal/api/routes/management_auth_routes.go
@@ -38,6 +38,7 @@ func registerManagementAuthRoutes(group *gin.RouterGroup, h *managementhandlers.
 
 	group.GET("/auth-files/warmup/targets", h.GetWarmupAccountTargets)
 	group.POST("/auth-files/warmup/run", h.PostWarmupAccount)
+	group.POST("/auth-files/warmup/batch", h.PostWarmupBatch)
 	group.GET("/auth-files/warmup/policies", h.GetWarmupPolicies)
 	group.POST("/auth-files/warmup/policies", h.PostWarmupPolicy)
 }

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 334; got != want {
+	if got, want := len(routes), 335; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -457,6 +457,7 @@ func expectedManagementRoutes() []string {
 		"POST /v0/management/api-key-entries/daily-spending/reset",
 		"POST /v0/management/api-key-entries/period-spending/reset",
 		"POST /v0/management/auth-files",
+		"POST /v0/management/auth-files/warmup/batch",
 		"POST /v0/management/auth-files/warmup/policies",
 		"POST /v0/management/auth-files/warmup/run",
 		"POST /v0/management/iflow-auth-url",

--- a/internal/management/warmup/batch_policy_test.go
+++ b/internal/management/warmup/batch_policy_test.go
@@ -1,0 +1,89 @@
+package warmup_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/management/warmup"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestBatchWarmupAndPolicyExclusions(t *testing.T) {
+	registry := warmup.NewDriverRegistry()
+	mockD := &mockTestDriver{
+		executeFn: func(ctx context.Context, auth *coreauth.Auth, target warmup.Target) (*warmup.Result, error) {
+			return &warmup.Result{
+				AuthID:     auth.ID,
+				PoolID:     target.PoolID,
+				Success:    true,
+				StatusCode: 200,
+			}, nil
+		},
+	}
+	registry.Register(mockD)
+
+	authMgr := coreauth.NewManager(nil, nil, nil)
+	auth1 := &coreauth.Auth{ID: "acc-1", Provider: "mock", FileName: "acc-1.json"}
+	auth2 := &coreauth.Auth{ID: "acc-2", Provider: "mock", FileName: "acc-2.json"}
+	auth3 := &coreauth.Auth{ID: "acc-3", Provider: "mock", FileName: "acc-3.json"}
+
+	_, _ = authMgr.Register(context.Background(), auth1)
+	_, _ = authMgr.Register(context.Background(), auth2)
+	_, _ = authMgr.Register(context.Background(), auth3)
+
+	queue := warmup.NewStaggeredQueue(
+		warmup.StaggeredQueueOptions{
+			MaxConcurrency: 2,
+			MinJitter:      1 * time.Millisecond,
+			MaxJitter:      2 * time.Millisecond,
+		},
+		registry,
+		nil,
+	)
+
+	// 1. Test Policy with Account Inclusions & Exclusions
+	now := time.Now()
+	timeMock := func() time.Time { return now }
+
+	scheduler := warmup.NewPolicyScheduler(queue, registry, authMgr)
+	scheduler.SetNowFunc(timeMock)
+
+	// Policy 1: Only includes acc-1 and acc-3
+	pInclusion := warmup.Policy{
+		ID:         "policy-inclusion",
+		TenantID:   "t1",
+		Enabled:    true,
+		Providers:  []string{"mock"},
+		AccountIDs: []string{"acc-1", "acc-3"},
+		DailyWindow: warmup.DailyTimeWindow{
+			Enabled: false,
+		},
+		IntervalSeconds: 3600,
+	}
+	scheduler.AddPolicy(pInclusion)
+	scheduler.EvaluateTick(context.Background())
+
+	policies := scheduler.GetPolicies("t1")
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 policy, got %d", len(policies))
+	}
+	if policies[0].TotalRuns != 1 {
+		t.Fatalf("expected 1 run, got %d", policies[0].TotalRuns)
+	}
+
+	// Policy 2: Excludes acc-2
+	pExclusion := warmup.Policy{
+		ID:              "policy-exclusion",
+		TenantID:        "t1",
+		Enabled:         true,
+		Providers:       []string{"mock"},
+		ExcludedAuthIDs: []string{"acc-2"},
+		DailyWindow: warmup.DailyTimeWindow{
+			Enabled: false,
+		},
+		IntervalSeconds: 3600,
+	}
+	scheduler.AddPolicy(pExclusion)
+	scheduler.EvaluateTick(context.Background())
+}

--- a/internal/management/warmup/policy.go
+++ b/internal/management/warmup/policy.go
@@ -46,8 +46,10 @@ type Policy struct {
 	TenantID        string          `json:"tenant_id"`
 	Name            string          `json:"name"`
 	Enabled         bool            `json:"enabled"`
-	Providers       []string        `json:"providers"` // e.g. ["antigravity", "codex"]
-	PoolIDs         []string        `json:"pool_ids"`  // e.g. ["antigravity:gemini", "antigravity:3p"]
+	Providers       []string        `json:"providers"`                   // e.g. ["antigravity", "codex"]
+	PoolIDs         []string        `json:"pool_ids"`                    // e.g. ["antigravity:gemini", "antigravity:3p"]
+	AccountIDs      []string        `json:"account_ids,omitempty"`       // Specific accounts to target; empty means all matching accounts
+	ExcludedAuthIDs []string        `json:"excluded_auth_ids,omitempty"` // Accounts explicitly excluded from auto warmup
 	StartAt         *time.Time      `json:"start_at,omitempty"`
 	StopAt          *time.Time      `json:"stop_at,omitempty"`
 	DailyWindow     DailyTimeWindow `json:"daily_window"`

--- a/internal/management/warmup/scheduler.go
+++ b/internal/management/warmup/scheduler.go
@@ -169,6 +169,32 @@ func (s *PolicyScheduler) triggerPolicy(ctx context.Context, policy *Policy, now
 		if a == nil || a.Unavailable {
 			continue
 		}
+		// Check explicit account inclusions
+		if len(policy.AccountIDs) > 0 {
+			included := false
+			for _, id := range policy.AccountIDs {
+				if a.ID == id || a.FileName == id {
+					included = true
+					break
+				}
+			}
+			if !included {
+				continue
+			}
+		}
+		// Check explicit account exclusions
+		if len(policy.ExcludedAuthIDs) > 0 {
+			excluded := false
+			for _, id := range policy.ExcludedAuthIDs {
+				if a.ID == id || a.FileName == id {
+					excluded = true
+					break
+				}
+			}
+			if excluded {
+				continue
+			}
+		}
 		if len(policy.Providers) > 0 {
 			match := false
 			for _, p := range policy.Providers {

--- a/internal/management/warmup/service.go
+++ b/internal/management/warmup/service.go
@@ -119,6 +119,45 @@ func (s *Service) WarmupSingleAccount(ctx context.Context, authID string, poolID
 	return res, err
 }
 
+// WarmupBatchAccounts triggers immediate staggered warmup for multiple accounts.
+func (s *Service) WarmupBatchAccounts(ctx context.Context, authIDs []string, poolID string) (int, error) {
+	if s.authMgr == nil {
+		return 0, fmt.Errorf("auth manager unavailable")
+	}
+	if len(authIDs) == 0 {
+		return 0, nil
+	}
+
+	tasks := make([]Task, 0, len(authIDs))
+	now := time.Now()
+	for _, id := range authIDs {
+		auth, ok := s.authMgr.GetByID(id)
+		if !ok || auth == nil {
+			continue
+		}
+		driver, okDriver := s.registry.Get(auth.Provider)
+		if !okDriver {
+			continue
+		}
+		targets := driver.GetTargets(auth)
+		for _, t := range targets {
+			if poolID == "" || t.PoolID == poolID {
+				tasks = append(tasks, Task{
+					ID:        auth.ID + ":" + t.PoolID,
+					Auth:      auth,
+					Target:    t,
+					CreatedAt: now,
+				})
+			}
+		}
+	}
+
+	if len(tasks) > 0 {
+		s.queue.Dispatch(ctx, tasks)
+	}
+	return len(tasks), nil
+}
+
 func (s *Service) GetMetrics() QueueMetrics {
 	return s.queue.GetMetrics()
 }


### PR DESCRIPTION
### Summary
- Adds `POST /v0/management/auth-files/warmup/batch` for staggered batch warmup execution across selected accounts.
- Adds `AccountIDs` (explicit inclusion) and `ExcludedAuthIDs` (explicit exclusion) to `Policy` model to allow fine-grained targeting.
- Updated route snapshot test (335 routes).