### PR TITLE
feat(codex): harden quota probe and reset transport with TLS fingerprinting and desktop headers

### DIFF
--- a/internal/management/aiaccountstatus/probe.go
+++ b/internal/management/aiaccountstatus/probe.go
@@ -131,7 +131,8 @@ func doAuthRequestStatus(ctx context.Context, svc *managementapitools.Service, a
 		mutate(req)
 	}
 	client := util.NewHTTPClient(30 * time.Second)
-	if transport := svc.APICallTransport(auth); transport != nil {
+	targetURL, _ := url.Parse(urlStr)
+	if transport := svc.APICallTransportForURL(auth, targetURL); transport != nil {
 		client.Transport = transport
 	}
 	resp, err := client.Do(req)

--- a/internal/management/aiaccountstatus/probe_codex.go
+++ b/internal/management/aiaccountstatus/probe_codex.go
@@ -24,8 +24,14 @@ const (
 
 func probeCodex(ctx context.Context, svc *managementapitools.Service, auth *coreauth.Auth) (ProbeResult, error) {
 	body, err := doAuthGET(ctx, svc, auth, codexUsageURL, map[string]string{
-		"Content-Type": "application/json",
-		"User-Agent":   config.DefaultCodexFingerprintUserAgent,
+		"Content-Type":   "application/json",
+		"User-Agent":     config.DefaultCodexFingerprintUserAgent,
+		"Originator":     "Codex Desktop",
+		"OpenAI-Beta":    "codex-1",
+		"Accept":         "application/json",
+		"Sec-Fetch-Site": "none",
+		"Sec-Fetch-Mode": "no-cors",
+		"Sec-Fetch-Dest": "empty",
 	}, func(req *http.Request) {
 		if accountID := codexAccountID(auth); accountID != "" {
 			req.Header.Set("Chatgpt-Account-Id", accountID)
@@ -47,8 +53,14 @@ func probeCodex(ctx context.Context, svc *managementapitools.Service, auth *core
 		result.ResetCreditCount = &v
 		if v > 0 {
 			if expBody, expErr := doAuthGET(ctx, svc, auth, codexResetCreditsURL, map[string]string{
-				"Content-Type": "application/json",
-				"User-Agent":   config.DefaultCodexFingerprintUserAgent,
+				"Content-Type":   "application/json",
+				"User-Agent":     config.DefaultCodexFingerprintUserAgent,
+				"Originator":     "Codex Desktop",
+				"OpenAI-Beta":    "codex-1",
+				"Accept":         "application/json",
+				"Sec-Fetch-Site": "none",
+				"Sec-Fetch-Mode": "no-cors",
+				"Sec-Fetch-Dest": "empty",
 			}, func(req *http.Request) {
 				if accountID := codexAccountID(auth); accountID != "" {
 					req.Header.Set("Chatgpt-Account-Id", accountID)

--- a/internal/management/apitools/api_call.go
+++ b/internal/management/apitools/api_call.go
@@ -111,7 +111,7 @@ func (s *Service) APICall(ctx context.Context, body APICallRequest) (int, any) {
 	}
 
 	httpClient := util.NewHTTPClient(s.defaultAPICallTimeout())
-	httpClient.Transport = s.APICallTransport(auth)
+	httpClient.Transport = s.APICallTransportForURL(auth, parsedURL)
 	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
 			return http.ErrUseLastResponse
@@ -142,6 +142,11 @@ func (s *Service) APICall(ctx context.Context, body APICallRequest) (int, any) {
 	}
 	if errReconcile := s.ReconcileCodexWhamUsagePlan(ctx, auth, parsedURL, resp.StatusCode, respBody); errReconcile != nil {
 		log.WithError(errReconcile).Warn("failed to reconcile codex usage plan type")
+	}
+	if isCodexResetConsumeURL(parsedURL) && resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		if s.authManager != nil && auth != nil {
+			_, _ = s.authManager.ClearQuotaStatus(ctx, auth.ID)
+		}
 	}
 
 	return http.StatusOK, APICallResponse{
@@ -264,6 +269,13 @@ func isCodexWhamUsageURL(parsedURL *url.URL) bool {
 	}
 	path := strings.TrimRight(parsedURL.EscapedPath(), "/")
 	return path == "/backend-api/wham/usage"
+}
+func isCodexResetConsumeURL(parsedURL *url.URL) bool {
+	if parsedURL == nil {
+		return false
+	}
+	path := strings.TrimRight(parsedURL.EscapedPath(), "/")
+	return path == "/backend-api/wham/rate-limit-reset-credits/consume"
 }
 
 func reconcileAuthExplicitDisplayTags(auth *coreauth.Auth) bool {

--- a/internal/management/apitools/proxy.go
+++ b/internal/management/apitools/proxy.go
@@ -2,15 +2,15 @@ package apitools
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
-	"net/url"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/tlsfingerprint"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/tlsfingerprint"
 )
 
 // Management probes must reuse transports by proxy/TLS config. Creating a new

--- a/internal/management/apitools/proxy.go
+++ b/internal/management/apitools/proxy.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"net/url"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/tlsfingerprint"
 )
 
 // Management probes must reuse transports by proxy/TLS config. Creating a new
@@ -51,6 +53,10 @@ func (s *Service) AuthByIndex(authIndex string) *coreauth.Auth {
 }
 
 func (s *Service) APICallTransport(auth *coreauth.Auth) http.RoundTripper {
+	return s.APICallTransportForURL(auth, nil)
+}
+
+func (s *Service) APICallTransportForURL(auth *coreauth.Auth, targetURL *url.URL) http.RoundTripper {
 	var proxyCandidates []string
 	if s != nil && s.cfg != nil {
 		proxyID := ""
@@ -73,11 +79,58 @@ func (s *Service) APICallTransport(auth *coreauth.Auth) http.RoundTripper {
 		sdkCfg = &s.cfg.SDKConfig
 	}
 	for _, proxyStr := range proxyCandidates {
+		if targetURL != nil && isCodexTargetURL(auth, targetURL) {
+			if fpTransport := cachedManagementTLSFingerprintTransport(proxyStr, sdkCfg); fpTransport != nil {
+				return fpTransport
+			}
+		}
 		if transport := cachedManagementProxyTransport(proxyStr, sdkCfg); transport != nil {
 			return transport
 		}
 	}
+	if targetURL != nil && isCodexTargetURL(auth, targetURL) {
+		if fpTransport := cachedManagementTLSFingerprintTransport("", sdkCfg); fpTransport != nil {
+			return fpTransport
+		}
+	}
 	return nil
+}
+
+func isCodexTargetURL(auth *coreauth.Auth, u *url.URL) bool {
+	if u == nil {
+		return false
+	}
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	if host == "chatgpt.com" || strings.HasSuffix(host, ".chatgpt.com") ||
+		host == "openai.com" || strings.HasSuffix(host, ".openai.com") {
+		return true
+	}
+	if auth != nil && strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return true
+	}
+	return false
+}
+
+func cachedManagementTLSFingerprintTransport(proxyStr string, sdkCfg *config.SDKConfig) http.RoundTripper {
+	key := managementTransportKey{proxyURL: strings.TrimSpace(proxyStr)}
+	if sdkCfg != nil {
+		key.preferIPv4 = sdkCfg.PreferIPv4
+		key.insecureSkipVerify = sdkCfg.InsecureSkipVerify
+		key.caCert = strings.TrimSpace(sdkCfg.CACert)
+	}
+	opts := tlsfingerprint.Options{
+		Profile:            tlsfingerprint.DefaultProfile,
+		ProxyURL:           key.proxyURL,
+		PreferIPv4:         key.preferIPv4,
+		InsecureSkipVerify: key.insecureSkipVerify,
+		CACertPath:         key.caCert,
+		DialTimeout:        30 * time.Second,
+	}
+	rt, err := tlsfingerprint.New(opts)
+	if err != nil {
+		return nil
+	}
+	return rt
 }
 
 func cachedManagementProxyTransport(proxyStr string, sdkCfg *config.SDKConfig) *http.Transport {

--- a/internal/management/apitools/proxy.go
+++ b/internal/management/apitools/proxy.go
@@ -79,7 +79,7 @@ func (s *Service) APICallTransportForURL(auth *coreauth.Auth, targetURL *url.URL
 		sdkCfg = &s.cfg.SDKConfig
 	}
 	for _, proxyStr := range proxyCandidates {
-		if targetURL != nil && isCodexTargetURL(auth, targetURL) {
+		if targetURL != nil && strings.EqualFold(targetURL.Scheme, "https") && isCodexTargetURL(auth, targetURL) {
 			if fpTransport := cachedManagementTLSFingerprintTransport(proxyStr, sdkCfg); fpTransport != nil {
 				return fpTransport
 			}
@@ -88,7 +88,7 @@ func (s *Service) APICallTransportForURL(auth *coreauth.Auth, targetURL *url.URL
 			return transport
 		}
 	}
-	if targetURL != nil && isCodexTargetURL(auth, targetURL) {
+	if targetURL != nil && strings.EqualFold(targetURL.Scheme, "https") && isCodexTargetURL(auth, targetURL) {
 		if fpTransport := cachedManagementTLSFingerprintTransport("", sdkCfg); fpTransport != nil {
 			return fpTransport
 		}

--- a/internal/management/apitools/proxy_test.go
+++ b/internal/management/apitools/proxy_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"net/url"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 func TestCachedManagementProxyTransportReusesSameKey(t *testing.T) {
@@ -53,6 +55,16 @@ func TestCachedManagementProxyTransportEvictsOldest(t *testing.T) {
 		t.Fatalf("cache size %d > max", n)
 	}
 }
+func TestAPICallTransportForURL_SelectsTLSFingerprintForCodexUpstream(t *testing.T) {
+	svc := NewForTenant("test-tenant", &config.Config{}, nil, Dependencies{})
+	targetURL, _ := url.Parse("https://chatgpt.com/backend-api/wham/usage")
+	auth := &coreauth.Auth{Provider: "codex"}
+	tr := svc.APICallTransportForURL(auth, targetURL)
+	if tr == nil {
+		t.Fatal("expected non-nil transport for Codex URL")
+	}
+}
+
 
 func itoa(v int) string {
 	if v == 0 {

--- a/internal/management/apitools/proxy_test.go
+++ b/internal/management/apitools/proxy_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
-	"net/url"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"net/url"
 )
 
 func TestCachedManagementProxyTransportReusesSameKey(t *testing.T) {
@@ -64,7 +64,6 @@ func TestAPICallTransportForURL_SelectsTLSFingerprintForCodexUpstream(t *testing
 		t.Fatal("expected non-nil transport for Codex URL")
 	}
 }
-
 
 func itoa(v int) string {
 	if v == 0 {


### PR DESCRIPTION
### Summary
- Routes management APICall and quota probe requests targeting ChatGPT/OpenAI endpoints through TLS fingerprinting transport (mimicking Chrome/browser ClientHello via utls), eliminating Go's default TLS handshake signatures that trigger Cloudflare Bot WAF.
- Updates Codex probe request headers to align with Codex Desktop official client expectations (`Originator: Codex Desktop`, `OpenAI-Beta: codex-1`, `Sec-Fetch-*`).
- Automatically triggers quota recovery and clears runtime cooldown upon successful reset credit redemption (`/backend-api/wham/rate-limit-reset-credits/consume`).

### Verification
- Ran `go test -v ./internal/management/...` (PASS)
- Ran `python3 scripts/check-backend-structure.py` (PASS)