### PR TITLE
release: v0.4.34

### DIFF
--- a/internal/registry/codex_model_capabilities.go
+++ b/internal/registry/codex_model_capabilities.go
@@ -21,6 +21,8 @@ type CodexModelCapability struct {
 
 var gpt56CatalogReasoningLevels = []string{"low", "medium", "high", "xhigh", "max", "ultra"}
 var gpt56RuntimeWireReasoningLevels = []string{"low", "medium", "high", "xhigh", "max"}
+var gpt6CatalogReasoningLevels = []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+var gpt6RuntimeWireReasoningLevels = []string{"low", "medium", "high", "xhigh", "max"}
 
 var codexModelCapabilities = map[string]CodexModelCapability{
 	"gpt-5.6": {
@@ -84,6 +86,30 @@ var codexModelCapabilities = map[string]CodexModelCapability{
 		RuntimeWireReasoningLevels: gpt56RuntimeWireReasoningLevels,
 		CompatibilityAlias:         true,
 	},
+	"gpt-6-astra": {
+		ModelID:                    "gpt-6-astra",
+		CanonicalTarget:            "gpt-6-astra",
+		DisplayName:                "GPT-6 Astra",
+		Description:                "OpenAI's flagship GPT-6 Astra model for complex coding and agentic tasks.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "medium",
+		CatalogReasoningLevels:     gpt6CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt6RuntimeWireReasoningLevels,
+	},
+	"gpt-6-astra-pro": {
+		ModelID:                    "gpt-6-astra-pro",
+		CanonicalTarget:            "gpt-6-astra-pro",
+		DisplayName:                "GPT-6 Astra Pro",
+		Description:                "OpenAI's GPT-6 Astra Pro model with enhanced reasoning and throughput.",
+		ContextWindow:              1050000,
+		MaxContextWindow:           1050000,
+		MaxCompletionTokens:        128000,
+		DefaultReasoningLevel:      "medium",
+		CatalogReasoningLevels:     gpt6CatalogReasoningLevels,
+		RuntimeWireReasoningLevels: gpt6RuntimeWireReasoningLevels,
+	},
 }
 
 // GetCodexModelCapability returns an isolated copy so callers cannot mutate the
@@ -100,6 +126,31 @@ func GetCodexModelCapability(modelID string) (CodexModelCapability, bool) {
 
 func getGPT56ModelDefinitions() []*ModelInfo {
 	modelIDs := []string{"gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-ultra"}
+	models := make([]*ModelInfo, 0, len(modelIDs))
+	for _, modelID := range modelIDs {
+		capability, _ := GetCodexModelCapability(modelID)
+		models = append(models, &ModelInfo{
+			ID:                  capability.ModelID,
+			Object:              "model",
+			OwnedBy:             "openai",
+			Type:                "openai",
+			Version:             capability.CanonicalTarget,
+			DisplayName:         capability.DisplayName,
+			UpstreamModelID:     capability.CanonicalTarget,
+			Description:         capability.Description,
+			ContextLength:       capability.ContextWindow,
+			MaxCompletionTokens: capability.MaxCompletionTokens,
+			SupportedParameters: []string{"tools"},
+			Thinking: &ThinkingSupport{
+				Levels: append([]string(nil), capability.RuntimeWireReasoningLevels...),
+			},
+		})
+	}
+	return models
+}
+
+func getGPT6ModelDefinitions() []*ModelInfo {
+	modelIDs := []string{"gpt-6-astra", "gpt-6-astra-pro"}
 	models := make([]*ModelInfo, 0, len(modelIDs))
 	for _, modelID := range modelIDs {
 		capability, _ := GetCodexModelCapability(modelID)

--- a/internal/registry/codex_model_capabilities_test.go
+++ b/internal/registry/codex_model_capabilities_test.go
@@ -24,6 +24,34 @@ func TestGPT56CodexCapabilities(t *testing.T) {
 	}
 }
 
+func TestGPT6AstraCodexCapabilities(t *testing.T) {
+	for _, modelID := range []string{"gpt-6-astra", "gpt-6-astra-pro"} {
+		capability, ok := GetCodexModelCapability(modelID)
+		if !ok {
+			t.Fatalf("GetCodexModelCapability(%q) not found", modelID)
+		}
+		if capability.ContextWindow != 1050000 || capability.MaxContextWindow != 1050000 {
+			t.Fatalf("%s context = (%d, %d), want (1050000, 1050000)", modelID, capability.ContextWindow, capability.MaxContextWindow)
+		}
+		if capability.MaxCompletionTokens != 128000 {
+			t.Fatalf("%s max completion = %d, want 128000", modelID, capability.MaxCompletionTokens)
+		}
+		assertStringSlice(t, modelID+" catalog levels", capability.CatalogReasoningLevels, []string{"low", "medium", "high", "xhigh", "max", "ultra"})
+		assertStringSlice(t, modelID+" wire levels", capability.RuntimeWireReasoningLevels, []string{"low", "medium", "high", "xhigh", "max"})
+	}
+}
+
+func TestGPT6AstraStaticRegistryUsesWireLevels(t *testing.T) {
+	info := LookupStaticModelInfo("gpt-6-astra")
+	if info == nil || info.Thinking == nil {
+		t.Fatal("gpt-6-astra registry metadata missing")
+	}
+	if info.ContextLength != 1050000 || info.MaxCompletionTokens != 128000 {
+		t.Fatalf("registry limits = (%d, %d), want (1050000, 128000)", info.ContextLength, info.MaxCompletionTokens)
+	}
+	assertStringSlice(t, "registry wire levels", info.Thinking.Levels, []string{"low", "medium", "high", "xhigh", "max"})
+}
+
 func TestGPT56StaticRegistryUsesWireLevels(t *testing.T) {
 	info := LookupStaticModelInfo("gpt-5.6-sol")
 	if info == nil || info.Thinking == nil {

--- a/internal/registry/model_definitions_static_data.go
+++ b/internal/registry/model_definitions_static_data.go
@@ -907,7 +907,7 @@ func GetOpenAIModels() []*ModelInfo {
 			SupportedParameters: []string{"tools"},
 			Thinking:            &ThinkingSupport{Levels: []string{"low", "medium", "high", "xhigh"}},
 		},
-	}, getGPT56ModelDefinitions()...)...)
+	}, append(getGPT56ModelDefinitions(), getGPT6ModelDefinitions()...)...)...)
 }
 
 func GetXAIModels() []*ModelInfo {

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -11,7 +11,7 @@ func TestCodexStaticModelsIncludeCurrentCodexModels(t *testing.T) {
 		}
 	}
 
-	for _, id := range []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark", "gpt-image-2", "codex-auto-review"} {
+	for _, id := range []string{"gpt-6-astra", "gpt-6-astra-pro", "gpt-5.6-sol", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark", "gpt-image-2", "codex-auto-review"} {
 		if !modelIDs[id] {
 			t.Fatalf("expected codex static models to include %q", id)
 		}


### PR DESCRIPTION
## Release Summary v0.4.34

### Features & Model Support
- **GPT-6 Astra & Astra Pro Support**: Add static model definitions, capability mappings, and thinking configuration for OpenAI's newly released `gpt-6-astra` and `gpt-6-astra-pro` models.
- **Reasoning Levels**: Support complete catalog reasoning levels (`low`, `medium`, `high`, `xhigh`, `max`, `ultra`) with default effort set to `medium`.
- **Large Context Window**: Full 1.05M tokens context window and 128K max completion tokens limits.

### Verification
- Full test suite passed (98 packages ok).
- Backend structure scan passed.