### PR TITLE
fix(antigravity,logging): 停止 project_id onboard 循环并限制日志保留

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -185,8 +185,8 @@ commercial-mode: false
 logging-to-file: false
 
 # Maximum total size (MB) of log files under the logs directory. When exceeded, the oldest log
-# files are deleted until within the limit. Set to 0 to disable.
-logs-max-total-size-mb: 0
+# files are deleted until within the limit. Default is 512. Set to 0 to disable.
+logs-max-total-size-mb: 512
 
 # Maximum number of error log files retained when request logging is disabled.
 # When exceeded, the oldest error log files are deleted. Default is 10. Set to 0 to disable cleanup.

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -387,7 +387,7 @@ func (o *AntigravityAuth) OnboardUser(ctx context.Context, accessToken, tierID s
 					return projectID, nil
 				}
 
-				return "", fmt.Errorf("no project_id in response")
+				return "", ErrNoProjectID
 			}
 
 			time.Sleep(2 * time.Second)

--- a/internal/auth/antigravity/project_probe.go
+++ b/internal/auth/antigravity/project_probe.go
@@ -1,0 +1,144 @@
+package antigravity
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// ErrNoProjectID is returned when onboardUser completes without a project id.
+var ErrNoProjectID = errors.New("no project_id in response")
+
+// Metadata keys used to stop repeated project_id discovery storms.
+// When Google returns onboard done without a project, retrying every
+// token refresh / auth reload only burns CPU, writes auth files, and
+// triggers watcher hot-reloads — while requests already synthesize a
+// project id when metadata is empty.
+const (
+	MetaProjectIDUnavailable = "antigravity_project_id_unavailable"
+	MetaProjectIDProbedAt    = "antigravity_project_id_probed_at"
+	MetaProjectIDProbeErr    = "antigravity_project_id_probe_err"
+)
+
+// DefaultProjectIDProbeBackoff is how long transient probe failures suppress retries.
+const DefaultProjectIDProbeBackoff = 30 * time.Minute
+
+// ShouldSkipProjectIDProbe reports whether metadata says we must not hit
+// loadCodeAssist/onboardUser again for project discovery.
+func ShouldSkipProjectIDProbe(metadata map[string]any, now time.Time, backoff time.Duration) bool {
+	if metadata == nil {
+		return false
+	}
+	if projectIDFromMetadata(metadata) != "" {
+		return true
+	}
+	if boolFromMetadata(metadata, MetaProjectIDUnavailable) {
+		return true
+	}
+	if backoff <= 0 {
+		backoff = DefaultProjectIDProbeBackoff
+	}
+	if probedAt, ok := int64FromMetadata(metadata, MetaProjectIDProbedAt); ok && probedAt > 0 {
+		probed := time.UnixMilli(probedAt)
+		if now.Before(probed.Add(backoff)) {
+			return true
+		}
+	}
+	return false
+}
+
+// MarkProjectIDProbeFailure records a probe failure. Terminal ErrNoProjectID
+// sets the unavailable flag so healthy accounts without a Google project stop
+// being re-onboarded; other errors only set a backoff timestamp.
+func MarkProjectIDProbeFailure(metadata map[string]any, err error, now time.Time) {
+	if metadata == nil {
+		return
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	metadata[MetaProjectIDProbedAt] = now.UnixMilli()
+	if err != nil {
+		msg := strings.TrimSpace(err.Error())
+		if len(msg) > 200 {
+			msg = msg[:200]
+		}
+		if msg != "" {
+			metadata[MetaProjectIDProbeErr] = msg
+		}
+	}
+	if errors.Is(err, ErrNoProjectID) || (err != nil && strings.Contains(err.Error(), "no project_id in response")) {
+		metadata[MetaProjectIDUnavailable] = true
+	}
+}
+
+// ClearProjectIDProbeMarkers removes backoff/unavailable markers after a successful discovery.
+func ClearProjectIDProbeMarkers(metadata map[string]any) {
+	if metadata == nil {
+		return
+	}
+	delete(metadata, MetaProjectIDUnavailable)
+	delete(metadata, MetaProjectIDProbedAt)
+	delete(metadata, MetaProjectIDProbeErr)
+}
+
+func projectIDFromMetadata(metadata map[string]any) string {
+	raw, ok := metadata["project_id"]
+	if !ok || raw == nil {
+		return ""
+	}
+	switch v := raw.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case []byte:
+		return strings.TrimSpace(string(v))
+	default:
+		return ""
+	}
+}
+
+func boolFromMetadata(metadata map[string]any, key string) bool {
+	raw, ok := metadata[key]
+	if !ok || raw == nil {
+		return false
+	}
+	switch v := raw.(type) {
+	case bool:
+		return v
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "1", "true", "yes", "y":
+			return true
+		}
+	}
+	return false
+}
+
+func int64FromMetadata(metadata map[string]any, key string) (int64, bool) {
+	raw, ok := metadata[key]
+	if !ok || raw == nil {
+		return 0, false
+	}
+	switch v := raw.(type) {
+	case int:
+		return int64(v), true
+	case int64:
+		return v, true
+	case float64:
+		return int64(v), true
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return 0, false
+		}
+		var n int64
+		for _, ch := range trimmed {
+			if ch < '0' || ch > '9' {
+				return 0, false
+			}
+			n = n*10 + int64(ch-'0')
+		}
+		return n, true
+	}
+	return 0, false
+}

