### PR TITLE
feat(routing): make stickiness orthogonal to distribution and unify weight semantics

### DIFF
--- a/internal/api/handlers/management/channel_groups.go
+++ b/internal/api/handlers/management/channel_groups.go
@@ -31,10 +31,25 @@ const (
 	channelDisabledAuthorityConfig  = 2
 )
 
+// channelGroupScheduling mirrors config.GroupScheduling on the wire. It is
+// always emitted (no omitempty on the block) so the panel can render the
+// resolved defaults for implicit groups such as "default", which have no stored
+// configuration of their own.
+type channelGroupScheduling struct {
+	Distribution        string         `json:"distribution"`
+	StickyEnabled       bool           `json:"sticky-enabled"`
+	StickyMaxRequests   int            `json:"sticky-max-requests,omitempty"`
+	StickyReleaseAtLoad float64        `json:"sticky-release-at-load,omitempty"`
+	ChannelWeights      map[string]int `json:"channel-weights,omitempty"`
+}
+
 type channelGroupItem struct {
-	Name               string                      `json:"name"`
-	Description        string                      `json:"description,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	// Strategy is the legacy mirror of Scheduling, retained so an older panel
+	// build keeps working against a newer backend during a staged rollout.
 	Strategy           string                      `json:"strategy,omitempty"`
+	Scheduling         channelGroupScheduling      `json:"scheduling"`
 	Priority           int                         `json:"priority,omitempty"`
 	ExcludeFromDefault bool                        `json:"exclude-from-default,omitempty"`
 	Implicit           bool                        `json:"implicit"`
@@ -44,6 +59,25 @@ type channelGroupItem struct {
 	ChannelDetails     []channelGroupChannelDetail `json:"channel-details,omitempty"`
 	AllowedModels      []string                    `json:"allowed-models,omitempty"`
 	PathRoutes         []string                    `json:"path-routes,omitempty"`
+}
+
+func schedulingItemFrom(group config.RoutingChannelGroup) channelGroupScheduling {
+	scheduling := group.Scheduling
+	if strings.TrimSpace(scheduling.Distribution) == "" && !scheduling.Sticky.Enabled && len(scheduling.ChannelWeights) == 0 {
+		scheduling = config.SchedulingFromLegacyGroup(group)
+	}
+	return channelGroupScheduling{
+		Distribution:        config.NormalizeDistribution(scheduling.Distribution),
+		StickyEnabled:       scheduling.Sticky.Enabled,
+		StickyMaxRequests:   scheduling.Sticky.MaxRequests,
+		StickyReleaseAtLoad: scheduling.Sticky.ReleaseAtLoad,
+		ChannelWeights:      scheduling.ChannelWeights,
+	}
+}
+
+// defaultSchedulingItem describes an implicit group that has no stored config.
+func defaultSchedulingItem() channelGroupScheduling {
+	return channelGroupScheduling{Distribution: config.DistributionWeighted}
 }
 
 func collectChannelDescriptors(cfg *config.Config, auths []*coreauth.Auth) []channelDescriptor {
@@ -196,7 +230,7 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 			}
 			return existing
 		}
-		item := &channelGroupItem{Name: name, Implicit: implicit}
+		item := &channelGroupItem{Name: name, Implicit: implicit, Scheduling: defaultSchedulingItem()}
 		groupMap[name] = item
 		return item
 	}
@@ -208,6 +242,7 @@ func buildChannelGroupItems(cfg *config.Config, auths []*coreauth.Auth) []channe
 		}
 		item.Description = group.Description
 		item.Strategy = group.Strategy
+		item.Scheduling = schedulingItemFrom(group)
 		item.Priority = group.Priority
 		item.ExcludeFromDefault = group.ExcludeFromDefault
 		item.AllowedModels = append(item.AllowedModels, group.AllowedModels...)
@@ -435,8 +470,12 @@ func validateRoutingAndAPIKeyRestrictions(cfg *config.Config, auths []*coreauth.
 			return fmt.Errorf("duplicate channel group %q", group.Name)
 		}
 		seenGroupNames[name] = struct{}{}
-		if _, exists := knownGroups[name]; !exists {
+		known, exists := knownGroups[name]
+		if !exists {
 			return fmt.Errorf("channel group %q does not match any known channel", group.Name)
+		}
+		if err := validateGroupWeights(group, known); err != nil {
+			return err
 		}
 	}
 
@@ -505,6 +544,41 @@ func validateRoutingAndAPIKeyRestrictions(cfg *config.Config, auths []*coreauth.
 	}
 
 	return nil
+}
+
+// validateGroupWeights rejects a group whose every resolved member is weighted
+// 0. Such a group cannot serve a single request, and letting it save produced a
+// runtime error far away from the setting that caused it.
+func validateGroupWeights(group config.RoutingChannelGroup, resolved channelGroupItem) error {
+	weights := group.Scheduling.ChannelWeights
+	if len(weights) == 0 {
+		weights = group.ChannelPriorities
+	}
+	if len(weights) == 0 || len(resolved.Channels) == 0 {
+		return nil
+	}
+	// A member without an entry keeps the default weight 1, so the group stays
+	// usable as long as one member is unconfigured or positively weighted.
+	for _, channel := range resolved.Channels {
+		weight, configured := lookupChannelWeight(weights, channel)
+		if !configured || weight > 0 {
+			return nil
+		}
+	}
+	return fmt.Errorf("channel group %q has every channel weighted 0, so it cannot serve any request", group.Name)
+}
+
+func lookupChannelWeight(weights map[string]int, channel string) (int, bool) {
+	channel = strings.TrimSpace(channel)
+	if channel == "" {
+		return 0, false
+	}
+	for name, weight := range weights {
+		if strings.EqualFold(strings.TrimSpace(name), channel) {
+			return weight, true
+		}
+	}
+	return 0, false
 }
 
 func channelGroupMatchesAnyDescriptor(group config.RoutingChannelGroup, descriptors []channelDescriptor) bool {

--- a/internal/api/handlers/management/channel_names.go
+++ b/internal/api/handlers/management/channel_names.go
@@ -271,6 +271,7 @@ func canonicalizeRoutingConfigChannels(routing config.RoutingConfig, known map[s
 		group := routing.ChannelGroups[i]
 		group.Match.Channels = canonicalizeChannelList(group.Match.Channels, known)
 		group.ChannelPriorities = canonicalizeChannelPriorities(group.ChannelPriorities, known)
+		group.Scheduling.ChannelWeights = canonicalizeChannelPriorities(group.Scheduling.ChannelWeights, known)
 		routing.ChannelGroups[i] = group
 	}
 	return routing

--- a/internal/api/handlers/management/channel_rename.go
+++ b/internal/api/handlers/management/channel_rename.go
@@ -242,21 +242,53 @@ func renameRoutingChannelReferences(routing *config.RoutingConfig, oldNameSet ma
 			routing.ChannelGroups[i].Match.Channels = channels
 			changed = true
 		}
-		if priorities := routing.ChannelGroups[i].ChannelPriorities; len(priorities) > 0 {
-			for channel, priority := range priorities {
-				if !shouldRenameChannel(channel, oldNameSet) {
-					continue
-				}
-				delete(priorities, channel)
-				if existing, exists := priorities[newName]; !exists || priority > existing {
-					priorities[newName] = priority
-				}
-				changed = true
-			}
-			if len(priorities) == 0 {
+		if renameWeightMap(routing.ChannelGroups[i].ChannelPriorities, oldNameSet, newName) {
+			if len(routing.ChannelGroups[i].ChannelPriorities) == 0 {
 				routing.ChannelGroups[i].ChannelPriorities = nil
 			}
+			changed = true
 		}
+		// The scheduling weights are keyed by channel name too; a rename that
+		// skipped them would silently reset that channel to the default weight.
+		if renameWeightMap(routing.ChannelGroups[i].Scheduling.ChannelWeights, oldNameSet, newName) {
+			if len(routing.ChannelGroups[i].Scheduling.ChannelWeights) == 0 {
+				routing.ChannelGroups[i].Scheduling.ChannelWeights = nil
+			}
+			changed = true
+		}
+	}
+	return changed
+}
+
+func renameWeightMap(weights map[string]int, oldNameSet map[string]struct{}, newName string) bool {
+	if len(weights) == 0 {
+		return false
+	}
+	changed := false
+	for channel, weight := range weights {
+		if !shouldRenameChannel(channel, oldNameSet) {
+			continue
+		}
+		delete(weights, channel)
+		if existing, exists := weights[newName]; !exists || weight > existing {
+			weights[newName] = weight
+		}
+		changed = true
+	}
+	return changed
+}
+
+func removeWeightMap(weights map[string]int, oldNameSet map[string]struct{}) bool {
+	if len(weights) == 0 {
+		return false
+	}
+	changed := false
+	for channel := range weights {
+		if !shouldRenameChannel(channel, oldNameSet) {
+			continue
+		}
+		delete(weights, channel)
+		changed = true
 	}
 	return changed
 }
@@ -272,17 +304,17 @@ func removeRoutingChannelReferences(routing *config.RoutingConfig, oldNameSet ma
 			routing.ChannelGroups[i].Match.Channels = channels
 			changed = true
 		}
-		if priorities := routing.ChannelGroups[i].ChannelPriorities; len(priorities) > 0 {
-			for channel := range priorities {
-				if !shouldRenameChannel(channel, oldNameSet) {
-					continue
-				}
-				delete(priorities, channel)
-				changed = true
-			}
-			if len(priorities) == 0 {
+		if removeWeightMap(routing.ChannelGroups[i].ChannelPriorities, oldNameSet) {
+			if len(routing.ChannelGroups[i].ChannelPriorities) == 0 {
 				routing.ChannelGroups[i].ChannelPriorities = nil
 			}
+			changed = true
+		}
+		if removeWeightMap(routing.ChannelGroups[i].Scheduling.ChannelWeights, oldNameSet) {
+			if len(routing.ChannelGroups[i].Scheduling.ChannelWeights) == 0 {
+				routing.ChannelGroups[i].Scheduling.ChannelWeights = nil
+			}
+			changed = true
 		}
 	}
 	return changed

--- a/internal/app/service/runtime_access.go
+++ b/internal/app/service/runtime_access.go
@@ -3,9 +3,11 @@ package serviceapp
 import (
 	"context"
 	"strings"
+	"sync"
 
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/management/schedulingload"
 	modelconfigsettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/modelconfig"
 	internalusage "github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher"
@@ -22,6 +24,21 @@ type OAuthProviderModelConfigRow struct {
 	Enabled     bool
 }
 
+// schedulingLoadProvider is a process-wide singleton: it caches one quota
+// snapshot shared by every selector, and ApplyTenantRuntimeConfigs runs again on
+// each config reload, so rebuilding it per call would throw the cache away.
+var (
+	schedulingLoadOnce     sync.Once
+	schedulingLoadProvider *schedulingload.Provider
+)
+
+func sharedSchedulingLoadProvider() *schedulingload.Provider {
+	schedulingLoadOnce.Do(func() {
+		schedulingLoadProvider = schedulingload.NewProvider()
+	})
+	return schedulingLoadProvider
+}
+
 func ApplyTenantRuntimeConfigs(base *config.Config, manager *coreauth.Manager) {
 	if base == nil || manager == nil || identity.Default() == nil {
 		return
@@ -30,13 +47,19 @@ func ApplyTenantRuntimeConfigs(base *config.Config, manager *coreauth.Manager) {
 	if err != nil {
 		return
 	}
+	loadProvider := sharedSchedulingLoadProvider()
+	loadProvider.TrackTenant(identity.SystemTenantID)
 	for _, tenant := range tenants {
 		if tenant.ID == "" || tenant.ID == identity.SystemTenantID {
 			continue
 		}
+		loadProvider.TrackTenant(tenant.ID)
 		tenantCfg := internalusage.BuildTenantRuntimeConfig(base, tenant.ID)
 		manager.SetConfigForTenant(tenant.ID, &tenantCfg)
 	}
+	// Least-load distribution and the sticky release threshold both read this;
+	// without it they degrade to concurrency-only signals.
+	manager.SetQuotaLoadSource(loadProvider)
 }
 
 func ListOAuthProviderModelConfigRows() []OAuthProviderModelConfigRow {

--- a/internal/config/routing_groups.go
+++ b/internal/config/routing_groups.go
@@ -14,10 +14,16 @@ type ChannelGroupMatch struct {
 }
 
 // RoutingChannelGroup defines a named channel group used by routing and API-key permissions.
+//
+// Strategy and ChannelPriorities are the pre-scheduling representation. They are
+// kept in sync with Scheduling by sanitizeScheduling so that an older binary or
+// admin panel reading this config still sees a coherent value; new code must
+// read Scheduling, never these two fields.
 type RoutingChannelGroup struct {
 	Name               string            `yaml:"name" json:"name"`
 	Description        string            `yaml:"description,omitempty" json:"description,omitempty"`
 	Strategy           string            `yaml:"strategy,omitempty" json:"strategy,omitempty"`
+	Scheduling         GroupScheduling   `yaml:"scheduling,omitempty" json:"scheduling,omitempty"`
 	Match              ChannelGroupMatch `yaml:"match,omitempty" json:"match,omitempty"`
 	ExcludeFromDefault bool              `yaml:"exclude-from-default,omitempty" json:"exclude-from-default,omitempty"`
 	Priority           int               `yaml:"priority,omitempty" json:"priority,omitempty"`
@@ -130,6 +136,7 @@ func (cfg *Config) SanitizeRouting() {
 		})
 		group.Match.Tags = normalizeStringList(group.Match.Tags, NormalizeRoutingTag)
 		group.ChannelPriorities = normalizeChannelPriorities(group.ChannelPriorities)
+		sanitizeScheduling(&group)
 		group.AllowedModels = normalizeStringList(group.AllowedModels, func(value string) string {
 			return strings.TrimSpace(value)
 		})

--- a/internal/config/routing_scheduling.go
+++ b/internal/config/routing_scheduling.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"math"
+	"strings"
+)
+
+// Distribution modes decide which candidate a group hands the request to once
+// the candidate set is known. They are orthogonal to session stickiness: sticky
+// only pins an already-running conversation, the distribution still decides
+// where every *new* conversation lands and where a released binding goes next.
+const (
+	DistributionWeighted  = "weighted"
+	DistributionLeastLoad = "least-load"
+	DistributionFillFirst = "fill-first"
+)
+
+// DefaultStickyMaxRequests bounds how many requests one conversation may pin to
+// a single account. Without a bound a long session keeps hammering the same
+// upstream account until it hits a 429, which is exactly the "burn one account"
+// behaviour this model replaces.
+const DefaultStickyMaxRequests = 200
+
+// GroupStickyConfig configures session stickiness as an independent switch.
+type GroupStickyConfig struct {
+	Enabled bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+
+	// MaxRequests forces a re-pick after this many requests on the same account.
+	// Zero means "use DefaultStickyMaxRequests"; a negative value means unbounded.
+	MaxRequests int `yaml:"max-requests,omitempty" json:"max-requests,omitempty"`
+
+	// ReleaseAtLoad releases the binding early once the bound account's load
+	// ratio (0..1 of its quota window) reaches this value, before the account is
+	// actually exhausted. Zero disables the early release.
+	ReleaseAtLoad float64 `yaml:"release-at-load,omitempty" json:"release-at-load,omitempty"`
+}
+
+// GroupScheduling describes how one channel group distributes requests.
+type GroupScheduling struct {
+	Distribution string            `yaml:"distribution,omitempty" json:"distribution,omitempty"`
+	Sticky       GroupStickyConfig `yaml:"sticky,omitempty" json:"sticky,omitempty"`
+
+	// ChannelWeights carries the relative share per channel. Absent entries mean
+	// weight 1 (matching the panel copy), an explicit 0 means "do not schedule".
+	ChannelWeights map[string]int `yaml:"channel-weights,omitempty" json:"channel-weights,omitempty"`
+}
+
+// NormalizeDistribution maps user input onto a supported distribution mode.
+func NormalizeDistribution(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "least-load", "leastload", "ll":
+		return DistributionLeastLoad
+	case "fill-first", "fillfirst", "ff":
+		return DistributionFillFirst
+	default:
+		return DistributionWeighted
+	}
+}
+
+// normalizeChannelWeights drops blank names and negative weights. Unlike the
+// legacy priority map, 0 is preserved: it is the explicit "exclude" value.
+func normalizeChannelWeights(values map[string]int) map[string]int {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(values))
+	for key, weight := range values {
+		name := strings.TrimSpace(key)
+		if name == "" || weight < 0 {
+			continue
+		}
+		if existing, exists := out[name]; exists && existing >= weight {
+			continue
+		}
+		out[name] = weight
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// legacyStrategyForScheduling derives the pre-scheduling `strategy` value so a
+// config written by this build still reads sensibly on an older binary and in
+// an older admin panel. least-load has no legacy equivalent and degrades to
+// round-robin, which is the closest balancing behaviour.
+func legacyStrategyForScheduling(scheduling GroupScheduling) string {
+	if scheduling.Sticky.Enabled {
+		return "session-sticky"
+	}
+	if scheduling.Distribution == DistributionFillFirst {
+		return "fill-first"
+	}
+	return "round-robin"
+}
+
+// MigrateLegacyPriorities converts an old `channel-priorities` map into weights.
+//
+// The old map was ambiguous: under round-robin a 0 already meant "excluded",
+// but under session-sticky and fill-first it meant "the default tier", which is
+// where every unconfigured channel sat. A map that is entirely zeros can only
+// have come from the second reading — nobody configures a group that can never
+// serve a request — so it is dropped and every member falls back to weight 1.
+// Mixed maps keep their zeros, since there a 0 was already an exclusion
+// relative to the higher-valued entries.
+func MigrateLegacyPriorities(priorities map[string]int) map[string]int {
+	if len(priorities) == 0 {
+		return nil
+	}
+	for _, priority := range priorities {
+		if priority > 0 {
+			return priorities
+		}
+	}
+	return nil
+}
+
+// SchedulingFromLegacyGroup derives the scheduling block for a group that has
+// not been migrated yet, so read paths (management API, runtime snapshot) show
+// the same effective configuration the selector will use.
+func SchedulingFromLegacyGroup(group RoutingChannelGroup) GroupScheduling {
+	scheduling := schedulingFromLegacy(group.Strategy, group.ChannelPriorities)
+	if scheduling.Sticky.Enabled && scheduling.Sticky.MaxRequests == 0 {
+		scheduling.Sticky.MaxRequests = DefaultStickyMaxRequests
+	}
+	return scheduling
+}
+
+// schedulingFromLegacy upgrades a group that only carries the old `strategy` +
+// `channel-priorities` pair.
+func schedulingFromLegacy(strategy string, priorities map[string]int) GroupScheduling {
+	scheduling := GroupScheduling{ChannelWeights: MigrateLegacyPriorities(priorities)}
+	switch NormalizeRoutingStrategy(strategy) {
+	case "session-sticky":
+		scheduling.Distribution = DistributionWeighted
+		scheduling.Sticky.Enabled = true
+	case "fill-first":
+		scheduling.Distribution = DistributionFillFirst
+	default:
+		scheduling.Distribution = DistributionWeighted
+	}
+	return scheduling
+}
+
+// sanitizeScheduling normalizes one group's scheduling block and keeps the
+// legacy fields mirrored so both readers stay consistent during the rollout.
+func sanitizeScheduling(group *RoutingChannelGroup) {
+	if group == nil {
+		return
+	}
+	scheduling := group.Scheduling
+	migrated := false
+	if strings.TrimSpace(scheduling.Distribution) == "" && !scheduling.Sticky.Enabled && len(scheduling.ChannelWeights) == 0 {
+		scheduling = schedulingFromLegacy(group.Strategy, group.ChannelPriorities)
+		migrated = true
+	}
+
+	scheduling.Distribution = NormalizeDistribution(scheduling.Distribution)
+	scheduling.ChannelWeights = normalizeChannelWeights(scheduling.ChannelWeights)
+	if !migrated && len(scheduling.ChannelWeights) == 0 && len(group.ChannelPriorities) > 0 {
+		// The group gained a scheduling block but kept its weights in the legacy
+		// map; carry them over instead of silently resetting everyone to 1.
+		scheduling.ChannelWeights = normalizeChannelWeights(MigrateLegacyPriorities(group.ChannelPriorities))
+	}
+
+	if !scheduling.Sticky.Enabled {
+		scheduling.Sticky = GroupStickyConfig{}
+	} else {
+		if scheduling.Sticky.MaxRequests == 0 {
+			scheduling.Sticky.MaxRequests = DefaultStickyMaxRequests
+		}
+		if scheduling.Sticky.MaxRequests < 0 {
+			scheduling.Sticky.MaxRequests = 0 // explicit "unbounded"
+		}
+		if scheduling.Sticky.ReleaseAtLoad < 0 || math.IsNaN(scheduling.Sticky.ReleaseAtLoad) {
+			scheduling.Sticky.ReleaseAtLoad = 0
+		}
+		if scheduling.Sticky.ReleaseAtLoad > 1 {
+			scheduling.Sticky.ReleaseAtLoad = 1
+		}
+	}
+
+	group.Scheduling = scheduling
+	group.Strategy = legacyStrategyForScheduling(scheduling)
+	group.ChannelPriorities = normalizeChannelWeights(scheduling.ChannelWeights)
+}
+
+// ExplicitWeightsAllZero reports whether every *explicitly configured* weight
+// excludes its channel. Callers must combine it with the group's resolved
+// membership: channels without an entry default to weight 1, so a group is only
+// truly unusable when every member is covered by a zero entry. Validating this
+// at save time avoids the opaque runtime "auth_unavailable" the old code
+// produced when a whole group was set to 0.
+func ExplicitWeightsAllZero(scheduling GroupScheduling) bool {
+	if len(scheduling.ChannelWeights) == 0 {
+		return false
+	}
+	for _, weight := range scheduling.ChannelWeights {
+		if weight > 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/management/schedulingload/provider.go
+++ b/internal/management/schedulingload/provider.go
@@ -1,0 +1,160 @@
+// Package schedulingload feeds observed upstream quota usage into credential
+// scheduling.
+//
+// The selector package deliberately knows nothing about storage, so this
+// package adapts the persisted AI account status (which already carries the
+// per-window quota percentages collected by the account status probes) into the
+// coreauth.QuotaLoadSource contract.
+package schedulingload
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+// snapshotTTL bounds how stale a quota reading may be before a refresh is
+// triggered. Quota percentages move on the order of minutes, and the account
+// status probes themselves run far less often than request selection, so a
+// short TTL here costs nothing and keeps the data fresh enough to steer traffic.
+const snapshotTTL = 60 * time.Second
+
+type snapshot struct {
+	ratios      map[string]float64
+	refreshedAt time.Time
+}
+
+// Provider serves cached quota load ratios and refreshes them out of band.
+//
+// Reads never block on the database: a stale snapshot is returned while a
+// refresh runs in the background, and an empty snapshot simply reports "no
+// data" so scheduling falls back to its in-process signals.
+type Provider struct {
+	current    atomic.Pointer[snapshot]
+	refreshing atomic.Bool
+	tenantsMu  sync.RWMutex
+	tenants    map[string]struct{}
+}
+
+func NewProvider() *Provider {
+	p := &Provider{tenants: make(map[string]struct{})}
+	p.current.Store(&snapshot{ratios: map[string]float64{}})
+	return p
+}
+
+// TrackTenant registers a tenant whose accounts should be included in refreshes.
+func (p *Provider) TrackTenant(tenantID string) {
+	tenantID = strings.TrimSpace(tenantID)
+	if p == nil || tenantID == "" {
+		return
+	}
+	p.tenantsMu.Lock()
+	p.tenants[tenantID] = struct{}{}
+	p.tenantsMu.Unlock()
+}
+
+// QuotaLoadRatio implements coreauth.QuotaLoadSource.
+func (p *Provider) QuotaLoadRatio(auth *coreauth.Auth) (float64, bool) {
+	if p == nil || auth == nil {
+		return 0, false
+	}
+	key := loadKey(auth.TenantID, auth.Index)
+	if key == "" {
+		return 0, false
+	}
+
+	current := p.current.Load()
+	if current == nil {
+		p.triggerRefresh()
+		return 0, false
+	}
+	if time.Since(current.refreshedAt) > snapshotTTL {
+		p.triggerRefresh()
+	}
+	ratio, ok := current.ratios[key]
+	return ratio, ok
+}
+
+func (p *Provider) triggerRefresh() {
+	if !p.refreshing.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer p.refreshing.Store(false)
+		p.Refresh()
+	}()
+}
+
+// Refresh rebuilds the snapshot synchronously. Exported for startup priming and
+// for tests that need deterministic timing.
+func (p *Provider) Refresh() {
+	if p == nil {
+		return
+	}
+	p.tenantsMu.RLock()
+	tenants := make([]string, 0, len(p.tenants))
+	for tenantID := range p.tenants {
+		tenants = append(tenants, tenantID)
+	}
+	p.tenantsMu.RUnlock()
+
+	ratios := make(map[string]float64)
+	for _, tenantID := range tenants {
+		records, err := usage.ListAIAccountStatusForTenant(tenantID, nil)
+		if err != nil {
+			// A missing or unreachable store must not break scheduling; the
+			// selectors fall back to their in-process load signals.
+			log.Debugf("schedulingload: list account status for tenant %s: %v", tenantID, err)
+			continue
+		}
+		for _, record := range records {
+			key := loadKey(tenantID, record.AuthIndex)
+			if key == "" {
+				continue
+			}
+			if ratio, ok := worstQuotaRatio(record.Quotas); ok {
+				ratios[key] = ratio
+			}
+		}
+	}
+	p.current.Store(&snapshot{ratios: ratios, refreshedAt: time.Now()})
+}
+
+// worstQuotaRatio takes the most constrained window for the account. An account
+// whose 5-hour window is nearly spent should shed traffic even when its weekly
+// window still looks healthy.
+func worstQuotaRatio(windows []usage.QuotaWindowDTO) (float64, bool) {
+	worst := 0.0
+	found := false
+	for _, window := range windows {
+		if window.Percent == nil {
+			continue
+		}
+		ratio := *window.Percent / 100
+		if ratio < 0 {
+			continue
+		}
+		if ratio > 1 {
+			ratio = 1
+		}
+		if !found || ratio > worst {
+			worst = ratio
+			found = true
+		}
+	}
+	return worst, found
+}
+
+func loadKey(tenantID, authIndex string) string {
+	authIndex = strings.TrimSpace(authIndex)
+	if authIndex == "" {
+		return ""
+	}
+	return coreauth.NormalizedTenantID(tenantID) + "|" + authIndex
+}

--- a/sdk/cliproxy/auth/account_load.go
+++ b/sdk/cliproxy/auth/account_load.go
@@ -1,0 +1,142 @@
+package auth
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// QuotaLoadSource reports how close an account is to exhausting its quota
+// window, as a ratio in [0,1]. It is injected from the usage layer, which owns
+// the quota tables; the selector package must not reach into storage itself.
+//
+// Implementations must be safe for concurrent use and must not block: this runs
+// on the selection hot path, so it is expected to serve from a cached snapshot
+// and refresh out of band. Returning false means "no data", which leaves
+// scheduling to the in-process signals alone.
+type QuotaLoadSource interface {
+	QuotaLoadRatio(auth *Auth) (float64, bool)
+}
+
+const (
+	// selectionDecayHalfLife controls how fast recent-selection pressure fades.
+	// Five minutes is long enough to spread a burst of turns from one agent
+	// session across accounts, short enough that an idle account recovers its
+	// standing before the next task starts.
+	selectionDecayHalfLife = 5 * time.Minute
+
+	// selectionTrackerMaxKeys bounds the tracker's memory. Reaching it evicts
+	// the coldest entries rather than clearing the whole map, so live accounts
+	// keep their pressure history.
+	selectionTrackerMaxKeys = 4096
+)
+
+type decayCounter struct {
+	value     float64
+	updatedAt time.Time
+}
+
+// decayedValue returns the counter's value faded to `now`.
+func (c decayCounter) decayedValue(now time.Time) float64 {
+	if c.value == 0 || c.updatedAt.IsZero() {
+		return 0
+	}
+	elapsed := now.Sub(c.updatedAt)
+	if elapsed <= 0 {
+		return c.value
+	}
+	// Half-life decay: value * 0.5^(elapsed/halfLife).
+	return c.value * math.Exp2(-elapsed.Seconds()/selectionDecayHalfLife.Seconds())
+}
+
+// selectionPressureTracker records how much traffic each account has recently
+// been handed. It is the self-contained load signal behind least-load
+// distribution: it needs no external data and still reflects the only thing
+// that matters for balancing, which account this proxy has been pushing work to.
+type selectionPressureTracker struct {
+	mu       sync.Mutex
+	counters map[string]decayCounter
+	maxKeys  int
+}
+
+func newSelectionPressureTracker() *selectionPressureTracker {
+	return &selectionPressureTracker{counters: make(map[string]decayCounter)}
+}
+
+// observe records that authID was just selected.
+func (t *selectionPressureTracker) observe(authID string, now time.Time) {
+	if t == nil || authID == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.counters == nil {
+		t.counters = make(map[string]decayCounter)
+	}
+	t.evictIfNeededLocked(authID, now)
+	current := t.counters[authID]
+	t.counters[authID] = decayCounter{value: current.decayedValue(now) + 1, updatedAt: now}
+}
+
+// pressure returns the decayed selection count for authID.
+func (t *selectionPressureTracker) pressure(authID string, now time.Time) float64 {
+	if t == nil || authID == "" {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.counters[authID].decayedValue(now)
+}
+
+// evictIfNeededLocked drops the coldest entries once the map is full. Must be
+// called with t.mu held.
+func (t *selectionPressureTracker) evictIfNeededLocked(incoming string, now time.Time) {
+	limit := t.maxKeys
+	if limit <= 0 {
+		limit = selectionTrackerMaxKeys
+	}
+	if _, exists := t.counters[incoming]; exists || len(t.counters) < limit {
+		return
+	}
+	oldestID := ""
+	oldestAt := time.Time{}
+	for id, counter := range t.counters {
+		if counter.decayedValue(now) < 0.01 {
+			delete(t.counters, id)
+			continue
+		}
+		if oldestID == "" || counter.updatedAt.Before(oldestAt) {
+			oldestID = id
+			oldestAt = counter.updatedAt
+		}
+	}
+	if len(t.counters) >= limit && oldestID != "" {
+		delete(t.counters, oldestID)
+	}
+}
+
+// accountLoadRatio reports a candidate's overall load in [0,1], combining the
+// in-flight concurrency ratio with the quota ratio when a source is available.
+// The larger of the two wins: an account that is either saturated by concurrent
+// requests or near its quota ceiling should attract less new traffic.
+func accountLoadRatio(auth *Auth, limiter *AccountConcurrencyLimiter, quota QuotaLoadSource) float64 {
+	if auth == nil {
+		return 0
+	}
+	ratio := 0.0
+	if limiter != nil {
+		ratio = limiter.GetLoadRate(auth.ID, auth.ConcurrencyLimit())
+	}
+	if quota != nil {
+		if quotaRatio, ok := quota.QuotaLoadRatio(auth); ok && quotaRatio > ratio {
+			ratio = quotaRatio
+		}
+	}
+	if ratio < 0 {
+		return 0
+	}
+	if ratio > 1 {
+		return 1
+	}
+	return ratio
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -159,7 +159,9 @@ type Manager struct {
 	selector              Selector
 	roundRobinSelector    *RoundRobinSelector
 	fillFirstSelector     *FillFirstSelector
+	leastLoadSelector     *LeastLoadSelector
 	sessionStickySelector *SessionStickySelector
+	scheduler             *schedulerDeps
 	hook                  Hook
 	mu                    sync.RWMutex
 	auths                 map[string]*Auth
@@ -201,21 +203,29 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	if selector == nil {
 		selector = &RoundRobinSelector{}
 	}
+	if hook == nil {
+		hook = NoopHook{}
+	}
+	limiter := NewAccountConcurrencyLimiter()
+	deps := &schedulerDeps{tracker: newSelectionPressureTracker(), limiter: limiter}
+
 	roundRobinSelector, _ := selector.(*RoundRobinSelector)
 	if roundRobinSelector == nil {
 		roundRobinSelector = &RoundRobinSelector{}
 	}
+	roundRobinSelector.deps = deps
 	fillFirstSelector, _ := selector.(*FillFirstSelector)
 	if fillFirstSelector == nil {
 		fillFirstSelector = &FillFirstSelector{}
 	}
+	fillFirstSelector.deps = deps
+	leastLoadSelector := &LeastLoadSelector{deps: deps}
 	sessionStickySelector, _ := selector.(*SessionStickySelector)
 	if sessionStickySelector == nil {
 		sessionStickySelector = NewSessionStickySelector(roundRobinSelector)
 	}
-	if hook == nil {
-		hook = NoopHook{}
-	}
+	sessionStickySelector.deps = deps
+
 	manager := &Manager{
 		store:                 store,
 		executors:             make(map[string]ProviderExecutor),
@@ -223,13 +233,20 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 		selector:              selector,
 		roundRobinSelector:    roundRobinSelector,
 		fillFirstSelector:     fillFirstSelector,
+		leastLoadSelector:     leastLoadSelector,
 		sessionStickySelector: sessionStickySelector,
+		scheduler:             deps,
 		hook:                  hook,
 		auths:                 make(map[string]*Auth),
 		providerOffsets:       make(map[string]int),
-		concurrencyLimiter:    NewAccountConcurrencyLimiter(),
+		concurrencyLimiter:    limiter,
 		refreshSemaphore:      make(chan struct{}, refreshMaxConcurrency),
 		quotaProbeAfter:       make(map[string]time.Time),
+	}
+	// Sticky delegates new conversations to whichever distribution the group
+	// configures, so it needs to reach the manager's singleton selectors.
+	sessionStickySelector.distribution = func(name string) Selector {
+		return manager.distributionSelectorLocked(name)
 	}
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(runtimeConfigSnapshotSet{defaultTenantID: newRuntimeConfigSnapshot(nil)})

--- a/sdk/cliproxy/auth/conductor_runtime_snapshot.go
+++ b/sdk/cliproxy/auth/conductor_runtime_snapshot.go
@@ -26,13 +26,23 @@ type runtimeRoutingConfigSnapshot struct {
 }
 
 type runtimeRoutingChannelGroup struct {
-	Name               string
+	Name string
+	// Strategy is the legacy mirror of Scheduling; selection reads Scheduling.
 	Strategy           string
+	Scheduling         runtimeGroupScheduling
 	Match              runtimeChannelGroupMatch
 	ExcludeFromDefault bool
 	Priority           int
 	ChannelPriorities  map[string]int
 	AllowedModels      []string
+}
+
+type runtimeGroupScheduling struct {
+	Distribution   string
+	StickyEnabled  bool
+	StickyMax      int
+	StickyRelease  float64
+	ChannelWeights map[string]int
 }
 
 type runtimeChannelGroupMatch struct {
@@ -135,6 +145,7 @@ func cloneRuntimeRoutingChannelGroups(groups []sdkconfig.RoutingChannelGroup) []
 		out = append(out, runtimeRoutingChannelGroup{
 			Name:               group.Name,
 			Strategy:           normalizeOptionalRuntimeRoutingStrategy(group.Strategy),
+			Scheduling:         cloneRuntimeGroupScheduling(group),
 			Match:              cloneRuntimeChannelGroupMatch(group.Match),
 			ExcludeFromDefault: group.ExcludeFromDefault,
 			Priority:           group.Priority,
@@ -143,6 +154,33 @@ func cloneRuntimeRoutingChannelGroups(groups []sdkconfig.RoutingChannelGroup) []
 		})
 	}
 	return out
+}
+
+// cloneRuntimeGroupScheduling reads the group's scheduling block, falling back
+// to the legacy strategy/priorities pair for configs that predate it or that
+// were written by an older binary between deploys.
+func cloneRuntimeGroupScheduling(group sdkconfig.RoutingChannelGroup) runtimeGroupScheduling {
+	scheduling := group.Scheduling
+	if strings.TrimSpace(scheduling.Distribution) == "" && !scheduling.Sticky.Enabled && len(scheduling.ChannelWeights) == 0 {
+		switch normalizeOptionalRuntimeRoutingStrategy(group.Strategy) {
+		case "session-sticky":
+			scheduling.Distribution = sdkconfig.DistributionWeighted
+			scheduling.Sticky.Enabled = true
+			scheduling.Sticky.MaxRequests = sdkconfig.DefaultStickyMaxRequests
+		case "fill-first":
+			scheduling.Distribution = sdkconfig.DistributionFillFirst
+		default:
+			scheduling.Distribution = sdkconfig.DistributionWeighted
+		}
+		scheduling.ChannelWeights = sdkconfig.MigrateLegacyPriorities(group.ChannelPriorities)
+	}
+	return runtimeGroupScheduling{
+		Distribution:   sdkconfig.NormalizeDistribution(scheduling.Distribution),
+		StickyEnabled:  scheduling.Sticky.Enabled,
+		StickyMax:      scheduling.Sticky.MaxRequests,
+		StickyRelease:  scheduling.Sticky.ReleaseAtLoad,
+		ChannelWeights: cloneStringIntMap(scheduling.ChannelWeights),
+	}
 }
 
 func cloneRuntimeChannelGroupMatch(match sdkconfig.ChannelGroupMatch) runtimeChannelGroupMatch {

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -1,6 +1,10 @@
 package auth
 
-import "strings"
+import (
+	"strings"
+
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
 
 func (m *Manager) normalizeProviders(providers []string) []string {
 	if len(providers) == 0 {
@@ -73,38 +77,86 @@ func (m *Manager) SetSelector(selector Selector) {
 	if m.fillFirstSelector == nil {
 		m.fillFirstSelector = &FillFirstSelector{}
 	}
+	if m.leastLoadSelector == nil {
+		m.leastLoadSelector = &LeastLoadSelector{}
+	}
 	if m.sessionStickySelector == nil {
 		m.sessionStickySelector = NewSessionStickySelector(m.roundRobinSelector)
+	}
+	// A replaced selector must keep observing load, otherwise least-load and the
+	// sticky release threshold silently lose their inputs after a config reload.
+	if m.scheduler != nil {
+		m.roundRobinSelector.deps = m.scheduler
+		m.fillFirstSelector.deps = m.scheduler
+		m.leastLoadSelector.deps = m.scheduler
+		m.sessionStickySelector.deps = m.scheduler
+	}
+	if m.sessionStickySelector.distribution == nil {
+		m.sessionStickySelector.distribution = func(name string) Selector {
+			return m.distributionSelectorLocked(name)
+		}
 	}
 	m.mu.Unlock()
 }
 
-func (m *Manager) selectorForRoutingScopeLocked(cfg *runtimeConfigSnapshot, routeGroup string, allowedGroups map[string]struct{}) Selector {
+// SetQuotaLoadSource wires the usage layer's quota snapshot into scheduling.
+// Least-load uses it to steer traffic away from accounts nearing their window
+// ceiling, and session stickiness uses it for early binding release.
+func (m *Manager) SetQuotaLoadSource(source QuotaLoadSource) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.scheduler == nil {
+		m.scheduler = &schedulerDeps{tracker: newSelectionPressureTracker(), limiter: m.concurrencyLimiter}
+	}
+	m.scheduler.quota = source
+	m.mu.Unlock()
+}
+
+// distributionSelectorLocked returns the singleton selector implementing one
+// distribution mode. Singletons matter: the cursors, pressure counters and
+// sticky bindings are what make the distribution behave consistently across
+// requests.
+func (m *Manager) distributionSelectorLocked(distribution string) Selector {
 	if m == nil {
 		return &RoundRobinSelector{}
 	}
-	switch scopedRoutingStrategy(cfg, routeGroup, allowedGroups) {
-	case "session-sticky":
-		if m.sessionStickySelector != nil {
-			return m.sessionStickySelector
-		}
-		return NewSessionStickySelector(m.roundRobinSelector)
-	case "fill-first":
+	switch sdkconfig.NormalizeDistribution(distribution) {
+	case sdkconfig.DistributionFillFirst:
 		if m.fillFirstSelector != nil {
 			return m.fillFirstSelector
 		}
 		return &FillFirstSelector{}
-	case "round-robin":
+	case sdkconfig.DistributionLeastLoad:
+		if m.leastLoadSelector != nil {
+			return m.leastLoadSelector
+		}
+		return &LeastLoadSelector{}
+	default:
 		if m.roundRobinSelector != nil {
 			return m.roundRobinSelector
 		}
 		return &RoundRobinSelector{}
-	default:
-		if m.selector != nil {
-			return m.selector
-		}
+	}
+}
+
+// selectorForRoutingScopeLocked picks the selector for this request's routing
+// scope. Session stickiness wraps a distribution mode rather than replacing it,
+// so an operator can combine "keep a conversation on one account" with any of
+// the balancing behaviours.
+func (m *Manager) selectorForRoutingScopeLocked(cfg *runtimeConfigSnapshot, routeGroup string, allowedGroups map[string]struct{}) Selector {
+	if m == nil {
 		return &RoundRobinSelector{}
 	}
+	scheduling := scopedScheduling(cfg, routeGroup, allowedGroups)
+	if scheduling.StickyEnabled {
+		if m.sessionStickySelector != nil {
+			return m.sessionStickySelector
+		}
+		return NewSessionStickySelector(m.distributionSelectorLocked(scheduling.Distribution))
+	}
+	return m.distributionSelectorLocked(scheduling.Distribution)
 }
 
 func authAllowedByChannels(auth *Auth, allowed map[string]struct{}) bool {

--- a/sdk/cliproxy/auth/conductor_selector_service.go
+++ b/sdk/cliproxy/auth/conductor_selector_service.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
@@ -128,9 +129,13 @@ func newSelectorService(manager *Manager) selectorService {
 	return selectorService{manager: manager}
 }
 
-func optionsForSelectionRouteGroup(opts cliproxyexecutor.Options, routeGroup string) cliproxyexecutor.Options {
+// optionsForSelectionScope stamps the resolved route group and the scheduling
+// settings that govern it onto the request options. The Selector interface is
+// part of the SDK contract and cannot grow a parameter, so per-group settings
+// ride along in the metadata.
+func optionsForSelectionScope(opts cliproxyexecutor.Options, routeGroup string, scheduling runtimeGroupScheduling) cliproxyexecutor.Options {
 	next := opts
-	meta := make(map[string]any, len(opts.Metadata)+1)
+	meta := make(map[string]any, len(opts.Metadata)+5)
 	for key, value := range opts.Metadata {
 		meta[key] = value
 	}
@@ -138,6 +143,16 @@ func optionsForSelectionRouteGroup(opts cliproxyexecutor.Options, routeGroup str
 		meta[cliproxyexecutor.RouteGroupMetadataKey] = routeGroup
 	} else {
 		delete(meta, cliproxyexecutor.RouteGroupMetadataKey)
+	}
+	meta[distributionMetadataKey] = scheduling.Distribution
+	if scheduling.StickyEnabled {
+		meta[stickyEnabledMetadataKey] = "true"
+		if scheduling.StickyMax > 0 {
+			meta[stickyMaxRequestsKey] = strconv.Itoa(scheduling.StickyMax)
+		}
+		if scheduling.StickyRelease > 0 {
+			meta[stickyReleaseAtLoadKey] = strconv.FormatFloat(scheduling.StickyRelease, 'f', -1, 64)
+		}
 	}
 	next.Metadata = meta
 	return next
@@ -241,11 +256,12 @@ func (s selectorService) pickLocked(
 			}
 			continue
 		}
+		scheduling := scopedScheduling(scope.cfg, selectorRouteGroup, scope.allowedGroups)
 		selector := s.manager.selectorForRoutingScopeLocked(scope.cfg, selectorRouteGroup, scope.allowedGroups)
 		if s.manager.concurrencyLimiter != nil {
 			candidates = s.manager.concurrencyLimiter.FilterAvailableCandidates(candidates)
 		}
-		selected, errPick := selector.Pick(ctx, selectorProvider, scope.model, optionsForSelectionRouteGroup(opts, selectorRouteGroup), candidates)
+		selected, errPick := selector.Pick(ctx, selectorProvider, scope.model, optionsForSelectionScope(opts, selectorRouteGroup, scheduling), candidates)
 		if errPick != nil {
 			return nil, "", errPick
 		}

--- a/sdk/cliproxy/auth/routing_groups_scope.go
+++ b/sdk/cliproxy/auth/routing_groups_scope.go
@@ -3,27 +3,26 @@ package auth
 import (
 	"strconv"
 	"strings"
+
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 )
 
-func channelGroupStrategy(cfg *runtimeConfigSnapshot, groupName string) string {
+func channelGroupScheduling(cfg *runtimeConfigSnapshot, groupName string) (runtimeGroupScheduling, bool) {
 	if cfg == nil {
-		return ""
+		return runtimeGroupScheduling{}, false
 	}
 	groupName = normalizeGroupName(groupName)
 	if groupName == "" {
-		return ""
+		return runtimeGroupScheduling{}, false
 	}
 	for i := range cfg.Routing.ChannelGroups {
 		group := cfg.Routing.ChannelGroups[i]
 		if normalizeGroupName(group.Name) != groupName {
 			continue
 		}
-		if strings.TrimSpace(group.Strategy) == "" {
-			return ""
-		}
-		return group.Strategy
+		return group.Scheduling, true
 	}
-	return ""
+	return runtimeGroupScheduling{}, false
 }
 
 func onlyAllowedGroupName(allowedGroups map[string]struct{}) string {
@@ -36,26 +35,40 @@ func onlyAllowedGroupName(allowedGroups map[string]struct{}) string {
 	return ""
 }
 
-func scopedRoutingStrategy(cfg *runtimeConfigSnapshot, routeGroup string, allowedGroups map[string]struct{}) string {
+// scopedScheduling resolves which group's scheduling block governs this
+// request. A named route group wins; otherwise a request restricted to exactly
+// one channel group adopts that group's settings; anything broader falls back
+// to the global default.
+func scopedScheduling(cfg *runtimeConfigSnapshot, routeGroup string, allowedGroups map[string]struct{}) runtimeGroupScheduling {
 	if routeGroup = normalizeGroupName(routeGroup); routeGroup != "" {
-		if strategy := channelGroupStrategy(cfg, routeGroup); strategy != "" {
-			return strategy
+		if scheduling, ok := channelGroupScheduling(cfg, routeGroup); ok {
+			return scheduling
 		}
-		return globalRoutingStrategy(cfg)
+		return globalScheduling(cfg)
 	}
 	if allowedGroup := onlyAllowedGroupName(allowedGroups); allowedGroup != "" {
-		if strategy := channelGroupStrategy(cfg, allowedGroup); strategy != "" {
-			return strategy
+		if scheduling, ok := channelGroupScheduling(cfg, allowedGroup); ok {
+			return scheduling
 		}
 	}
-	return globalRoutingStrategy(cfg)
+	return globalScheduling(cfg)
 }
 
-func globalRoutingStrategy(cfg *runtimeConfigSnapshot) string {
+// globalScheduling derives the fallback scheduling from the top-level routing
+// strategy, which has no scheduling block of its own.
+func globalScheduling(cfg *runtimeConfigSnapshot) runtimeGroupScheduling {
+	scheduling := runtimeGroupScheduling{Distribution: sdkconfig.DistributionWeighted}
 	if cfg == nil {
-		return ""
+		return scheduling
 	}
-	return strings.TrimSpace(cfg.Routing.Strategy)
+	switch strings.TrimSpace(cfg.Routing.Strategy) {
+	case "session-sticky":
+		scheduling.StickyEnabled = true
+		scheduling.StickyMax = sdkconfig.DefaultStickyMaxRequests
+	case "fill-first":
+		scheduling.Distribution = sdkconfig.DistributionFillFirst
+	}
+	return scheduling
 }
 
 func includeDefaultGroup(cfg *runtimeConfigSnapshot) bool {
@@ -203,7 +216,15 @@ func priorityScopeGroups(routeGroup string, allowedGroups map[string]struct{}) m
 	return out
 }
 
-func derivedGroupPriority(cfg *runtimeConfigSnapshot, auth *Auth, scopedGroups map[string]struct{}) (int, bool) {
+// derivedGroupWeight resolves the weight a candidate should carry inside the
+// scoped routing groups.
+//
+// Only per-channel weights participate. The group-level Priority field used to
+// be folded in here with a max(), which conflated two different questions:
+// "which group serves this request" and "what share does this account get
+// inside its group". Group-level priority is a group-ordering concern and no
+// longer leaks into per-account weights.
+func derivedGroupWeight(cfg *runtimeConfigSnapshot, auth *Auth, scopedGroups map[string]struct{}) (int, bool) {
 	if cfg == nil || auth == nil {
 		return 0, false
 	}
@@ -225,20 +246,23 @@ func derivedGroupPriority(cfg *runtimeConfigSnapshot, auth *Auth, scopedGroups m
 		if _, ok := scopedGroups[groupName]; !ok {
 			continue
 		}
-		for name, priority := range group.ChannelPriorities {
-			if authMatchesChannelName(auth, name) && (!found || priority > best) {
-				best = priority
+		for name, weight := range group.Scheduling.ChannelWeights {
+			if authMatchesChannelName(auth, name) && (!found || weight > best) {
+				best = weight
 				found = true
 			}
-		}
-		if group.Priority != 0 && (!found || group.Priority > best) {
-			best = group.Priority
-			found = true
 		}
 	}
 	return best, found
 }
 
+// prepareCandidateForSelection stamps the effective selection weight onto a
+// copy of the candidate.
+//
+// The group configuration wins over any weight written directly on the
+// credential: the group is what an operator can actually see and edit in the
+// panel, and the old precedence meant a stray `priority` attribute silently
+// disabled every weight configured there.
 func prepareCandidateForSelection(cfg *runtimeConfigSnapshot, auth *Auth, routeGroup string, allowedGroups map[string]struct{}) *Auth {
 	if auth == nil {
 		return nil
@@ -247,17 +271,14 @@ func prepareCandidateForSelection(cfg *runtimeConfigSnapshot, auth *Auth, routeG
 	if cloned == nil {
 		return nil
 	}
-	if strings.TrimSpace(cloned.Attributes["priority"]) != "" {
-		return cloned
-	}
-	priority, ok := derivedGroupPriority(cfg, cloned, priorityScopeGroups(routeGroup, allowedGroups))
+	weight, ok := derivedGroupWeight(cfg, cloned, priorityScopeGroups(routeGroup, allowedGroups))
 	if !ok {
 		return cloned
 	}
 	if cloned.Attributes == nil {
 		cloned.Attributes = make(map[string]string)
 	}
-	cloned.Attributes["priority"] = strconv.Itoa(priority)
+	cloned.Attributes[selectionWeightAttribute] = strconv.Itoa(weight)
 	return cloned
 }
 

--- a/sdk/cliproxy/auth/routing_groups_test.go
+++ b/sdk/cliproxy/auth/routing_groups_test.go
@@ -143,8 +143,8 @@ func TestAuthGroupsMatchesLegacyOAuthEmailAfterRename(t *testing.T) {
 	if _, ok := groups["team-alpha"]; !ok {
 		t.Fatalf("expected group match through legacy email alias, got %v", groups)
 	}
-	if got, ok := derivedGroupPriority(runtimeCfg, auth, map[string]struct{}{"team-alpha": {}}); !ok || got != 100 {
-		t.Fatalf("derivedGroupPriority() = %d, want 100", got)
+	if got, ok := derivedGroupWeight(runtimeCfg, auth, map[string]struct{}{"team-alpha": {}}); !ok || got != 100 {
+		t.Fatalf("derivedGroupWeight() = %d, want 100", got)
 	}
 }
 
@@ -281,7 +281,7 @@ func TestAuthGroupsIgnoresHiddenDisplayTags(t *testing.T) {
 	}
 }
 
-func TestDerivedGroupPriorityPreservesExplicitZero(t *testing.T) {
+func TestDerivedGroupWeightPreservesExplicitZero(t *testing.T) {
 	t.Parallel()
 
 	cfg := &internalconfig.Config{
@@ -290,10 +290,14 @@ func TestDerivedGroupPriorityPreservesExplicitZero(t *testing.T) {
 				{
 					Name: "team-alpha",
 					Match: internalconfig.ChannelGroupMatch{
-						Channels: []string{"chatgpt-pro1"},
+						Channels: []string{"chatgpt-pro1", "chatgpt-pro2"},
 					},
-					ChannelPriorities: map[string]int{
-						"chatgpt-pro1": 0,
+					Scheduling: internalconfig.GroupScheduling{
+						Distribution: internalconfig.DistributionWeighted,
+						ChannelWeights: map[string]int{
+							"chatgpt-pro1": 0,
+							"chatgpt-pro2": 1,
+						},
 					},
 				},
 			},
@@ -302,20 +306,23 @@ func TestDerivedGroupPriorityPreservesExplicitZero(t *testing.T) {
 	auth := &Auth{Label: "chatgpt-pro1"}
 
 	runtimeCfg := newRuntimeConfigSnapshot(cfg)
-	got, ok := derivedGroupPriority(runtimeCfg, auth, map[string]struct{}{"team-alpha": {}})
+	got, ok := derivedGroupWeight(runtimeCfg, auth, map[string]struct{}{"team-alpha": {}})
 	if !ok {
-		t.Fatal("derivedGroupPriority() did not report an explicit priority")
+		t.Fatal("derivedGroupWeight() did not report an explicit weight")
 	}
 	if got != 0 {
-		t.Fatalf("derivedGroupPriority() = %d, want 0", got)
+		t.Fatalf("derivedGroupWeight() = %d, want 0", got)
 	}
 
 	prepared := prepareCandidateForSelection(runtimeCfg, auth, "", map[string]struct{}{"team-alpha": {}})
 	if prepared == nil {
 		t.Fatal("prepareCandidateForSelection() = nil")
 	}
-	if got := prepared.Attributes["priority"]; got != "0" {
-		t.Fatalf("prepared priority = %q, want %q", got, "0")
+	if got := prepared.Attributes[selectionWeightAttribute]; got != "0" {
+		t.Fatalf("prepared weight = %q, want %q", got, "0")
+	}
+	if authParticipatesInSelection(prepared) {
+		t.Fatal("weight 0 must exclude the candidate from scheduling")
 	}
 }
 

--- a/sdk/cliproxy/auth/scheduling_metadata.go
+++ b/sdk/cliproxy/auth/scheduling_metadata.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"strconv"
+	"strings"
+
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+// Selection-scoped metadata keys. The Selector interface is fixed by the SDK
+// contract, so per-group scheduling settings travel with the request options
+// rather than through the selector constructor. That also keeps the selectors
+// themselves singletons, which is required for their cursors, sticky bindings
+// and pressure counters to survive across requests.
+const (
+	distributionMetadataKey  = "scheduling_distribution"
+	stickyMaxRequestsKey     = "sticky_max_requests"
+	stickyReleaseAtLoadKey   = "sticky_release_at_load"
+	stickyEnabledMetadataKey = "sticky_enabled"
+)
+
+type stickyLimits struct {
+	maxRequests   int
+	releaseAtLoad float64
+}
+
+func distributionFromMetadata(meta map[string]any) string {
+	return sdkconfig.NormalizeDistribution(metadataStringValue(meta, distributionMetadataKey))
+}
+
+func stickyEnabledFromMetadata(meta map[string]any) bool {
+	value := strings.TrimSpace(metadataStringValue(meta, stickyEnabledMetadataKey))
+	if value == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(value)
+	return err == nil && enabled
+}
+
+func stickyLimitsFromMetadata(meta map[string]any) stickyLimits {
+	limits := stickyLimits{}
+	if raw := strings.TrimSpace(metadataStringValue(meta, stickyMaxRequestsKey)); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			limits.maxRequests = parsed
+		}
+	}
+	if raw := strings.TrimSpace(metadataStringValue(meta, stickyReleaseAtLoadKey)); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			limits.releaseAtLoad = parsed
+		}
+	}
+	return limits
+}

--- a/sdk/cliproxy/auth/scheduling_test.go
+++ b/sdk/cliproxy/auth/scheduling_test.go
@@ -1,0 +1,374 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+func weightedAuth(id string, weight int) *Auth {
+	auth := &Auth{ID: id, Label: id, Provider: "codex"}
+	if weight >= 0 {
+		auth.Attributes = map[string]string{selectionWeightAttribute: fmt.Sprint(weight)}
+	}
+	return auth
+}
+
+func distributionOptions(distribution string) cliproxyexecutor.Options {
+	return cliproxyexecutor.Options{Metadata: map[string]any{
+		distributionMetadataKey: distribution,
+	}}
+}
+
+// The pre-scheduling code kept only the highest priority tier whenever the group
+// used session-sticky or fill-first, so an account with no configured priority
+// was dropped as soon as any sibling had one. Weights must instead let every
+// positive-weight account participate.
+func TestGetAvailableAuthsKeepsLowerWeightsInScope(t *testing.T) {
+	t.Parallel()
+
+	auths := []*Auth{
+		weightedAuth("configured", 1),
+		{ID: "unconfigured", Label: "unconfigured", Provider: "codex"},
+	}
+
+	available, err := getAvailableAuths(auths, "codex", "gpt-5.6-sol", time.Now())
+	if err != nil {
+		t.Fatalf("getAvailableAuths() error = %v", err)
+	}
+	if len(available) != 2 {
+		t.Fatalf("len(available) = %d, want 2 (an unweighted account still participates)", len(available))
+	}
+}
+
+func TestGetAvailableAuthsReportsWeightExclusionDistinctly(t *testing.T) {
+	t.Parallel()
+
+	auths := []*Auth{weightedAuth("a", 0), weightedAuth("b", 0)}
+
+	_, err := getAvailableAuths(auths, "codex", "gpt-5.6-sol", time.Now())
+	if err == nil {
+		t.Fatal("getAvailableAuths() error = nil, want a weight-exclusion error")
+	}
+	authErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("getAvailableAuths() error type = %T, want *Error", err)
+	}
+	if authErr.Code != "auth_excluded_by_weight" {
+		t.Fatalf("error code = %q, want %q", authErr.Code, "auth_excluded_by_weight")
+	}
+}
+
+// A stored legacy `priority: 0` meant "default tier", not "excluded". Upgrading
+// must not take those accounts out of rotation.
+func TestLegacyPriorityZeroStillParticipates(t *testing.T) {
+	t.Parallel()
+
+	auth := &Auth{ID: "legacy", Attributes: map[string]string{"priority": "0"}}
+	if got := authSelectionWeight(auth); got != defaultSelectionWeight {
+		t.Fatalf("authSelectionWeight() = %d, want %d", got, defaultSelectionWeight)
+	}
+}
+
+func TestMigrateLegacyPrioritiesDropsAllZeroMap(t *testing.T) {
+	t.Parallel()
+
+	allZero := map[string]int{"a": 0, "b": 0}
+	if got := internalconfig.MigrateLegacyPriorities(allZero); got != nil {
+		t.Fatalf("MigrateLegacyPriorities(all zero) = %v, want nil", got)
+	}
+
+	mixed := map[string]int{"a": 0, "b": 2}
+	if got := internalconfig.MigrateLegacyPriorities(mixed); len(got) != 2 {
+		t.Fatalf("MigrateLegacyPriorities(mixed) = %v, want the map preserved", got)
+	}
+}
+
+func TestWeightedDistributionRespectsShare(t *testing.T) {
+	t.Parallel()
+
+	selector := &RoundRobinSelector{}
+	auths := []*Auth{weightedAuth("heavy", 3), weightedAuth("light", 1)}
+
+	counts := map[string]int{}
+	for i := 0; i < 400; i++ {
+		picked, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", distributionOptions("weighted"), auths)
+		if err != nil {
+			t.Fatalf("Pick() error = %v", err)
+		}
+		counts[picked.ID]++
+	}
+	if counts["heavy"] != 300 || counts["light"] != 100 {
+		t.Fatalf("counts = %v, want heavy=300 light=100 for a 3:1 weighting", counts)
+	}
+}
+
+func TestLeastLoadSpreadsAcrossAccounts(t *testing.T) {
+	t.Parallel()
+
+	deps := &schedulerDeps{tracker: newSelectionPressureTracker(), limiter: NewAccountConcurrencyLimiter()}
+	selector := &LeastLoadSelector{deps: deps}
+	auths := []*Auth{
+		{ID: "a", Provider: "codex"},
+		{ID: "b", Provider: "codex"},
+		{ID: "c", Provider: "codex"},
+	}
+
+	counts := map[string]int{}
+	for i := 0; i < 300; i++ {
+		picked, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", distributionOptions("least-load"), auths)
+		if err != nil {
+			t.Fatalf("Pick() error = %v", err)
+		}
+		counts[picked.ID]++
+	}
+	for id, count := range counts {
+		if count < 90 || count > 110 {
+			t.Fatalf("counts = %v, account %q is off an even split", counts, id)
+		}
+	}
+}
+
+func TestLeastLoadHonoursWeightRatio(t *testing.T) {
+	t.Parallel()
+
+	deps := &schedulerDeps{tracker: newSelectionPressureTracker(), limiter: NewAccountConcurrencyLimiter()}
+	selector := &LeastLoadSelector{deps: deps}
+	auths := []*Auth{weightedAuth("heavy", 3), weightedAuth("light", 1)}
+
+	counts := map[string]int{}
+	for i := 0; i < 200; i++ {
+		picked, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", distributionOptions("least-load"), auths)
+		if err != nil {
+			t.Fatalf("Pick() error = %v", err)
+		}
+		counts[picked.ID]++
+	}
+	// A 3:1 weighting should land near 150/50; allow slack for decay timing.
+	if counts["heavy"] < 130 || counts["heavy"] > 170 {
+		t.Fatalf("counts = %v, want heavy near 150 for a 3:1 weighting", counts)
+	}
+}
+
+type stubQuotaSource map[string]float64
+
+func (s stubQuotaSource) QuotaLoadRatio(auth *Auth) (float64, bool) {
+	if auth == nil {
+		return 0, false
+	}
+	ratio, ok := s[auth.ID]
+	return ratio, ok
+}
+
+func TestLeastLoadAvoidsAccountNearQuotaCeiling(t *testing.T) {
+	t.Parallel()
+
+	deps := &schedulerDeps{
+		tracker: newSelectionPressureTracker(),
+		limiter: NewAccountConcurrencyLimiter(),
+		quota:   stubQuotaSource{"nearly-full": 0.95},
+	}
+	selector := &LeastLoadSelector{deps: deps}
+	auths := []*Auth{
+		{ID: "fresh", Provider: "codex"},
+		{ID: "nearly-full", Provider: "codex"},
+	}
+
+	counts := map[string]int{}
+	for i := 0; i < 100; i++ {
+		picked, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", distributionOptions("least-load"), auths)
+		if err != nil {
+			t.Fatalf("Pick() error = %v", err)
+		}
+		counts[picked.ID]++
+	}
+	if counts["fresh"] <= counts["nearly-full"] {
+		t.Fatalf("counts = %v, want the account with quota headroom to take the majority", counts)
+	}
+}
+
+// fill-first used to return available[0] after sorting by auth ID, so the burn
+// order was an internal identifier rather than anything the operator chose.
+func TestFillFirstFollowsWeightOrder(t *testing.T) {
+	t.Parallel()
+
+	deps := &schedulerDeps{tracker: newSelectionPressureTracker(), limiter: NewAccountConcurrencyLimiter()}
+	selector := &FillFirstSelector{deps: deps}
+	// "a" sorts first by ID but is configured as the lowest share.
+	auths := []*Auth{weightedAuth("a", 1), weightedAuth("z", 9)}
+
+	picked, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", distributionOptions("fill-first"), auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if picked.ID != "z" {
+		t.Fatalf("Pick() = %q, want the highest-weighted account %q", picked.ID, "z")
+	}
+}
+
+func TestFillFirstMovesOnWhenAccountIsFull(t *testing.T) {
+	t.Parallel()
+
+	deps := &schedulerDeps{
+		tracker: newSelectionPressureTracker(),
+		limiter: NewAccountConcurrencyLimiter(),
+		quota:   stubQuotaSource{"primary": 0.95},
+	}
+	selector := &FillFirstSelector{deps: deps}
+	auths := []*Auth{weightedAuth("primary", 9), weightedAuth("secondary", 1)}
+
+	picked, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", distributionOptions("fill-first"), auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if picked.ID != "secondary" {
+		t.Fatalf("Pick() = %q, want the next account once the primary is full", picked.ID)
+	}
+}
+
+func stickyOptions(sessionKey string, extra map[string]any) cliproxyexecutor.Options {
+	meta := map[string]any{
+		cliproxyexecutor.SessionStickyMetadataKey: sessionKey,
+		stickyEnabledMetadataKey:                  "true",
+	}
+	for key, value := range extra {
+		meta[key] = value
+	}
+	return cliproxyexecutor.Options{SourceFormat: "openai", Metadata: meta}
+}
+
+// The core of the "one long session burns one account" problem: a binding used
+// to survive until the account failed, so a busy conversation kept the same
+// upstream until it hit a 429.
+func TestSessionStickyReleasesAfterMaxRequests(t *testing.T) {
+	t.Parallel()
+
+	deps := &schedulerDeps{tracker: newSelectionPressureTracker(), limiter: NewAccountConcurrencyLimiter()}
+	selector := NewSessionStickySelector(&RoundRobinSelector{deps: deps})
+	selector.deps = deps
+	auths := []*Auth{{ID: "a", Provider: "codex"}, {ID: "b", Provider: "codex"}}
+	opts := stickyOptions("sess-1", map[string]any{stickyMaxRequestsKey: "3"})
+
+	seen := make([]string, 0, 6)
+	for i := 0; i < 6; i++ {
+		picked, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", opts, auths)
+		if err != nil {
+			t.Fatalf("Pick() #%d error = %v", i, err)
+		}
+		seen = append(seen, picked.ID)
+	}
+
+	// First three requests pin one account, then the binding is released and the
+	// distribution places the session on the other one.
+	if seen[0] != seen[1] || seen[1] != seen[2] {
+		t.Fatalf("picks = %v, want the first three requests pinned to one account", seen)
+	}
+	if seen[3] == seen[0] {
+		t.Fatalf("picks = %v, want a different account after max-requests was reached", seen)
+	}
+}
+
+func TestSessionStickyReleasesWhenBoundAccountIsLoaded(t *testing.T) {
+	t.Parallel()
+
+	deps := &schedulerDeps{
+		tracker: newSelectionPressureTracker(),
+		limiter: NewAccountConcurrencyLimiter(),
+		quota:   stubQuotaSource{"a": 0.9},
+	}
+	selector := NewSessionStickySelector(&RoundRobinSelector{deps: deps})
+	selector.deps = deps
+	auths := []*Auth{{ID: "a", Provider: "codex"}, {ID: "b", Provider: "codex"}}
+
+	// Bind the session to "a" while it still looks healthy.
+	bindOpts := stickyOptions("sess-1", nil)
+	first, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", bindOpts, auths)
+	if err != nil {
+		t.Fatalf("Pick() first error = %v", err)
+	}
+	if first.ID != "a" {
+		t.Fatalf("Pick() first = %q, want a", first.ID)
+	}
+
+	// Now the same session runs under a group that releases at 80% load.
+	releaseOpts := stickyOptions("sess-1", map[string]any{stickyReleaseAtLoadKey: "0.8"})
+	second, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", releaseOpts, auths)
+	if err != nil {
+		t.Fatalf("Pick() second error = %v", err)
+	}
+	if second.ID != "b" {
+		t.Fatalf("Pick() second = %q, want b once the bound account passed the release threshold", second.ID)
+	}
+}
+
+// Overflow used to reset the whole binding map, moving every live conversation
+// onto a different account at the same moment.
+func TestSessionStickyOverflowEvictsOnlyColdBindings(t *testing.T) {
+	t.Parallel()
+
+	deps := &schedulerDeps{tracker: newSelectionPressureTracker(), limiter: NewAccountConcurrencyLimiter()}
+	selector := NewSessionStickySelector(&RoundRobinSelector{deps: deps})
+	selector.deps = deps
+	selector.maxKeys = 4
+	auths := []*Auth{{ID: "a", Provider: "codex"}, {ID: "b", Provider: "codex"}}
+
+	hot := stickyOptions("hot-session", nil)
+	hotFirst, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", hot, auths)
+	if err != nil {
+		t.Fatalf("Pick() hot error = %v", err)
+	}
+
+	// Fill the table well past its cap with unrelated sessions, touching the hot
+	// session in between so it stays the most recently used entry.
+	for i := 0; i < 12; i++ {
+		_, _ = selector.Pick(context.Background(), "codex", "gpt-5.6-sol", stickyOptions(fmt.Sprintf("cold-%d", i), nil), auths)
+		_, _ = selector.Pick(context.Background(), "codex", "gpt-5.6-sol", hot, auths)
+	}
+
+	hotAgain, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", hot, auths)
+	if err != nil {
+		t.Fatalf("Pick() hot again error = %v", err)
+	}
+	if hotAgain.ID != hotFirst.ID {
+		t.Fatalf("hot session moved from %q to %q; overflow must not evict live bindings", hotFirst.ID, hotAgain.ID)
+	}
+}
+
+// Stickiness must not swallow the distribution: new sessions are still placed
+// by the configured mode.
+func TestSessionStickyDelegatesNewSessionsToDistribution(t *testing.T) {
+	t.Parallel()
+
+	deps := &schedulerDeps{tracker: newSelectionPressureTracker(), limiter: NewAccountConcurrencyLimiter()}
+	leastLoad := &LeastLoadSelector{deps: deps}
+	selector := NewSessionStickySelector(nil)
+	selector.deps = deps
+	selector.distribution = func(name string) Selector {
+		if name != internalconfig.DistributionLeastLoad {
+			t.Fatalf("distribution = %q, want least-load to be honoured under stickiness", name)
+		}
+		return leastLoad
+	}
+	auths := []*Auth{{ID: "a", Provider: "codex"}, {ID: "b", Provider: "codex"}, {ID: "c", Provider: "codex"}}
+
+	counts := map[string]int{}
+	for i := 0; i < 60; i++ {
+		opts := stickyOptions(fmt.Sprintf("sess-%d", i), map[string]any{
+			distributionMetadataKey: internalconfig.DistributionLeastLoad,
+		})
+		picked, err := selector.Pick(context.Background(), "codex", "gpt-5.6-sol", opts, auths)
+		if err != nil {
+			t.Fatalf("Pick() #%d error = %v", i, err)
+		}
+		counts[picked.ID]++
+	}
+	for id, count := range counts {
+		if count < 15 || count > 25 {
+			t.Fatalf("counts = %v, account %q is off an even split of new sessions", counts, id)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -11,27 +11,75 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 )
 
-// RoundRobinSelector provides a simple provider scoped round-robin selection strategy.
+// schedulerDeps carries the shared, cross-request signals a distribution mode
+// may consult. All fields are optional: a zero-value selector still works, it
+// just falls back to weight-only decisions.
+type schedulerDeps struct {
+	tracker *selectionPressureTracker
+	limiter *AccountConcurrencyLimiter
+	quota   QuotaLoadSource
+}
+
+func (d *schedulerDeps) observeSelection(auth *Auth, now time.Time) {
+	if d == nil || auth == nil {
+		return
+	}
+	d.tracker.observe(auth.ID, now)
+}
+
+func (d *schedulerDeps) loadRatio(auth *Auth) float64 {
+	if d == nil {
+		return 0
+	}
+	return accountLoadRatio(auth, d.limiter, d.quota)
+}
+
+func (d *schedulerDeps) pressure(auth *Auth, now time.Time) float64 {
+	if d == nil || auth == nil {
+		return 0
+	}
+	return d.tracker.pressure(auth.ID, now)
+}
+
+// RoundRobinSelector distributes requests across candidates in proportion to
+// their configured weight (smooth weighted round-robin). With every weight left
+// at the default 1 it degenerates to plain round-robin, which is why the name
+// is kept for SDK compatibility.
 type RoundRobinSelector struct {
 	mu       sync.Mutex
 	cursors  map[string]int
 	weighted map[string]*weightedCursorState
 	maxKeys  int
+	deps     *schedulerDeps
 }
 
-// FillFirstSelector selects the first available credential (deterministic ordering).
-// This "burns" one account before moving to the next, which can help stagger
-// rolling-window subscription caps (e.g. chat message limits).
-type FillFirstSelector struct{}
+// FillFirstSelector keeps sending traffic to the highest-weighted account until
+// that account approaches its ceiling, then moves to the next one. This
+// staggers rolling-window subscription caps instead of draining every account
+// at the same rate.
+//
+// The previous implementation returned `available[0]` after sorting by auth ID,
+// so which account got burned depended on an opaque internal identifier and it
+// only ever moved on after a hard 429.
+type FillFirstSelector struct {
+	deps *schedulerDeps
+}
 
-// Pick selects the next available auth for the provider in a round-robin manner.
-// For gemini-cli virtual auths (identified by the gemini_virtual_parent attribute),
-// a two-level round-robin is used: first cycling across credential groups (parent
-// accounts), then cycling within each group's project auths.
+// fillFirstSwitchLoad is the load ratio at which fill-first considers an
+// account "full enough" and moves to the next one. It stops short of 1.0 so the
+// switch happens before the upstream starts rejecting requests.
+const fillFirstSwitchLoad = 0.9
+
+// Pick selects the next auth for the provider, weighted by configuration.
+//
+// For gemini-cli virtual auths (identified by the gemini_virtual_parent
+// attribute) a two-level round-robin is used instead: first cycling across
+// credential groups (parent accounts), then within each group's project auths.
+// Weights are not applied there because those entries are projects of one
+// credential, not independently billed accounts.
 func (s *RoundRobinSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	now := time.Now()
-	weightedSelection := isWeightedPrioritySelection(opts.Metadata)
-	available, err := getAvailableAuths(auths, provider, model, now, weightedSelection)
+	available, err := getAvailableAuths(auths, provider, model, now)
 	if err != nil {
 		return nil, err
 	}
@@ -44,19 +92,6 @@ func (s *RoundRobinSelector) Pick(ctx context.Context, provider, model string, o
 	limit := s.maxKeys
 	if limit <= 0 {
 		limit = 4096
-	}
-	if weightedSelection {
-		if s.weighted == nil {
-			s.weighted = make(map[string]*weightedCursorState)
-		}
-		weightedKey := weightedSelectionKey(provider, model, opts)
-		s.weighted = ensureWeightedState(s.weighted, weightedKey, limit)
-		selected := pickWeightedAvailable(s.weighted, weightedKey, available)
-		s.mu.Unlock()
-		if selected == nil {
-			return nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
-		}
-		return selected, nil
 	}
 
 	// Check if any available auth has gemini_virtual_parent attribute,
@@ -88,18 +123,23 @@ func (s *RoundRobinSelector) Pick(ctx context.Context, provider, model string, o
 		}
 		s.cursors[innerKey] = innerIndex + 1
 		s.mu.Unlock()
-		return group[innerIndex%len(group)], nil
+		selected := group[innerIndex%len(group)]
+		s.deps.observeSelection(selected, now)
+		return selected, nil
 	}
 
-	// Flat round-robin for non-grouped auths (original behavior).
-	s.ensureCursorKey(key, limit)
-	index := s.cursors[key]
-	if index >= 2_147_483_640 {
-		index = 0
+	if s.weighted == nil {
+		s.weighted = make(map[string]*weightedCursorState)
 	}
-	s.cursors[key] = index + 1
+	weightedKey := weightedSelectionKey(provider, model, opts)
+	s.weighted = ensureWeightedState(s.weighted, weightedKey, limit)
+	selected := pickWeightedAvailable(s.weighted, weightedKey, available)
 	s.mu.Unlock()
-	return available[index%len(available)], nil
+	if selected == nil {
+		return nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	s.deps.observeSelection(selected, now)
+	return selected, nil
 }
 
 // ensureCursorKey ensures the cursor map has capacity for the given key.
@@ -139,13 +179,40 @@ func groupByVirtualParent(auths []*Auth) (map[string][]*Auth, []string) {
 	return groups, parentOrder
 }
 
-// Pick selects the first available auth for the provider in a deterministic manner.
+// Pick returns the highest-weighted account that still has headroom, falling
+// back to the least loaded one when every candidate is near its ceiling.
 func (s *FillFirstSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	now := time.Now()
-	available, err := getAvailableAuths(auths, provider, model, now, false)
+	available, err := getAvailableAuths(auths, provider, model, now)
 	if err != nil {
 		return nil, err
 	}
 	available = preferCodexWebsocketAuths(ctx, provider, available)
-	return available[0], nil
+
+	ordered := make([]*Auth, len(available))
+	copy(ordered, available)
+	// Highest weight first; ties keep the stable ID order from getAvailableAuths
+	// so the fill order is reproducible across restarts.
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return authSelectionWeight(ordered[i]) > authSelectionWeight(ordered[j])
+	})
+
+	var fallback *Auth
+	fallbackLoad := 0.0
+	for _, candidate := range ordered {
+		load := s.deps.loadRatio(candidate)
+		if load < fillFirstSwitchLoad {
+			s.deps.observeSelection(candidate, now)
+			return candidate, nil
+		}
+		if fallback == nil || load < fallbackLoad {
+			fallback = candidate
+			fallbackLoad = load
+		}
+	}
+	if fallback == nil {
+		fallback = ordered[0]
+	}
+	s.deps.observeSelection(fallback, now)
+	return fallback, nil
 }

--- a/sdk/cliproxy/auth/selector_availability.go
+++ b/sdk/cliproxy/auth/selector_availability.go
@@ -11,29 +11,6 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 )
 
-func authPriority(auth *Auth) int {
-	priority, ok := authPriorityValue(auth)
-	if !ok {
-		return 0
-	}
-	return priority
-}
-
-func authPriorityValue(auth *Auth) (int, bool) {
-	if auth == nil || auth.Attributes == nil {
-		return 0, false
-	}
-	raw := strings.TrimSpace(auth.Attributes["priority"])
-	if raw == "" {
-		return 0, false
-	}
-	parsed, err := strconv.Atoi(raw)
-	if err != nil {
-		return 0, false
-	}
-	return parsed, true
-}
-
 func canonicalModelKey(model string) string {
 	model = strings.TrimSpace(model)
 	if model == "" {
@@ -103,14 +80,17 @@ func preferCodexWebsocketAuths(ctx context.Context, provider string, available [
 	return available
 }
 
-func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (available map[int][]*Auth, cooldownCount int, cooldownEarliest time.Time, temporaryCount int, temporaryEarliest time.Time) {
-	available = make(map[int][]*Auth)
+// collectAvailableAuths partitions candidates into "can serve now" and the
+// diagnostic counters used to explain an empty result. Weight filtering is not
+// applied here: an excluded (weight 0) candidate must not be reported as being
+// in cooldown, so the caller drops those separately.
+func collectAvailableAuths(auths []*Auth, model string, now time.Time) (available []*Auth, cooldownCount int, cooldownEarliest time.Time, temporaryCount int, temporaryEarliest time.Time) {
+	available = make([]*Auth, 0, len(auths))
 	for i := 0; i < len(auths); i++ {
 		candidate := auths[i]
 		blocked, reason, next := isAuthBlockedForModel(candidate, model, now)
 		if !blocked {
-			priority := authPriority(candidate)
-			available[priority] = append(available[priority], candidate)
+			available = append(available, candidate)
 			continue
 		}
 		if reason == blockReasonCooldown {
@@ -200,28 +180,23 @@ func weightedSelectionScope(meta map[string]any) string {
 	return ""
 }
 
-func isWeightedPrioritySelection(meta map[string]any) bool {
-	return weightedSelectionScope(meta) != ""
-}
-
-func authSelectionWeight(auth *Auth) int {
-	weight, ok := authPriorityValue(auth)
-	if !ok {
-		return 1
-	}
-	if weight <= 0 {
-		return 0
-	}
-	return weight
-}
-
-func getAvailableAuths(auths []*Auth, provider, model string, now time.Time, includeAllPriorities bool) ([]*Auth, error) {
+// getAvailableAuths returns every candidate that can serve the request right
+// now, in a stable order.
+//
+// It deliberately has one behaviour for all distribution modes. The previous
+// implementation took an `includeAllPriorities` flag: round-robin passed true
+// and treated the priority as a weight, while session-sticky and fill-first
+// passed false and kept only the single highest priority tier. The same number
+// therefore meant "share" in one group and "hard cutoff" in another, and an
+// account with no configured priority (tier 0) was silently excluded from any
+// group where somebody else had set 1.
+func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]*Auth, error) {
 	if len(auths) == 0 {
 		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
 	}
 
-	availableByPriority, cooldownCount, earliest, temporaryCount, temporaryEarliest := collectAvailableByPriority(auths, model, now)
-	if len(availableByPriority) == 0 {
+	available, cooldownCount, earliest, temporaryCount, temporaryEarliest := collectAvailableAuths(auths, model, now)
+	if len(available) == 0 {
 		if cooldownCount == len(auths) && !earliest.IsZero() {
 			providerForError := provider
 			if providerForError == "mixed" {
@@ -247,49 +222,21 @@ func getAvailableAuths(auths []*Auth, provider, model string, now time.Time, inc
 		return nil, &Error{Code: "auth_unavailable", Message: "no auth available"}
 	}
 
-	if includeAllPriorities {
-		priorities := make([]int, 0, len(availableByPriority))
-		total := 0
-		for priority, items := range availableByPriority {
-			priorities = append(priorities, priority)
-			for _, item := range items {
-				if authSelectionWeight(item) > 0 {
-					total++
-				}
-			}
-		}
-		sort.Ints(priorities)
-
-		available := make([]*Auth, 0, total)
-		for _, priority := range priorities {
-			for _, item := range availableByPriority[priority] {
-				if authSelectionWeight(item) <= 0 {
-					continue
-				}
-				available = append(available, item)
-			}
-		}
-		if len(available) == 0 {
-			return nil, &Error{Code: "auth_unavailable", Message: "no auth available"}
-		}
-		sort.Slice(available, func(i, j int) bool { return available[i].ID < available[j].ID })
-		return available, nil
-	}
-
-	bestPriority := 0
-	found := false
-	for priority := range availableByPriority {
-		if !found || priority > bestPriority {
-			bestPriority = priority
-			found = true
+	scheduled := make([]*Auth, 0, len(available))
+	for _, candidate := range available {
+		if authParticipatesInSelection(candidate) {
+			scheduled = append(scheduled, candidate)
 		}
 	}
-
-	available := availableByPriority[bestPriority]
-	if len(available) > 1 {
-		sort.Slice(available, func(i, j int) bool { return available[i].ID < available[j].ID })
+	if len(scheduled) == 0 {
+		// Healthy accounts exist but every one of them is weighted 0. Saying
+		// "no auth available" here would send the operator hunting for a quota
+		// or auth problem that does not exist.
+		return nil, &Error{Code: "auth_excluded_by_weight", Message: "every candidate in this routing scope is configured with weight 0"}
 	}
-	return available, nil
+
+	sort.Slice(scheduled, func(i, j int) bool { return scheduled[i].ID < scheduled[j].ID })
+	return scheduled, nil
 }
 
 func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, blockReason, time.Time) {

--- a/sdk/cliproxy/auth/selector_least_load.go
+++ b/sdk/cliproxy/auth/selector_least_load.go
@@ -1,0 +1,72 @@
+package auth
+
+import (
+	"context"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+// LeastLoadSelector sends each request to the account that is currently
+// carrying the least work relative to its configured weight.
+//
+// Weighted round-robin balances the *count* of requests, which is the right
+// answer only when every request costs the same. In practice one agent session
+// can hold a single account busy for minutes while short requests cycle past
+// it, so counting alone still produces a lopsided distribution. This mode
+// scores candidates on observed pressure instead:
+//
+//	score = (recent selection pressure + in-flight requests) / weight
+//
+// and additionally penalises accounts approaching their quota ceiling, so a
+// nearly-exhausted account sheds traffic before it starts returning 429s.
+type LeastLoadSelector struct {
+	deps *schedulerDeps
+}
+
+// quotaLoadPenalty scales a candidate's score as it approaches its quota
+// ceiling. At load 0 the score is untouched; at load 1 it is multiplied by
+// 1+quotaLoadPenalty, which is enough to move traffic away without hard-banning
+// an account that still has headroom.
+const quotaLoadPenalty = 4.0
+
+func (s *LeastLoadSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	now := time.Now()
+	available, err := getAvailableAuths(auths, provider, model, now)
+	if err != nil {
+		return nil, err
+	}
+	available = preferCodexWebsocketAuths(ctx, provider, available)
+
+	var best *Auth
+	bestScore := 0.0
+	for _, candidate := range available {
+		score := s.score(candidate, now)
+		// available is already sorted by ID, so a strict comparison keeps the
+		// selection deterministic when several accounts are equally idle.
+		if best == nil || score < bestScore {
+			best = candidate
+			bestScore = score
+		}
+	}
+	if best == nil {
+		return nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	s.deps.observeSelection(best, now)
+	return best, nil
+}
+
+func (s *LeastLoadSelector) score(candidate *Auth, now time.Time) float64 {
+	weight := authSelectionWeight(candidate)
+	if weight <= 0 {
+		// getAvailableAuths already filtered these out; guard against a caller
+		// handing us a pre-filtered slice that skipped that step.
+		weight = 1
+	}
+	load := s.deps.pressure(candidate, now)
+	if s.deps != nil && s.deps.limiter != nil {
+		load += float64(s.deps.limiter.GetInFlight(candidate.ID))
+	}
+	score := load / float64(weight)
+	return score * (1 + quotaLoadPenalty*s.deps.loadRatio(candidate))
+}

--- a/sdk/cliproxy/auth/selector_session_sticky.go
+++ b/sdk/cliproxy/auth/selector_session_sticky.go
@@ -21,14 +21,28 @@ const (
 type sessionStickyBinding struct {
 	authID    string
 	expiresAt time.Time
+	// requests counts how many times this binding has been honoured. It bounds
+	// how long one conversation may pin a single upstream account.
+	requests   int
+	lastUsedAt time.Time
 }
 
-// SessionStickySelector keeps stable client sessions on the same auth while it remains available.
+// SessionStickySelector keeps a client session on the same auth while that auth
+// remains a sensible target.
+//
+// Stickiness is a constraint layered on top of a distribution mode, not a
+// distribution mode of its own: it only pins conversations that are already
+// running. Every new conversation, and every conversation whose binding was
+// released, is placed by the group's configured distribution.
 type SessionStickySelector struct {
 	mu       sync.Mutex
-	bindings map[string]sessionStickyBinding
-	fallback Selector
-	maxKeys  int
+	bindings map[string]*sessionStickyBinding
+	// fallback is used when no distribution resolver is wired (SDK embedders
+	// constructing this selector directly).
+	fallback     Selector
+	distribution func(name string) Selector
+	deps         *schedulerDeps
+	maxKeys      int
 }
 
 func NewSessionStickySelector(fallback Selector) *SessionStickySelector {
@@ -45,20 +59,15 @@ func (s *SessionStickySelector) Pick(ctx context.Context, provider, model string
 	}
 
 	now := time.Now()
-	available, err := getAvailableAuths(auths, provider, model, now, false)
+	available, err := getAvailableAuths(auths, provider, model, now)
 	if err != nil {
 		return nil, err
 	}
 	available = preferCodexWebsocketAuths(ctx, provider, available)
 
-	if boundID := s.boundAuthID(key, now); boundID != "" {
-		for _, auth := range available {
-			if auth != nil && auth.ID == boundID {
-				s.refreshBinding(key, boundID, now)
-				return auth, nil
-			}
-		}
-		s.deleteBinding(key)
+	limits := stickyLimitsFromMetadata(opts.Metadata)
+	if bound := s.honourBinding(key, available, limits, now); bound != nil {
+		return bound, nil
 	}
 
 	selected, err := s.pickFallback(ctx, provider, model, opts, available)
@@ -66,53 +75,116 @@ func (s *SessionStickySelector) Pick(ctx context.Context, provider, model string
 		return nil, err
 	}
 	if selected != nil && strings.TrimSpace(selected.ID) != "" {
-		s.refreshBinding(key, selected.ID, now)
+		s.bind(key, selected.ID, now)
 	}
 	return selected, nil
 }
 
-func (s *SessionStickySelector) pickFallback(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
-	if s == nil || s.fallback == nil {
-		return (&RoundRobinSelector{}).Pick(ctx, provider, model, opts, auths)
-	}
-	return s.fallback.Pick(ctx, provider, model, opts, auths)
-}
-
-func (s *SessionStickySelector) boundAuthID(key string, now time.Time) string {
+// honourBinding returns the bound auth when the binding is still valid, and
+// releases it otherwise. Releasing here (rather than only when the account goes
+// unavailable) is what stops a long session from burning one account until it
+// hits a 429.
+func (s *SessionStickySelector) honourBinding(key string, available []*Auth, limits stickyLimits, now time.Time) *Auth {
 	if s == nil || key == "" {
-		return ""
+		return nil
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	binding, ok := s.bindings[key]
-	if !ok {
-		return ""
+	if !ok || binding == nil {
+		return nil
 	}
 	if !binding.expiresAt.IsZero() && now.After(binding.expiresAt) {
 		delete(s.bindings, key)
-		return ""
+		return nil
 	}
-	return binding.authID
+	if limits.maxRequests > 0 && binding.requests >= limits.maxRequests {
+		delete(s.bindings, key)
+		return nil
+	}
+
+	var bound *Auth
+	for _, auth := range available {
+		if auth != nil && auth.ID == binding.authID {
+			bound = auth
+			break
+		}
+	}
+	if bound == nil {
+		delete(s.bindings, key)
+		return nil
+	}
+	if limits.releaseAtLoad > 0 && s.deps.loadRatio(bound) >= limits.releaseAtLoad {
+		delete(s.bindings, key)
+		return nil
+	}
+
+	binding.requests++
+	binding.lastUsedAt = now
+	binding.expiresAt = now.Add(sessionStickyTTL)
+	s.deps.observeSelection(bound, now)
+	return bound
 }
 
-func (s *SessionStickySelector) refreshBinding(key, authID string, now time.Time) {
+func (s *SessionStickySelector) pickFallback(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	if s == nil {
+		return (&RoundRobinSelector{}).Pick(ctx, provider, model, opts, auths)
+	}
+	if s.distribution != nil {
+		if selector := s.distribution(distributionFromMetadata(opts.Metadata)); selector != nil {
+			return selector.Pick(ctx, provider, model, opts, auths)
+		}
+	}
+	if s.fallback != nil {
+		return s.fallback.Pick(ctx, provider, model, opts, auths)
+	}
+	return (&RoundRobinSelector{}).Pick(ctx, provider, model, opts, auths)
+}
+
+func (s *SessionStickySelector) bind(key, authID string, now time.Time) {
 	if s == nil || key == "" || authID == "" {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.bindings == nil {
+		s.bindings = make(map[string]*sessionStickyBinding)
+	}
+	s.evictIfNeededLocked(key, now)
+	s.bindings[key] = &sessionStickyBinding{
+		authID:     authID,
+		expiresAt:  now.Add(sessionStickyTTL),
+		requests:   1,
+		lastUsedAt: now,
+	}
+}
+
+// evictIfNeededLocked makes room for a new binding by dropping expired entries
+// first and then the least recently used one. The previous implementation reset
+// the whole map on overflow, which re-shuffled every live conversation onto a
+// different account at once. Must be called with s.mu held.
+func (s *SessionStickySelector) evictIfNeededLocked(incoming string, now time.Time) {
 	limit := s.maxKeys
 	if limit <= 0 {
 		limit = sessionStickyMaxKeys
 	}
-	if s.bindings == nil {
-		s.bindings = make(map[string]sessionStickyBinding)
-	} else if len(s.bindings) >= limit {
-		s.bindings = make(map[string]sessionStickyBinding)
+	if _, exists := s.bindings[incoming]; exists || len(s.bindings) < limit {
+		return
 	}
-	s.bindings[key] = sessionStickyBinding{
-		authID:    authID,
-		expiresAt: now.Add(sessionStickyTTL),
+	oldestKey := ""
+	oldestAt := time.Time{}
+	for key, binding := range s.bindings {
+		if binding == nil || (!binding.expiresAt.IsZero() && now.After(binding.expiresAt)) {
+			delete(s.bindings, key)
+			continue
+		}
+		if oldestKey == "" || binding.lastUsedAt.Before(oldestAt) {
+			oldestKey = key
+			oldestAt = binding.lastUsedAt
+		}
+	}
+	if len(s.bindings) >= limit && oldestKey != "" {
+		delete(s.bindings, oldestKey)
 	}
 }
 

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -159,7 +159,11 @@ func TestSessionStickyKeyUsesPromptCacheKey(t *testing.T) {
 	}
 }
 
-func TestRoundRobinSelectorPick_PriorityBuckets(t *testing.T) {
+// A legacy `priority: 0` marked the default tier, not an exclusion, so such an
+// account keeps a minimal share rather than being dropped from rotation on
+// upgrade. Higher values still dominate, which is what the original "priority
+// buckets" behaviour existed for.
+func TestRoundRobinSelectorPick_LegacyPriorityZeroKeepsMinimalShare(t *testing.T) {
 	t.Parallel()
 
 	selector := &RoundRobinSelector{}
@@ -169,8 +173,8 @@ func TestRoundRobinSelectorPick_PriorityBuckets(t *testing.T) {
 		{ID: "b", Attributes: map[string]string{"priority": "10"}},
 	}
 
-	want := []string{"a", "b", "a", "b"}
-	for i, id := range want {
+	counts := map[string]int{}
+	for i := 0; i < 210; i++ {
 		got, err := selector.Pick(context.Background(), "mixed", "", cliproxyexecutor.Options{}, auths)
 		if err != nil {
 			t.Fatalf("Pick() #%d error = %v", i, err)
@@ -178,12 +182,10 @@ func TestRoundRobinSelectorPick_PriorityBuckets(t *testing.T) {
 		if got == nil {
 			t.Fatalf("Pick() #%d auth = nil", i)
 		}
-		if got.ID != id {
-			t.Fatalf("Pick() #%d auth.ID = %q, want %q", i, got.ID, id)
-		}
-		if got.ID == "c" {
-			t.Fatalf("Pick() #%d unexpectedly selected lower priority auth", i)
-		}
+		counts[got.ID]++
+	}
+	if counts["a"] != 100 || counts["b"] != 100 || counts["c"] != 10 {
+		t.Fatalf("counts = %v, want a=100 b=100 c=10 for weights 10:10:1", counts)
 	}
 }
 
@@ -295,7 +297,9 @@ func TestRoundRobinSelectorPick_AllowedChannelGroupZeroWeightIsExcluded(t *testi
 	}
 }
 
-func TestFillFirstSelectorPick_GroupedRouteUsesHighestPriorityFillFirst(t *testing.T) {
+// fill-first drains the highest-weighted account first; the weights here come
+// from the legacy priority attribute, which still maps onto a share.
+func TestFillFirstSelectorPick_GroupedRouteUsesHighestWeightFillFirst(t *testing.T) {
 	t.Parallel()
 
 	selector := &FillFirstSelector{}
@@ -834,7 +838,9 @@ func TestRoundRobinSelectorPick_ThinkingSuffixSharesCursor(t *testing.T) {
 	}
 }
 
-func TestRoundRobinSelectorPick_CursorKeyCap(t *testing.T) {
+// Flat (non gemini-virtual) selection keeps its per-model state in the weighted
+// cursor map, so that is where the key cap has to hold.
+func TestRoundRobinSelectorPick_WeightedStateKeyCap(t *testing.T) {
 	t.Parallel()
 
 	selector := &RoundRobinSelector{maxKeys: 2}
@@ -847,15 +853,15 @@ func TestRoundRobinSelectorPick_CursorKeyCap(t *testing.T) {
 	selector.mu.Lock()
 	defer selector.mu.Unlock()
 
-	if selector.cursors == nil {
-		t.Fatalf("selector.cursors = nil")
+	if selector.weighted == nil {
+		t.Fatalf("selector.weighted = nil")
 	}
-	if len(selector.cursors) != 1 {
-		t.Fatalf("len(selector.cursors) = %d, want %d", len(selector.cursors), 1)
+	if len(selector.weighted) != 1 {
+		t.Fatalf("len(selector.weighted) = %d, want %d", len(selector.weighted), 1)
 	}
-	expectedKey := defaultTenantID + ":gemini:m3"
-	if _, ok := selector.cursors[expectedKey]; !ok {
-		t.Fatalf("selector.cursors missing key %q", expectedKey)
+	expectedKey := defaultTenantID + ":gemini:m3:"
+	if _, ok := selector.weighted[expectedKey]; !ok {
+		t.Fatalf("selector.weighted missing key %q", expectedKey)
 	}
 }
 

--- a/sdk/cliproxy/auth/selector_weight.go
+++ b/sdk/cliproxy/auth/selector_weight.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"strconv"
+	"strings"
+)
+
+// selectionWeightAttribute carries the effective per-candidate weight resolved
+// from the routing group. It replaces the overloaded "priority" attribute,
+// which used to mean "relative share" under round-robin but "hard tier cutoff"
+// under session-sticky / fill-first — the same number produced opposite
+// routing decisions depending on the group's strategy.
+const selectionWeightAttribute = "selection_weight"
+
+// legacySelectionWeightAttribute is still honoured so credentials that carry a
+// hand-written attribute (there has never been a panel input for it) keep
+// working. It is only consulted when the routing group does not resolve a
+// weight for the candidate.
+const legacySelectionWeightAttribute = "priority"
+
+// defaultSelectionWeight matches the documented panel behaviour: a channel with
+// no configured weight participates with share 1.
+const defaultSelectionWeight = 1
+
+func parseWeightAttribute(auth *Auth, key string) (int, bool) {
+	if auth == nil || auth.Attributes == nil {
+		return 0, false
+	}
+	raw := strings.TrimSpace(auth.Attributes[key])
+	if raw == "" {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+// authSelectionWeight returns the relative share for a candidate.
+//
+// Semantics (uniform across every distribution mode):
+//   - unset      -> defaultSelectionWeight (1)
+//   - n > 0      -> relative share
+//   - 0 or below -> excluded from scheduling
+func authSelectionWeight(auth *Auth) int {
+	if weight, ok := parseWeightAttribute(auth, selectionWeightAttribute); ok {
+		if weight <= 0 {
+			return 0
+		}
+		return weight
+	}
+
+	// The legacy "priority" attribute is read with its own historical meaning:
+	// it was a tier, where 0 was simply the default tier every unconfigured
+	// credential landed in — not an exclusion. Interpreting a stored 0 as the
+	// new "weight 0 = do not schedule" would silently take existing accounts
+	// out of rotation on upgrade, so only positive legacy values carry over.
+	if weight, ok := parseWeightAttribute(auth, legacySelectionWeightAttribute); ok && weight > 0 {
+		return weight
+	}
+	return defaultSelectionWeight
+}
+
+// authParticipatesInSelection reports whether the candidate may receive traffic.
+func authParticipatesInSelection(auth *Auth) bool {
+	return authSelectionWeight(auth) > 0
+}

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -16,6 +16,8 @@ type RoutingConfig = bridgeconfig.RoutingConfig
 type RoutingChannelGroup = bridgeconfig.RoutingChannelGroup
 type RoutingPathRoute = bridgeconfig.RoutingPathRoute
 type ChannelGroupMatch = bridgeconfig.ChannelGroupMatch
+type GroupScheduling = bridgeconfig.GroupScheduling
+type GroupStickyConfig = bridgeconfig.GroupStickyConfig
 type TLSConfig = bridgeconfig.TLSConfig
 type PprofConfig = bridgeconfig.PprofConfig
 type RemoteManagement = bridgeconfig.RemoteManagement
@@ -54,7 +56,20 @@ const (
 	DefaultOllamaCloudBaseURL    = bridgeconfig.DefaultOllamaCloudBaseURL
 	DefaultCommandCodeBaseURL    = bridgeconfig.DefaultCommandCodeBaseURL
 	DefaultPprofAddr             = bridgeconfig.DefaultPprofAddr
+
+	DistributionWeighted     = bridgeconfig.DistributionWeighted
+	DistributionLeastLoad    = bridgeconfig.DistributionLeastLoad
+	DistributionFillFirst    = bridgeconfig.DistributionFillFirst
+	DefaultStickyMaxRequests = bridgeconfig.DefaultStickyMaxRequests
 )
+
+func NormalizeDistribution(value string) string {
+	return bridgeconfig.NormalizeDistribution(value)
+}
+
+func MigrateLegacyPriorities(priorities map[string]int) map[string]int {
+	return bridgeconfig.MigrateLegacyPriorities(priorities)
+}
 
 func LoadConfig(configFile string) (*Config, error) { return bridgeconfig.LoadConfig(configFile) }
 

--- a/sdkbridge/config/config.go
+++ b/sdkbridge/config/config.go
@@ -13,6 +13,8 @@ type RoutingConfig = internalconfig.RoutingConfig
 type RoutingChannelGroup = internalconfig.RoutingChannelGroup
 type RoutingPathRoute = internalconfig.RoutingPathRoute
 type ChannelGroupMatch = internalconfig.ChannelGroupMatch
+type GroupScheduling = internalconfig.GroupScheduling
+type GroupStickyConfig = internalconfig.GroupStickyConfig
 type TLSConfig = internalconfig.TLSConfig
 type PprofConfig = internalconfig.PprofConfig
 type RemoteManagement = internalconfig.RemoteManagement
@@ -51,7 +53,20 @@ const (
 	DefaultOllamaCloudBaseURL    = internalconfig.DefaultOllamaCloudBaseURL
 	DefaultCommandCodeBaseURL    = internalconfig.DefaultCommandCodeBaseURL
 	DefaultPprofAddr             = internalconfig.DefaultPprofAddr
+
+	DistributionWeighted     = internalconfig.DistributionWeighted
+	DistributionLeastLoad    = internalconfig.DistributionLeastLoad
+	DistributionFillFirst    = internalconfig.DistributionFillFirst
+	DefaultStickyMaxRequests = internalconfig.DefaultStickyMaxRequests
 )
+
+func NormalizeDistribution(value string) string {
+	return internalconfig.NormalizeDistribution(value)
+}
+
+func MigrateLegacyPriorities(priorities map[string]int) map[string]int {
+	return internalconfig.MigrateLegacyPriorities(priorities)
+}
 
 func LoadConfig(configFile string) (*Config, error) { return internalconfig.LoadConfig(configFile) }
 


### PR DESCRIPTION
## Why

Reported symptom: requests kept hammering one AI account with no discernible pattern, even though the accounts involved were configured identically.

Evidence from production (tenant `9e003dfb`, last 24h):

| account | requests | configured priority |
|---|---|---|
| `lanlanjiaxin@proton.me` | 6752 | 1 |
| `jd7njnb5nh@privaterelay.appleid.com` | 2181 | 1 |
| `rojasteresita717@gmail.com` | 48 | none |

Two independent defects produced this.

**1. The priority field had two opposite meanings.** `getAvailableAuths` took an `includeAllPriorities` flag. Round-robin passed `true` and treated priority as a weight; session-sticky and fill-first passed `false` and kept only the single highest tier. An account with no configured priority therefore sat in tier 0 and was silently excluded from any sticky group where a sibling had been given 1 — which is exactly why the third account above received almost no traffic. The panel copy ("priority is a weight, empty means 1, 0 excludes") only ever described the round-robin path.

**2. A sticky binding was released only when the bound account became unavailable.** With a sliding TTL refreshed on every hit, one long conversation held the same upstream account until it hit a 429.

## What changed

The `strategy` enum is replaced by a `scheduling` block with three orthogonal dimensions:

```yaml
scheduling:
  distribution: weighted   # weighted | least-load | fill-first
  sticky:
    enabled: true
    max-requests: 200
    release-at-load: 0.8
  channel-weights:
    account-a: 1
```

- `getAvailableAuths` loses the dual-semantics flag; weight means the same thing on every path (unset = 1, 0 = excluded)
- stickiness wraps a distribution rather than replacing it, and releases on `max-requests` or when the bound account passes `release-at-load`
- sticky overflow evicts LRU instead of clearing the whole table, which used to re-shuffle every live conversation at once
- `fill-first` drains by weight order and account load instead of auth-ID order
- `least-load` is new: scores on decayed selection pressure, in-flight requests and quota headroom
- group config now wins over a hand-written `priority` attribute, which had no panel input yet silently overrode everything configured in the group
- quota load is fed in from the persisted AI account status via a cached, non-blocking provider

## Migration

Deliberately conservative, because both legacy encodings of "0" meant *default tier*, not *excluded*:

- a stored `priority: 0` attribute is read as unset, not as an exclusion
- an all-zero `channel-priorities` map is dropped so its members fall back to weight 1 (a mixed map keeps its zeros, where 0 was already an exclusion)
- groups where every resolved member is weighted 0 are now rejected at save time instead of failing at runtime with an opaque `auth_unavailable`

For the tenant above this means the third account rejoins rotation at an equal share instead of never being selected.

## Compatibility

`strategy` and `channel-priorities` are kept mirrored with the new block, so an older binary or admin panel reading this config still sees coherent values during the staged rollout. The panel change ships in kittors/codeProxy#995 and should merge after this.

## Testing

`./scripts/ci-pr.sh` — passed (structure scan, gofmt, secret scan, `go vet`, `go test ./...` 98 packages, golangci-lint, build).

New coverage in `sdk/cliproxy/auth/scheduling_test.go`: weight-share ratios, weight exclusion reporting, legacy-zero handling, least-load spread and quota avoidance, fill-first weight order and switchover, sticky release on max-requests and on load, LRU overflow, and stickiness delegating new sessions to the configured distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)