### PR TITLE
fix(usagelogs): pass projection quota fields through shared trend merge

### DIFF
--- a/internal/management/usagelogs/trends.go
+++ b/internal/management/usagelogs/trends.go
@@ -100,6 +100,10 @@ func mergeAuthFileTrendShared(tenant, shared AuthFileTrendResponse) AuthFileTren
 		if shared.WeeklyQuotaUsed != nil {
 			out.WeeklyQuotaUsed = shared.WeeklyQuotaUsed
 		}
+		if shared.ProjectionQuotaUsed != nil {
+			out.ProjectionQuotaUsed = shared.ProjectionQuotaUsed
+		}
+		out.ProjectionQuotaAttributable = shared.ProjectionQuotaAttributable
 	}
 	// Prefer richer shared hourly (all tenants); keep tenant-only when shared empty.
 	if sumHourlyRequests(shared.HourlyUsage) > sumHourlyRequests(tenant.HourlyUsage) {

--- a/internal/management/usagelogs/trends_projection_quota_test.go
+++ b/internal/management/usagelogs/trends_projection_quota_test.go
@@ -111,3 +111,30 @@ func TestProjectionQuotaUsedSumsAttributableWindows(t *testing.T) {
 		t.Fatalf("summed projection used=%v, want 15", got)
 	}
 }
+
+func TestMergeAuthFileTrendSharedPassesProjectionQuota(t *testing.T) {
+	t.Parallel()
+
+	weeklyUsed := 80.0
+	projUsed := 20.0
+	shared := AuthFileTrendResponse{
+		QuotaSeries: []usage.QuotaSnapshotSeries{
+			{QuotaKey: "product:GrokBuild"},
+		},
+		WeeklyQuotaUsed:             &weeklyUsed,
+		ProjectionQuotaUsed:         &projUsed,
+		ProjectionQuotaAttributable: true,
+	}
+	tenant := AuthFileTrendResponse{}
+
+	merged := mergeAuthFileTrendShared(tenant, shared)
+	if merged.WeeklyQuotaUsed == nil || *merged.WeeklyQuotaUsed != 80.0 {
+		t.Fatalf("merged weekly quota used=%v, want 80.0", merged.WeeklyQuotaUsed)
+	}
+	if merged.ProjectionQuotaUsed == nil || *merged.ProjectionQuotaUsed != 20.0 {
+		t.Fatalf("merged projection quota used=%v, want 20.0", merged.ProjectionQuotaUsed)
+	}
+	if !merged.ProjectionQuotaAttributable {
+		t.Fatalf("merged projection quota attributable=false, want true")
+	}
+}


### PR DESCRIPTION
### Summary
- Pass `ProjectionQuotaUsed` and `ProjectionQuotaAttributable` in `mergeAuthFileTrendShared` so cross-tenant/shared trends retain the attributable projection quota divisor for xAI / Grok.
- Add unit test in `trends_projection_quota_test.go` ensuring projection quota fields pass through correctly.

### Verification
- `./scripts/ci-pr.sh` passed locally.
- `go test -v ./internal/management/usagelogs` passed.