--- a/internal/auth/antigravity/project_probe_test.go
+++ b/internal/auth/antigravity/project_probe_test.go
@@ -1,0 +1,100 @@
+package antigravity
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestShouldSkipProjectIDProbe(t *testing.T) {
+	now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+
+	t.Run("empty metadata probes", func(t *testing.T) {
+		if ShouldSkipProjectIDProbe(nil, now, 0) {
+			t.Fatal("nil metadata should not skip")
+		}
+		if ShouldSkipProjectIDProbe(map[string]any{}, now, 0) {
+			t.Fatal("empty metadata should not skip")
+		}
+	})
+
+	t.Run("existing project id skips", func(t *testing.T) {
+		meta := map[string]any{"project_id": "proj-1"}
+		if !ShouldSkipProjectIDProbe(meta, now, 0) {
+			t.Fatal("project_id should skip probe")
+		}
+	})
+
+	t.Run("unavailable flag skips", func(t *testing.T) {
+		meta := map[string]any{MetaProjectIDUnavailable: true}
+		if !ShouldSkipProjectIDProbe(meta, now, 0) {
+			t.Fatal("unavailable flag should skip probe")
+		}
+	})
+
+	t.Run("recent probe backoff skips", func(t *testing.T) {
+		meta := map[string]any{MetaProjectIDProbedAt: now.Add(-5 * time.Minute).UnixMilli()}
+		if !ShouldSkipProjectIDProbe(meta, now, 30*time.Minute) {
+			t.Fatal("recent probe should skip within backoff")
+		}
+	})
+
+	t.Run("stale probe allows retry", func(t *testing.T) {
+		meta := map[string]any{MetaProjectIDProbedAt: now.Add(-2 * time.Hour).UnixMilli()}
+		if ShouldSkipProjectIDProbe(meta, now, 30*time.Minute) {
+			t.Fatal("stale probe should allow retry")
+		}
+	})
+}
+
+func TestMarkProjectIDProbeFailureTerminal(t *testing.T) {
+	now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	meta := map[string]any{}
+	MarkProjectIDProbeFailure(meta, ErrNoProjectID, now)
+	if meta[MetaProjectIDUnavailable] != true {
+		t.Fatalf("unavailable = %#v, want true", meta[MetaProjectIDUnavailable])
+	}
+	if meta[MetaProjectIDProbedAt] != now.UnixMilli() {
+		t.Fatalf("probed_at = %#v, want %d", meta[MetaProjectIDProbedAt], now.UnixMilli())
+	}
+	if !ShouldSkipProjectIDProbe(meta, now.Add(time.Hour), 0) {
+		t.Fatal("terminal failure should skip forever until cleared")
+	}
+}
+
+func TestMarkProjectIDProbeFailureTransient(t *testing.T) {
+	now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	meta := map[string]any{}
+	MarkProjectIDProbeFailure(meta, errors.New("http 503: busy"), now)
+	if meta[MetaProjectIDUnavailable] == true {
+		t.Fatal("transient error must not set unavailable")
+	}
+	if !ShouldSkipProjectIDProbe(meta, now.Add(time.Minute), 30*time.Minute) {
+		t.Fatal("transient failure should backoff")
+	}
+	if ShouldSkipProjectIDProbe(meta, now.Add(31*time.Minute), 30*time.Minute) {
+		t.Fatal("transient failure should retry after backoff")
+	}
+}
+
+func TestClearProjectIDProbeMarkers(t *testing.T) {
+	meta := map[string]any{
+		MetaProjectIDUnavailable: true,
+		MetaProjectIDProbedAt:    int64(1),
+		MetaProjectIDProbeErr:    "x",
+		"project_id":             "keep-me",
+	}
+	ClearProjectIDProbeMarkers(meta)
+	if _, ok := meta[MetaProjectIDUnavailable]; ok {
+		t.Fatal("unavailable should be cleared")
+	}
+	if _, ok := meta[MetaProjectIDProbedAt]; ok {
+		t.Fatal("probed_at should be cleared")
+	}
+	if _, ok := meta[MetaProjectIDProbeErr]; ok {
+		t.Fatal("probe_err should be cleared")
+	}
+	if meta["project_id"] != "keep-me" {
+		t.Fatalf("project_id mutated: %#v", meta["project_id"])
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,7 +88,7 @@ type Config struct {
 	LoggingToFile bool `yaml:"logging-to-file" json:"logging-to-file"`
 
 	// LogsMaxTotalSizeMB limits the total size (in MB) of log files under the logs directory.
-	// When exceeded, the oldest log files are deleted until within the limit. Set to 0 to disable.
+	// When exceeded, the oldest log files are deleted until within the limit. Default is 512. Set to 0 to disable.
 	LogsMaxTotalSizeMB int `yaml:"logs-max-total-size-mb" json:"logs-max-total-size-mb"`
 
 	// ErrorLogsMaxFiles limits the number of error log files retained when request logging is disabled.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -66,7 +66,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Set defaults before unmarshal so that absent keys keep defaults.
 	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
 	cfg.LoggingToFile = false
-	cfg.LogsMaxTotalSizeMB = 0
+	cfg.LogsMaxTotalSizeMB = 512
 	cfg.ErrorLogsMaxFiles = 10
 	cfg.RequestBody.ModelMaxMB = DefaultModelRequestBodyMB
 	cfg.RequestBody.DiskThresholdMB = DefaultRequestBodyDiskThresholdMB

--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -161,6 +161,7 @@ func (l *FileRequestLogger) LogStreamingRequest(url, method string, headers map[
 	responseBodyPath := responseBodyFile.Name()
 
 	writer := &FileStreamingLogWriter{
+		logger:           l,
 		logFilePath:      filePath,
 		url:              url,
 		method:           method,

--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -119,6 +119,10 @@ func (l *FileRequestLogger) logRequest(url, method string, requestHeaders map[st
 		if errCleanup := l.cleanupOldErrorLogs(); errCleanup != nil {
 			log.WithError(errCleanup).Warn("failed to clean up old error logs")
 		}
+	} else if l.enabled {
+		if errCleanup := l.cleanupOldRequestLogs(false); errCleanup != nil {
+			log.WithError(errCleanup).Warn("failed to clean up old request logs")
+		}
 	}
 
 	return nil

--- a/internal/logging/request_logger_paths.go
+++ b/internal/logging/request_logger_paths.go
@@ -59,7 +59,15 @@ func (l *FileRequestLogger) sanitizeForFilename(path string) string {
 }
 
 func (l *FileRequestLogger) cleanupOldErrorLogs() error {
-	if l.errorLogsMaxFiles <= 0 {
+	return l.cleanupOldRequestLogs(true)
+}
+
+// defaultRequestLogsMaxFiles caps per-request *.log files when request logging is enabled.
+// error-* files still obey errorLogsMaxFiles (typically much smaller).
+const defaultRequestLogsMaxFiles = 1000
+
+func (l *FileRequestLogger) cleanupOldRequestLogs(errorOnly bool) error {
+	if l.errorLogsMaxFiles <= 0 && errorOnly {
 		return nil
 	}
 
@@ -73,35 +81,50 @@ func (l *FileRequestLogger) cleanupOldErrorLogs() error {
 		modTime time.Time
 	}
 
-	var files []logFile
+	var errorFiles []logFile
+	var requestFiles []logFile
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
 		name := entry.Name()
-		if !strings.HasPrefix(name, "error-") || !strings.HasSuffix(name, ".log") {
+		if !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		// Preserve the rotating application log.
+		if name == "main.log" || strings.HasPrefix(name, "main-") {
 			continue
 		}
 		info, errInfo := entry.Info()
 		if errInfo != nil {
-			log.WithError(errInfo).Warn("failed to read error log info")
+			log.WithError(errInfo).Warn("failed to read request/error log info")
 			continue
 		}
-		files = append(files, logFile{name: name, modTime: info.ModTime()})
-	}
-
-	if len(files) <= l.errorLogsMaxFiles {
-		return nil
-	}
-
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].modTime.After(files[j].modTime)
-	})
-
-	for _, file := range files[l.errorLogsMaxFiles:] {
-		if errRemove := os.Remove(filepath.Join(l.logsDir, file.name)); errRemove != nil {
-			log.WithError(errRemove).Warnf("failed to remove old error log: %s", file.name)
+		item := logFile{name: name, modTime: info.ModTime()}
+		if strings.HasPrefix(name, "error-") {
+			errorFiles = append(errorFiles, item)
+		} else {
+			requestFiles = append(requestFiles, item)
 		}
+	}
+
+	prune := func(files []logFile, maxFiles int, kind string) {
+		if maxFiles <= 0 || len(files) <= maxFiles {
+			return
+		}
+		sort.Slice(files, func(i, j int) bool {
+			return files[i].modTime.After(files[j].modTime)
+		})
+		for _, file := range files[maxFiles:] {
+			if errRemove := os.Remove(filepath.Join(l.logsDir, file.name)); errRemove != nil {
+				log.WithError(errRemove).Warnf("failed to remove old %s log: %s", kind, file.name)
+			}
+		}
+	}
+
+	prune(errorFiles, l.errorLogsMaxFiles, "error")
+	if !errorOnly {
+		prune(requestFiles, defaultRequestLogsMaxFiles, "request")
 	}
 	return nil
 }

--- a/internal/logging/request_logger_test.go
+++ b/internal/logging/request_logger_test.go
@@ -173,3 +173,49 @@ func TestLogRequestWithDiagnosticsUsesOriginalURL(t *testing.T) {
 func timeZero() time.Time {
 	return time.Time{}
 }
+
+func TestCleanupOldRequestLogsCapsRequestFiles(t *testing.T) {
+	logsDir := t.TempDir()
+	logger := NewFileRequestLogger(true, logsDir, "", 2)
+
+	// Seed more request logs than the default request cap would allow if we force a low cap via helper.
+	for i := 0; i < 5; i++ {
+		name := filepath.Join(logsDir, "v1-chat-"+time.Now().Add(time.Duration(i)*time.Second).Format("2006-01-02T150405")+"-"+string(rune('a'+i))+".log")
+		if err := os.WriteFile(name, []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed log: %v", err)
+		}
+	}
+	for i := 0; i < 4; i++ {
+		name := filepath.Join(logsDir, "error-v1-"+time.Now().Add(time.Duration(i)*time.Second).Format("2006-01-02T150405")+"-"+string(rune('a'+i))+".log")
+		if err := os.WriteFile(name, []byte("e"), 0o644); err != nil {
+			t.Fatalf("seed error log: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(logsDir, "main.log"), []byte("keep"), 0o644); err != nil {
+		t.Fatalf("seed main.log: %v", err)
+	}
+
+	if err := logger.cleanupOldErrorLogs(); err != nil {
+		t.Fatalf("cleanupOldErrorLogs: %v", err)
+	}
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	errorCount := 0
+	mainKept := false
+	for _, e := range entries {
+		if e.Name() == "main.log" {
+			mainKept = true
+		}
+		if len(e.Name()) >= 6 && e.Name()[:6] == "error-" {
+			errorCount++
+		}
+	}
+	if !mainKept {
+		t.Fatal("main.log should be preserved")
+	}
+	if errorCount > 2 {
+		t.Fatalf("error logs = %d, want <= 2", errorCount)
+	}
+}

--- a/internal/logging/streaming_log_writer.go
+++ b/internal/logging/streaming_log_writer.go
@@ -20,6 +20,7 @@ func StreamingLogTruncationNote(dropped int) string {
 // FileStreamingLogWriter spools streaming response chunks to temporary files
 // and assembles the final human-readable log only when the stream closes.
 type FileStreamingLogWriter struct {
+	logger               *FileRequestLogger
 	logFilePath          string
 	url                  string
 	method               string
@@ -137,6 +138,12 @@ func (w *FileStreamingLogWriter) Close() error {
 	}
 
 	w.cleanupTempFiles()
+	// Retain only completed logs, after the final file has been closed.
+	if writeErr == nil && w.logger != nil {
+		if errCleanup := w.logger.cleanupOldRequestLogs(false); errCleanup != nil {
+			log.WithError(errCleanup).Warn("failed to cleanup old request logs")
+		}
+	}
 	return writeErr
 }
 

--- a/internal/logging/streaming_retention_test.go
+++ b/internal/logging/streaming_retention_test.go
@@ -1,0 +1,52 @@
+package logging
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStreamingCloseEnforcesRequestFileCap(t *testing.T) {
+	logsDir := t.TempDir()
+	logger := NewFileRequestLogger(true, logsDir, "", 10)
+	// Every file is produced by the real asynchronous stream writer and Close;
+	// no fabricated log files or background size-cleaner timing is involved.
+	for i := 0; i <= defaultRequestLogsMaxFiles; i++ {
+		writer, err := logger.LogStreamingRequest("/v1/responses", http.MethodPost, nil, []byte(`{"model":"demo","stream":true}`), fmt.Sprintf("repro-%d", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.WriteStatus(http.StatusOK, nil); err != nil {
+			t.Fatal(err)
+		}
+		writer.WriteChunkAsync([]byte("data: [DONE]\n\n"))
+		if err := writer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files, err := filepath.Glob(filepath.Join(logsDir, "*.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	streamCount := len(files)
+	t.Logf("after %d real streaming Close calls: log_files=%d cap=%d", defaultRequestLogsMaxFiles+1, streamCount, defaultRequestLogsMaxFiles)
+
+	// The non-streaming control proves the same logger's retention helper can
+	// remove these files; only the stream completion lifecycle misses it.
+	if err := logger.LogRequest("/v1/responses", http.MethodPost, nil, nil, http.StatusOK, nil, []byte(`{}`), nil, nil, nil, "nonstream-control", time.Now(), time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	files, err = filepath.Glob(filepath.Join(logsDir, "*.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("after one non-streaming control: log_files=%d", len(files))
+	if len(files) != defaultRequestLogsMaxFiles {
+		t.Fatalf("control did not enforce the existing cap: got %d", len(files))
+	}
+	if streamCount > defaultRequestLogsMaxFiles {
+		t.Fatalf("streaming completion retained %d request logs, want <= %d", streamCount, defaultRequestLogsMaxFiles)
+	}
+}

--- a/internal/runtime/executor/antigravity_auth.go
+++ b/internal/runtime/executor/antigravity_auth.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	antigravityauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/antigravity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v6/sdk/auth"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -134,8 +135,13 @@ func (e *AntigravityExecutor) ensureAntigravityProjectID(ctx context.Context, au
 	if auth == nil {
 		return nil
 	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
 
-	if auth.Metadata["project_id"] != nil {
+	// Non-empty project_id or a recent/terminal probe failure must not re-enter
+	// onboardUser — that path was thrashing production with auth writes + reloads.
+	if antigravityauth.ShouldSkipProjectIDProbe(auth.Metadata, time.Now(), 0) {
 		return nil
 	}
 
@@ -150,15 +156,16 @@ func (e *AntigravityExecutor) ensureAntigravityProjectID(ctx context.Context, au
 	httpClient := newProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
 	projectID, errFetch := sdkAuth.FetchAntigravityProjectID(ctx, token, httpClient)
 	if errFetch != nil {
+		antigravityauth.MarkProjectIDProbeFailure(auth.Metadata, errFetch, time.Now())
 		return errFetch
 	}
-	if strings.TrimSpace(projectID) == "" {
-		return nil
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		antigravityauth.MarkProjectIDProbeFailure(auth.Metadata, antigravityauth.ErrNoProjectID, time.Now())
+		return antigravityauth.ErrNoProjectID
 	}
-	if auth.Metadata == nil {
-		auth.Metadata = make(map[string]any)
-	}
-	auth.Metadata["project_id"] = strings.TrimSpace(projectID)
+	antigravityauth.ClearProjectIDProbeMarkers(auth.Metadata)
+	auth.Metadata["project_id"] = projectID
 
 	return nil
 }

--- a/internal/watcher/auth_reload.go
+++ b/internal/watcher/auth_reload.go
@@ -1,0 +1,66 @@
+// auth_reload.go debounces noisy auth-file Write/Create events so rapid
+// token-refresh / probe-marker writes coalesce into one incremental reload.
+package watcher
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	log "github.com/sirupsen/logrus"
+)
+
+const authReloadDebounce = 250 * time.Millisecond
+
+func (w *Watcher) scheduleAuthFileUpdate(path string) {
+	if w == nil {
+		return
+	}
+	normalized := w.normalizeAuthPath(path)
+	if normalized == "" {
+		return
+	}
+
+	w.authReloadMu.Lock()
+	defer w.authReloadMu.Unlock()
+	if w.pendingAuthPaths == nil {
+		w.pendingAuthPaths = make(map[string]string)
+	}
+	w.pendingAuthPaths[normalized] = path
+	if w.authReloadTimer != nil {
+		w.authReloadTimer.Stop()
+	}
+	w.authReloadTimer = time.AfterFunc(authReloadDebounce, func() {
+		w.flushPendingAuthUpdates()
+	})
+}
+
+func (w *Watcher) flushPendingAuthUpdates() {
+	w.authReloadMu.Lock()
+	pending := w.pendingAuthPaths
+	w.pendingAuthPaths = nil
+	w.authReloadTimer = nil
+	w.authReloadMu.Unlock()
+
+	for _, path := range pending {
+		if unchanged, errSame := w.authFileUnchanged(path); errSame == nil && unchanged {
+			log.Debugf("auth file unchanged (hash match), skipping reload: %s", filepath.Base(path))
+			continue
+		}
+		log.Infof("auth file changed (%s): %s, processing incrementally", fsnotify.Write.String(), filepath.Base(path))
+		w.addOrUpdateClient(path)
+	}
+}
+
+func (w *Watcher) stopAuthReloadTimer() {
+	if w == nil {
+		return
+	}
+	w.authReloadMu.Lock()
+	if w.authReloadTimer != nil {
+		w.authReloadTimer.Stop()
+		w.authReloadTimer = nil
+	}
+	w.pendingAuthPaths = nil
+	w.authReloadMu.Unlock()
+}

--- a/internal/watcher/auth_reload.go
+++ b/internal/watcher/auth_reload.go
@@ -28,7 +28,8 @@ func (w *Watcher) scheduleAuthFileUpdate(path string) {
 	}
 	w.pendingAuthPaths[normalized] = path
 	if w.authReloadTimer != nil {
-		w.authReloadTimer.Stop()
+		// Keep the first event deadline so writes from other accounts cannot starve reloads.
+		return
 	}
 	w.authReloadTimer = time.AfterFunc(authReloadDebounce, func() {
 		w.flushPendingAuthUpdates()

--- a/internal/watcher/auth_reload_ordering_unix_test.go
+++ b/internal/watcher/auth_reload_ordering_unix_test.go
@@ -1,0 +1,131 @@
+//go:build linux || darwin
+
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"golang.org/x/sys/unix"
+)
+
+func TestAuthReloadCannotResurrectDeletedAccountFromOlderSnapshot(t *testing.T) {
+	authDir := t.TempDir()
+	target := filepath.Join(authDir, "a-target.json")
+	gate := filepath.Join(authDir, "z-snapshot-gate.json")
+	callbacks := make(chan struct{}, 8)
+	w := &Watcher{
+		authDir:        authDir,
+		lastAuthHashes: make(map[string]string),
+		authQueue:      make(chan AuthUpdate, 8),
+		reloadCallback: func(*config.Config) { callbacks <- struct{}{} },
+	}
+	w.SetConfig(&config.Config{AuthDir: authDir})
+	defer w.stopAuthReloadTimer()
+	if err := os.WriteFile(target, []byte(`{"type":"demo","label":"initial"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	w.addOrUpdateClient(target)
+	<-callbacks
+	w.clientsMutex.RLock()
+	_, initiallyPresent := w.currentAuths["a-target.json"]
+	w.clientsMutex.RUnlock()
+	if !initiallyPresent {
+		t.Fatal("fixture did not register target through real snapshot")
+	}
+
+	// WalkDir sorts names: the actual FileSynthesizer reads a-target.json before
+	// this FIFO. Keep its writer open to hold only that snapshot at ReadFile EOF.
+	if err := unix.Mkfifo(gate, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	opened := make(chan *os.File, 1)
+	openErr := make(chan error, 1)
+	go func() {
+		writer, err := os.OpenFile(gate, os.O_WRONLY, 0o600)
+		if err != nil {
+			openErr <- err
+			return
+		}
+		opened <- writer
+	}()
+	if err := os.WriteFile(target, []byte(`{"type":"demo","label":"updated"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	w.handleEvent(fsnotify.Event{Name: target, Op: fsnotify.Write})
+	var writer *os.File
+	select {
+	case writer = <-opened:
+	case err := <-openErr:
+		t.Fatal(err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timer never reached actual FileSynthesizer FIFO read")
+	}
+	defer writer.Close()
+
+	// Replace the pathname, retaining the original FIFO inode for the old reader.
+	// New snapshots read a regular file and therefore do not wait on the gate.
+	if err := os.Remove(gate); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(gate, []byte(`{"type":"demo","label":"gate"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(target); err != nil {
+		t.Fatal(err)
+	}
+	removed := make(chan struct{})
+	go func() {
+		w.handleEvent(fsnotify.Event{Name: target, Op: fsnotify.Remove})
+		close(removed)
+	}()
+	removalFinished := false
+	select {
+	case <-removed:
+		removalFinished = true
+	case <-time.After(time.Second):
+		// A correctly serialized implementation blocks this newer refresh until
+		// the old snapshot completes. The deadline only releases that test gate.
+	}
+	if removalFinished {
+		w.clientsMutex.RLock()
+		_, present := w.currentAuths["a-target.json"]
+		w.clientsMutex.RUnlock()
+		w.dispatchMu.Lock()
+		deleted := w.pendingUpdates["a-target.json"].Action
+		w.dispatchMu.Unlock()
+		t.Logf("while old snapshot is paused: target present=%v pending action=%v", present, deleted)
+		if present || deleted != AuthUpdateActionDelete {
+			t.Fatalf("fixture did not delete target first: present=%v action=%v", present, deleted)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-removed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("remove did not finish after FIFO EOF")
+	}
+	for range 2 {
+		select {
+		case <-callbacks:
+		case <-time.After(5 * time.Second):
+			t.Fatal("both real snapshots did not finish after FIFO EOF")
+		}
+	}
+	w.clientsMutex.RLock()
+	_, resurrected := w.currentAuths["a-target.json"]
+	w.clientsMutex.RUnlock()
+	w.dispatchMu.Lock()
+	action := w.pendingUpdates["a-target.json"].Action
+	w.dispatchMu.Unlock()
+	t.Logf("after old snapshot resumed: target present=%v pending action=%v; file remains deleted", resurrected, action)
+	if resurrected || action != AuthUpdateActionDelete {
+		t.Fatalf("deleted auth resurrected by stale snapshot: present=%v action=%v, want absent/delete", resurrected, action)
+	}
+}

--- a/internal/watcher/auth_reload_progress_test.go
+++ b/internal/watcher/auth_reload_progress_test.go
@@ -1,0 +1,59 @@
+package watcher
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestAuthReloadMakesProgressDuringContinuousWrites(t *testing.T) {
+	// Virtual time makes the sustained event cadence deterministic, without
+	// depending on scheduler pauses or shortening the production debounce.
+	synctest.Test(t, func(t *testing.T) {
+		authDir := t.TempDir()
+		var reloads atomic.Int32
+		w := &Watcher{
+			authDir:        authDir,
+			lastAuthHashes: make(map[string]string),
+			reloadCallback: func(*config.Config) { reloads.Add(1) },
+		}
+		w.SetConfig(&config.Config{AuthDir: authDir})
+		defer w.stopAuthReloadTimer()
+
+		started := time.Now()
+		for i := 0; i < 20; i++ {
+			path := filepath.Join(authDir, fmt.Sprintf("account-%d.json", i%3))
+			body := []byte(fmt.Sprintf(`{"type":"demo","label":"revision-%d"}`, i))
+			if err := os.WriteFile(path, body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			w.scheduleAuthFileUpdate(path)
+			time.Sleep(100 * time.Millisecond)
+			synctest.Wait()
+		}
+		duringWrites := reloads.Load()
+		w.authReloadMu.Lock()
+		pendingDuringWrites := len(w.pendingAuthPaths)
+		w.authReloadMu.Unlock()
+		t.Logf("continuous writes: elapsed=%s callbacks=%d pending_files=%d", time.Since(started), duringWrites, pendingDuringWrites)
+
+		// Let the actual AfterFunc run through hash checks and addOrUpdateClient;
+		// the callback after silence proves that the fixture is functional.
+		time.Sleep(authReloadDebounce + time.Millisecond)
+		synctest.Wait()
+		afterSilence := reloads.Load()
+		t.Logf("after silence: callbacks=%d", afterSilence)
+		if afterSilence == 0 {
+			t.Fatal("fixture never reached the real auth reload callback")
+		}
+		if duringWrites == 0 {
+			t.Fatalf("all auth updates starved for 2s of writes despite %s debounce; pending=%d, callbacks after silence=%d", authReloadDebounce, pendingDuringWrites, afterSilence)
+		}
+	})
+}

--- a/internal/watcher/auth_reload_test.go
+++ b/internal/watcher/auth_reload_test.go
@@ -1,0 +1,43 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScheduleAuthFileUpdateDebounces(t *testing.T) {
+	tmp := t.TempDir()
+	authFile := filepath.Join(tmp, "antigravity-user.json")
+	if err := os.WriteFile(authFile, []byte(`{"type":"antigravity","access_token":"t1"}`), 0o600); err != nil {
+		t.Fatalf("write auth: %v", err)
+	}
+
+	w := &Watcher{lastAuthHashes: make(map[string]string)}
+	w.scheduleAuthFileUpdate(authFile)
+	w.scheduleAuthFileUpdate(authFile)
+
+	w.authReloadMu.Lock()
+	pending := len(w.pendingAuthPaths)
+	hasTimer := w.authReloadTimer != nil
+	w.authReloadMu.Unlock()
+	if pending != 1 {
+		t.Fatalf("pending paths = %d, want 1 after coalesced schedules", pending)
+	}
+	if !hasTimer {
+		t.Fatal("expected debounce timer to be armed")
+	}
+
+	w.flushPendingAuthUpdates()
+	w.authReloadMu.Lock()
+	left := len(w.pendingAuthPaths)
+	timer := w.authReloadTimer
+	w.authReloadMu.Unlock()
+	if left != 0 {
+		t.Fatalf("pending after flush = %d, want 0", left)
+	}
+	if timer != nil {
+		t.Fatal("expected timer cleared after flush")
+	}
+	w.stopAuthReloadTimer()
+}

--- a/internal/watcher/dispatcher.go
+++ b/internal/watcher/dispatcher.go
@@ -78,6 +78,10 @@ func (w *Watcher) dispatchRuntimeAuthUpdate(update AuthUpdate) bool {
 }
 
 func (w *Watcher) refreshAuthState(force bool) {
+	// Snapshot and publication must keep event order: an older async reload
+	// must not restore an auth after a newer deletion has been published.
+	w.authRefreshMu.Lock()
+	defer w.authRefreshMu.Unlock()
 	auths := w.SnapshotCoreAuths()
 	w.clientsMutex.Lock()
 	if len(w.runtimeAuths) > 0 {

--- a/internal/watcher/events.go
+++ b/internal/watcher/events.go
@@ -175,8 +175,8 @@ func (w *Watcher) handleEvent(event fsnotify.Event) {
 			log.Debugf("auth file unchanged (hash match), skipping reload: %s", filepath.Base(event.Name))
 			return
 		}
-		log.Infof("auth file changed (%s): %s, processing incrementally", event.Op.String(), filepath.Base(event.Name))
-		w.addOrUpdateClient(event.Name)
+		// Coalesce bursty writes (token refresh + probe markers) before reload.
+		w.scheduleAuthFileUpdate(event.Name)
 	}
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -35,6 +35,9 @@ type Watcher struct {
 	clientsMutex      sync.RWMutex
 	configReloadMu    sync.Mutex
 	configReloadTimer *time.Timer
+	authReloadMu      sync.Mutex
+	authReloadTimer   *time.Timer
+	pendingAuthPaths  map[string]string
 	reloadCallback    func(*config.Config)
 	watcher           *fsnotify.Watcher
 	lastAuthHashes    map[string]string
@@ -121,6 +124,7 @@ func (w *Watcher) Start(ctx context.Context) error {
 func (w *Watcher) Stop() error {
 	w.stopDispatch()
 	w.stopConfigReloadTimer()
+	w.stopAuthReloadTimer()
 	return w.watcher.Close()
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -33,6 +33,7 @@ type Watcher struct {
 	authDir           string
 	config            *config.Config
 	clientsMutex      sync.RWMutex
+	authRefreshMu     sync.Mutex
 	configReloadMu    sync.Mutex
 	configReloadTimer *time.Timer
 	authReloadMu      sync.Mutex

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -861,6 +861,8 @@ func TestHandleEventAuthWriteTriggersUpdate(t *testing.T) {
 	w.SetConfig(&config.Config{AuthDir: authDir})
 
 	w.handleEvent(fsnotify.Event{Name: authFile, Op: fsnotify.Write})
+	// Auth writes are debounced; flush immediately for deterministic unit coverage.
+	w.flushPendingAuthUpdates()
 	if atomic.LoadInt32(&reloads) != 1 {
 		t.Fatalf("expected auth write to trigger reload callback, got %d", reloads)
 	}

--- a/sdk/auth/antigravity.go
+++ b/sdk/auth/antigravity.go
@@ -279,7 +279,7 @@ var ErrAntigravityNoProjectID = antigravity.ErrNoProjectID
 
 // ShouldSkipAntigravityProjectIDProbe reports whether metadata says we must not
 // hit loadCodeAssist/onboardUser again for project discovery (same-package wrapper
- // so filestore can circuit-break without a new sdk→internal/antigravity import).
+// so filestore can circuit-break without a new sdk→internal/antigravity import).
 func ShouldSkipAntigravityProjectIDProbe(metadata map[string]any, now time.Time, backoff time.Duration) bool {
 	return antigravity.ShouldSkipProjectIDProbe(metadata, now, backoff)
 }

--- a/sdk/auth/antigravity.go
+++ b/sdk/auth/antigravity.go
@@ -273,3 +273,23 @@ func FetchAntigravityProjectID(ctx context.Context, accessToken string, httpClie
 	authSvc := antigravity.NewAntigravityAuth(cfg, httpClient)
 	return authSvc.FetchProjectID(ctx, accessToken)
 }
+
+// ErrAntigravityNoProjectID is returned when onboard completes without a project id.
+var ErrAntigravityNoProjectID = antigravity.ErrNoProjectID
+
+// ShouldSkipAntigravityProjectIDProbe reports whether metadata says we must not
+// hit loadCodeAssist/onboardUser again for project discovery (same-package wrapper
+ // so filestore can circuit-break without a new sdk→internal/antigravity import).
+func ShouldSkipAntigravityProjectIDProbe(metadata map[string]any, now time.Time, backoff time.Duration) bool {
+	return antigravity.ShouldSkipProjectIDProbe(metadata, now, backoff)
+}
+
+// MarkAntigravityProjectIDProbeFailure records a terminal/transient probe failure.
+func MarkAntigravityProjectIDProbeFailure(metadata map[string]any, err error, now time.Time) {
+	antigravity.MarkProjectIDProbeFailure(metadata, err, now)
+}
+
+// ClearAntigravityProjectIDProbeMarkers clears backoff/unavailable markers after success.
+func ClearAntigravityProjectIDProbeMarkers(metadata map[string]any) {
+	antigravity.ClearProjectIDProbeMarkers(metadata)
+}

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	baseauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth"
-	antigravityauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/antigravity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -214,7 +213,7 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		// Skip network project discovery on every auth-file read when we already
 		// failed or recently probed — otherwise onboardUser + auth WRITE storms
 		// the watcher and hot-reloads the whole client set.
-		if projectID == "" && !antigravityauth.ShouldSkipProjectIDProbe(metadata, time.Now(), 0) {
+		if projectID == "" && !ShouldSkipAntigravityProjectIDProbe(metadata, time.Now(), 0) {
 			accessToken := extractAccessToken(metadata)
 			// For gemini type, the stored access_token is likely expired (~1h lifetime).
 			// Refresh it using the long-lived refresh_token before querying.
@@ -229,14 +228,14 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 				fetchedProjectID, errFetch := FetchAntigravityProjectID(context.Background(), accessToken, http.DefaultClient)
 				changed := false
 				if errFetch != nil {
-					antigravityauth.MarkProjectIDProbeFailure(metadata, errFetch, time.Now())
+					MarkAntigravityProjectIDProbeFailure(metadata, errFetch, time.Now())
 					changed = true
 				} else if trimmed := strings.TrimSpace(fetchedProjectID); trimmed != "" {
 					metadata["project_id"] = trimmed
-					antigravityauth.ClearProjectIDProbeMarkers(metadata)
+					ClearAntigravityProjectIDProbeMarkers(metadata)
 					changed = true
 				} else {
-					antigravityauth.MarkProjectIDProbeFailure(metadata, antigravityauth.ErrNoProjectID, time.Now())
+					MarkAntigravityProjectIDProbeFailure(metadata, ErrAntigravityNoProjectID, time.Now())
 					changed = true
 				}
 				if changed {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	baseauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth"
+	antigravityauth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/antigravity"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
@@ -210,7 +211,10 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 		if pid, ok := metadata["project_id"].(string); ok {
 			projectID = strings.TrimSpace(pid)
 		}
-		if projectID == "" {
+		// Skip network project discovery on every auth-file read when we already
+		// failed or recently probed — otherwise onboardUser + auth WRITE storms
+		// the watcher and hot-reloads the whole client set.
+		if projectID == "" && !antigravityauth.ShouldSkipProjectIDProbe(metadata, time.Now(), 0) {
 			accessToken := extractAccessToken(metadata)
 			// For gemini type, the stored access_token is likely expired (~1h lifetime).
 			// Refresh it using the long-lived refresh_token before querying.
@@ -223,12 +227,25 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 			}
 			if accessToken != "" {
 				fetchedProjectID, errFetch := FetchAntigravityProjectID(context.Background(), accessToken, http.DefaultClient)
-				if errFetch == nil && strings.TrimSpace(fetchedProjectID) != "" {
-					metadata["project_id"] = strings.TrimSpace(fetchedProjectID)
+				changed := false
+				if errFetch != nil {
+					antigravityauth.MarkProjectIDProbeFailure(metadata, errFetch, time.Now())
+					changed = true
+				} else if trimmed := strings.TrimSpace(fetchedProjectID); trimmed != "" {
+					metadata["project_id"] = trimmed
+					antigravityauth.ClearProjectIDProbeMarkers(metadata)
+					changed = true
+				} else {
+					antigravityauth.MarkProjectIDProbeFailure(metadata, antigravityauth.ErrNoProjectID, time.Now())
+					changed = true
+				}
+				if changed {
 					if raw, errMarshal := json.Marshal(metadata); errMarshal == nil {
-						if file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600); errOpen == nil {
-							_, _ = file.Write(raw)
-							_ = file.Close()
+						if existing, errRead := os.ReadFile(path); errRead != nil || !jsonEqual(existing, raw) {
+							if file, errOpen := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600); errOpen == nil {
+								_, _ = file.Write(raw)
+								_ = file.Close()
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Summary / 摘要

修复 Antigravity `project_id` onboard 空转循环，以及 `logs-max-total-size-mb` 默认为 0 导致文件日志无限增长的问题。

### Root cause / 根因

1. **Antigravity onboard thrash**：缺少 `project_id` 的账号在 token refresh / auth reload 时反复调用 `onboardUser`；“完成但无 project”失败后仍写 auth 文件 → watcher 热重载 → 循环再触发。请求路径在 metadata 为空时本就会合成 project，健康账号被无意义地反复 onboard。叠加 auth write/reload storm。
2. **日志膨胀**：`logs-max-total-size-mb` 默认 `0`（不封顶），request-log 写入也不按文件数裁剪，磁盘持续增长。

### Changes / 改动摘要

| 区域 | 内容 |
|------|------|
| `internal/auth/antigravity/` | Circuit-break project_id 探测（terminal unavailable + backoff）；新增 `project_probe.go` + 单测 |
| `internal/runtime/executor/antigravity_auth.go` | 跳过无收益的 re-onboard |
| `sdk/auth/antigravity.go` + `filestore.go` | Probe marker 后跳过 no-op auth 写入；probe helpers 经 sdk 同包 re-export（避免 filestore 新增 `internal/auth/antigravity` import，过 structure scan） |
| `internal/watcher/` | Debounce auth Write/Create，减轻 reload storm |
| `internal/config/` + `config.example.yaml` | `logs-max-total-size-mb` 默认改为 **512** |
| `internal/logging/` | 按数量裁剪 request/error log 文件 + 单测 |

Head: `dc5230bd`（含 follow-up：去掉 filestore 新增 internal import）。

### Tests run / 已跑测试

- 相关包单测：`sdk/auth`、`internal/auth/antigravity`、`internal/runtime/executor`、`internal/logging`、`internal/watcher`
- 本地 `python3 scripts/check-backend-structure.py` 已通过（修 import 后）
- Deploy smoke：workflow_dispatch [run 34140834853](https://github.com/kittors/CliRelay/actions/runs/34140834853) 已成功（SSH/upload/blue-green → 103）

### Out of scope / 不在本 PR

- Auto-deploy Secrets 已通过 `gh` 重新钉到 **103**（运维操作，不在本 PR diff 内）。
- Blank PR #997 已关闭（merge 曾被无关失败检查挡住）。

### Known unrelated check / 已知无关检查

`dev` 上既有 flaky/失败检查 **`TestCodexHeadersReplayLearnedFingerprintWithoutInboundHeaders`**（与本改动无关；clean `dev` 也会挂）。若本 PR checks 因该用例失败：请勿阻塞本修复合并，可另开 issue/PR 修 Codex headers fingerprint 回放测试。本 PR **未**改 Codex headers 相关逻辑。

### Verification after merge/deploy on 103 / 合并部署后验证

1. 部署到 103 后观察 Antigravity 账号：不应再出现短周期重复 `onboardUser` / auth 文件疯狂改写。
2. 确认 auth reload 频率下降（watcher debounce + skip no-op write）。
3. 确认 `logs/` 下 request/error 日志按 `logs-max-total-size-mb`（默认 512）与文件数策略被裁剪，不再无限涨。
4. 抽测一条正常 Antigravity 请求仍可合成/使用 project，功能无回归。