### PR TITLE
chore: deploy smoke to verify auto-deploy

### DIFF
--- a/scripts/.deploy-smoke-marker
+++ b/scripts/.deploy-smoke-marker
@@ -1,0 +1,2 @@
+# deploy smoke marker — safe to ignore
+# last-smoke: 2026-09-07T15:52:06Z


### PR DESCRIPTION
## Summary
- Empty/no-op smoke: touch `scripts/.deploy-smoke-marker` so push to `dev` triggers Deploy CliRelay.
- Purpose: verify GHA auto-deploy still reaches `103.231.58.53:2233` after secret re-pin.

## Test plan
- [ ] Merge to `dev`
- [ ] Confirm Deploy CliRelay runs and mode is deployed (not built-only)
- [ ] Confirm 103 binary/service healthy