### PR TITLE
fix(deploy): restore automatic dev deploys and stop cutover from picking a backup vhost

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      SHOULD_DEPLOY: ${{ github.event_name == 'workflow_dispatch' || vars.CLIRELAY_DEV_AUTO_DEPLOY == 'true' }}
-      EXPECTED_SCRIPT_VERSION: '2026.08.19.3'
+      # Deploying is the default for a merge into dev. This used to require
+      # CLIRELAY_DEV_AUTO_DEPLOY=true, so an unset or reset repository variable
+      # silently turned every merge into a build-only run. Set the variable to
+      # 'false' to stop deployments deliberately.
+      SHOULD_DEPLOY: ${{ github.event_name == 'workflow_dispatch' || vars.CLIRELAY_DEV_AUTO_DEPLOY != 'false' }}
+      # Must match SCRIPT_VERSION in scripts/deploy-blue-green.sh; the host
+      # entrypoint refuses to run on a mismatch. Guarded by
+      # TestDeployScriptVersionMatchesWorkflowExpectation.
+      EXPECTED_SCRIPT_VERSION: '2026.09.08.1'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -88,7 +95,7 @@ jobs:
         if: env.SHOULD_DEPLOY != 'true'
         run: |
           echo "Built dev binary, but server deploy is disabled."
-          echo "Run this workflow manually or set repository variable CLIRELAY_DEV_AUTO_DEPLOY=true after the target server data stack is ready."
+          echo "Deployment is opt-out: repository variable CLIRELAY_DEV_AUTO_DEPLOY is set to 'false'. Unset it to resume automatic deploys."
           echo "DEPLOY_MODE=built-only" >> "$GITHUB_ENV"
 
       # Native ssh/scp only. Remote user is deploy (not root).

--- a/deployment_workflow_test.go
+++ b/deployment_workflow_test.go
@@ -118,7 +118,7 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 		`DRAIN_SECONDS`,
 		`systemd-run`,
 		`scripts/cleanup-drained-slot.sh`,
-		`grep -v '\.bak\.'`,
+		`NGINX_BACKUP_PATTERN`,
 		`SCRIPT_VERSION`,
 		`TimeoutStopSec=${SHUTDOWN_GRACE_SECONDS}`,
 		`CLIRELAY_SHUTDOWN_GRACE`,
@@ -139,6 +139,11 @@ func TestBlueGreenDeployScriptSyntaxAndGuards(t *testing.T) {
 		// perl is not installed on the deploy host. Using it for the config
 		// rewrite failed silently and the deploy still reported success.
 		`perl -0pi`,
+		// The dot-anchored backup filter only caught `.bak.<timestamp>` and let
+		// every `.bak-before-<tag>` file through, so the lookup could return a
+		// backup vhost that nginx never reads. Replaced by NGINX_BACKUP_PATTERN;
+		// see TestNginxBackupPatternExcludesEveryBackupShape.
+		`grep -v '\.bak\.'`,
 		`migrate-sqlite-to-postgres.sh`,
 		`Legacy SQLite`,
 		`stop_active_units_for_migration`,
@@ -369,5 +374,179 @@ func TestDockerPublishWorkflowUsesGHCRForBranchesAndReleaseTags(t *testing.T) {
 		if strings.Contains(content, forbidden) {
 			t.Fatalf("Docker publish workflow still contains legacy DockerHub marker %q", forbidden)
 		}
+	}
+}
+
+// extractShellAssignment pulls a single-quoted assignment out of a shell script
+// so the test exercises the value the deploy host will actually use, rather
+// than a copy that can drift away from it.
+func extractShellAssignment(t *testing.T, path, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, name+"=") {
+			continue
+		}
+		value := strings.TrimPrefix(line, name+"=")
+		value = strings.TrimSuffix(strings.TrimPrefix(value, "'"), "'")
+		if value != "" {
+			return value
+		}
+	}
+	t.Fatalf("%s does not define %s", path, name)
+	return ""
+}
+
+// The deploy host keeps every historical vhost next to the live one (74 files
+// at the time of writing), all containing the same server_name. Picking a
+// backup means the cutover rewrites a file nginx never reads: traffic stays on
+// the old slot, the deploy reports success, and the drain step then stops the
+// slot that is still serving. This asserts the real grep behaviour against the
+// filename shapes observed on the host.
+func TestNginxBackupPatternExcludesEveryBackupShape(t *testing.T) {
+	pattern := extractShellAssignment(t, "scripts/deploy-blue-green.sh", "NGINX_BACKUP_PATTERN")
+
+	dir := t.TempDir()
+	const live = "code.07230805.xyz.conf"
+	backups := []string{
+		"code.07230805.xyz.conf.bak.1787125852",
+		"code.07230805.xyz.conf.bak.20260819_152834",
+		"code.07230805.xyz.conf.bak-before-options",
+		"code.07230805.xyz.conf.bak-before-restore-001802",
+		"code.07230805.xyz.conf.bak",
+	}
+	for _, name := range append([]string{live}, backups...) {
+		if err := os.WriteFile(dir+"/"+name, []byte("server_name code.07230805.xyz;\nproxy_pass http://127.0.0.1:8319;\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	script := `set -o pipefail; grep -Rsl "$DOMAIN" "$DIR" 2>/dev/null | grep -Ev "$PATTERN" || true`
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(), "DOMAIN=code.07230805.xyz", "DIR="+dir, "PATTERN="+pattern)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run lookup: %v\n%s", err, out)
+	}
+
+	matches := strings.Fields(strings.TrimSpace(string(out)))
+	if len(matches) != 1 {
+		t.Fatalf("lookup matched %d files, want only the live vhost: %v", len(matches), matches)
+	}
+	if got := matches[0]; got != dir+"/"+live {
+		t.Fatalf("lookup selected %q, want the live vhost %q", got, dir+"/"+live)
+	}
+}
+
+// A cutover that failed to move nginx leaves .active-port and systemd agreeing
+// with each other while nginx still points at the old slot. Draining then takes
+// production down, so the drain must refuse.
+func TestCleanupDrainedSlotRefusesToStopSlotNginxStillServes(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := tmp + "/bin"
+	nginxDir := tmp + "/nginx"
+	for _, dir := range []string{binDir, nginxDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+
+	activeUnitPath := tmp + "/active-unit"
+	fakeSystemctl := `#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
+if [ "$1" = "is-active" ] && [ "$2" = "--quiet" ]; then
+  active="$(cat "$SYSTEMCTL_ACTIVE_UNIT" 2>/dev/null || true)"
+  if [ "${3:-}" = "$active" ]; then
+    exit 0
+  fi
+  exit 3
+fi
+`
+	if err := os.WriteFile(binDir+"/systemctl", []byte(fakeSystemctl), 0o755); err != nil {
+		t.Fatalf("write fake systemctl: %v", err)
+	}
+
+	activePortFile := tmp + "/.active-port"
+	// Both local sources say 8319 won the cutover...
+	if err := os.WriteFile(activePortFile, []byte("8319\n"), 0o644); err != nil {
+		t.Fatalf("write active port: %v", err)
+	}
+	if err := os.WriteFile(activeUnitPath, []byte("clirelay2-8319\n"), 0o644); err != nil {
+		t.Fatalf("write active unit: %v", err)
+	}
+	// ...but nginx never moved off 8318.
+	if err := os.WriteFile(nginxDir+"/live.conf", []byte("proxy_pass http://127.0.0.1:8318;\n"), 0o644); err != nil {
+		t.Fatalf("write live vhost: %v", err)
+	}
+	// A stale backup pointing at the new slot must not be mistaken for live config.
+	if err := os.WriteFile(nginxDir+"/live.conf.bak-before-cutover", []byte("proxy_pass http://127.0.0.1:8319;\n"), 0o644); err != nil {
+		t.Fatalf("write backup vhost: %v", err)
+	}
+
+	logPath := tmp + "/systemctl.log"
+	cmd := exec.Command("bash", "scripts/cleanup-drained-slot.sh", "8318", "8319")
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"SYSTEMCTL_LOG="+logPath,
+		"SYSTEMCTL_ACTIVE_UNIT="+activeUnitPath,
+		"BASE_DIR="+tmp,
+		"ACTIVE_PORT_FILE="+activePortFile,
+		"NGINX_SEARCH_DIRS="+nginxDir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("drain succeeded while nginx still served 8318; output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "live nginx still proxies to it") {
+		t.Fatalf("drain refused for the wrong reason:\n%s", out)
+	}
+
+	logData, _ := os.ReadFile(logPath)
+	if strings.Contains(string(logData), "disable --now clirelay2-8318") {
+		t.Fatalf("drain stopped the slot nginx was serving:\n%s", logData)
+	}
+}
+
+// The gate compares the workflow's expectation against the version baked into
+// the script. When they drift, every deploy fails before touching the host --
+// safe, but it silently disables deployment until someone notices.
+func TestDeployScriptVersionMatchesWorkflowExpectation(t *testing.T) {
+	raw := extractShellAssignment(t, "scripts/deploy-blue-green.sh", "SCRIPT_VERSION")
+	raw = strings.Trim(raw, `"`)
+	scriptVersion := strings.TrimSuffix(strings.TrimPrefix(raw, "${SCRIPT_VERSION:-"), "}")
+	if scriptVersion == "" || strings.ContainsAny(scriptVersion, "${}\"") {
+		t.Fatalf("could not parse SCRIPT_VERSION, got %q", raw)
+	}
+
+	data, err := os.ReadFile(".github/workflows/deploy.yml")
+	if err != nil {
+		t.Fatalf("read deploy workflow: %v", err)
+	}
+	want := "EXPECTED_SCRIPT_VERSION: '" + scriptVersion + "'"
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("deploy workflow must expect script version %q (looked for %q)", scriptVersion, want)
+	}
+}
+
+// Deployment must not depend on a repository variable being present. It used to
+// require CLIRELAY_DEV_AUTO_DEPLOY == 'true', so clearing or losing that
+// variable turned every merge into dev into a silent build-only run while the
+// workflow still reported success.
+func TestDeployIsOptOutRatherThanOptIn(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/deploy.yml")
+	if err != nil {
+		t.Fatalf("read deploy workflow: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, `vars.CLIRELAY_DEV_AUTO_DEPLOY != 'false'`) {
+		t.Fatalf("merges into dev must deploy unless explicitly disabled")
+	}
+	if strings.Contains(content, `vars.CLIRELAY_DEV_AUTO_DEPLOY == 'true'`) {
+		t.Fatalf("deployment must not be gated behind an opt-in variable")
 	}
 }

--- a/scripts/cleanup-drained-slot.sh
+++ b/scripts/cleanup-drained-slot.sh
@@ -29,6 +29,21 @@ if ! systemctl is-active --quiet "${SERVICE_NAME}-${expected_active_port}"; then
 	exit 1
 fi
 
+# Last line of defence: nginx decides where traffic actually goes, so never stop
+# a slot it still proxies to. .active-port and systemd can both agree while the
+# cutover silently failed to rewrite the vhost, and draining then takes the
+# serving slot down. Backup vhosts are excluded because nginx never reads them.
+NGINX_SEARCH_DIRS="${NGINX_SEARCH_DIRS:-/etc/nginx/conf.d /etc/nginx/sites-enabled}"
+NGINX_BACKUP_PATTERN="${NGINX_BACKUP_PATTERN:-\.bak($|[.-])|/[^/]*bak-before}"
+# shellcheck disable=SC2086 # NGINX_SEARCH_DIRS is an intentional word list.
+live_nginx_ports="$(grep -Rsl "127.0.0.1:" $NGINX_SEARCH_DIRS 2>/dev/null \
+	| grep -Ev "$NGINX_BACKUP_PATTERN" \
+	| xargs -r grep -hoE "127\.0\.0\.1:(${PORT_A}|${PORT_B})" 2>/dev/null | sort -u || true)"
+if printf '%s\n' "$live_nginx_ports" | grep -q "127.0.0.1:${old_port}"; then
+	echo "Refusing to drain ${old_port}: live nginx still proxies to it (${live_nginx_ports})." >&2
+	exit 1
+fi
+
 for old_unit in "$SERVICE_NAME" "${SERVICE_NAME}-${old_port}"; do
 	if [ "$old_unit" != "${SERVICE_NAME}-${expected_active_port}" ]; then
 		systemctl disable --now "$old_unit" 2>/dev/null || systemctl stop "$old_unit" 2>/dev/null || true

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SCRIPT_VERSION must stay in sync with deploy gate expectations.
-SCRIPT_VERSION="${SCRIPT_VERSION:-2026.08.19.3}"
+SCRIPT_VERSION="${SCRIPT_VERSION:-2026.09.08.1}"
 set -euo pipefail
 
 SERVICE_NAME="${SERVICE_NAME:-clirelay2}"
@@ -114,12 +114,25 @@ case "${redis_enable,,}" in
 esac
 
 config_port="$(awk '/^port:[[:space:]]*[0-9]+/ {print $2; exit}' "$config_path" 2>/dev/null || true)"
+NGINX_SEARCH_DIRS="${NGINX_SEARCH_DIRS:-/etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available}"
+
+# Backups of the live vhost sit in the same directory and contain the same
+# server_name, so an under-filtered match hands cutover a file nginx never
+# reads. The rewrite then "succeeds" against a backup, traffic never moves, and
+# drain stops the slot nginx is still serving -- the same shape of outage the
+# missing-perl bug caused. The deploy host carries both `.bak.<timestamp>` and
+# `.bak-before-<tag>` shapes; the previous dot-anchored filter only matched the
+# first of those and let every `bak-before` file through.
+# Single source of truth: both lookups and the drain guard use this pattern.
+NGINX_BACKUP_PATTERN='\.bak($|[.-])|/[^/]*bak-before'
+
 find_host_nginx_conf() {
 	if [ -n "${NGINX_CONF:-}" ]; then
 		echo "$NGINX_CONF"
 		return
 	fi
-	grep -Rsl "$DOMAIN" /etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available 2>/dev/null | grep -v '\.bak\.' | head -n1 || true
+	# shellcheck disable=SC2086 # NGINX_SEARCH_DIRS is an intentional word list.
+	grep -Rsl "$DOMAIN" $NGINX_SEARCH_DIRS 2>/dev/null | grep -Ev "$NGINX_BACKUP_PATTERN" | head -n1 || true
 }
 
 find_container_nginx_conf() {
@@ -129,7 +142,7 @@ find_container_nginx_conf() {
 	if ! docker inspect "$NGINX_CONTAINER" >/dev/null 2>&1; then
 		return
 	fi
-	docker exec "$NGINX_CONTAINER" sh -c "grep -Rsl '$DOMAIN' /etc/nginx/conf.d /etc/nginx/sites-enabled /etc/nginx/sites-available 2>/dev/null | grep -v '\\.bak\\.' | head -n1" || true
+	docker exec "$NGINX_CONTAINER" sh -c "grep -Rsl '$DOMAIN' ${NGINX_SEARCH_DIRS} 2>/dev/null | grep -Ev '${NGINX_BACKUP_PATTERN}' | head -n1" || true
 }
 
 # Nginx is the third state source, and the only one that decides where traffic


### PR DESCRIPTION
## Why

Merges into `dev` stopped reaching production. The most recent deploy run finished in 33s with `should_deploy: false` / `mode: built-only` — green, but nothing shipped. Two independent faults were behind it.

### 1. The nginx lookup could resolve to a backup vhost

`find_host_nginx_conf` filtered candidates with `grep -v '\.bak\.'`, which only matches `.bak.<timestamp>`. The deploy host also keeps `.bak-before-<tag>` copies of the same vhost — **74 backups in `/etc/nginx/conf.d`**, all carrying the same `server_name`. Combined with `head -n1`:

```
repo filter    → code.07230805.xyz.conf.bak-before-options   ← selected
                 code.07230805.xyz.conf
                 code.07230805.xyz.conf.bak-before-restore-001802
fixed filter   → code.07230805.xyz.conf                      ← correct
```

Cutover would rewrite a file nginx never reads. Traffic stays on the old slot, the deploy reports success, and the drain step then stops the slot that is still serving — the same outage shape as the earlier missing-perl bug, reached by a different route.

### 2. Deployment was gated behind an opt-in variable

`SHOULD_DEPLOY` required `vars.CLIRELAY_DEV_AUTO_DEPLOY == 'true'`. An unset or reset repository variable silently downgraded every merge to a build-only run while the workflow still reported success. `EXPECTED_SCRIPT_VERSION` had also drifted from the script's `SCRIPT_VERSION` (`2026.08.19.3` vs `2026.09.08.1`), which fails every deploy before it touches the host — safe, but invisible.

## What changed

- both nginx lookups (host and container) share one `NGINX_BACKUP_PATTERN` covering every backup shape present on the host
- the drain step refuses to stop a slot that **live** (non-backup) nginx config still proxies to. `.active-port` and systemd can agree with each other while nginx never moved, and that is exactly when draining takes production down
- deployment is opt-out: merges into `dev` deploy unless `CLIRELAY_DEV_AUTO_DEPLOY` is explicitly `'false'`
- `EXPECTED_SCRIPT_VERSION` realigned with the script

## Guard tests

The previous guard asserted the script *contained* `grep -v '\.bak\.'` — fixing the filter failed CI, which is why the working fix only ever existed on the server. That assertion is now inverted, and the replacements test behaviour rather than text:

| test | what it pins |
|---|---|
| `TestNginxBackupPatternExcludesEveryBackupShape` | runs the real grep against the host's backup filename shapes; only the live vhost may match |
| `TestCleanupDrainedSlotRefusesToStopSlotNginxStillServes` | simulates a failed cutover; drain must refuse and call no `systemctl` stop |
| `TestDeployScriptVersionMatchesWorkflowExpectation` | fails on script/workflow version drift |
| `TestDeployIsOptOutRatherThanOptIn` | keeps deployment from regressing to opt-in |

## Verified on the deploy host before shipping

`scripts/*` are root-managed and never uploaded by GHA, so they were installed manually and checked:

- all three scripts are byte-identical to this commit (md5 match against the repo)
- the lookup resolves to the live vhost against the real 74-backup directory
- drain guard, exercised with a fake `systemctl` against the real nginx config: a normal drain (nginx on 8319, draining 8318) is allowed; a drain that would stop the serving slot is refused with no stop issued
- current slot state is consistent and healthy: `.active-port`=8319, `clirelay2-8319` active, nginx `proxy_pass`→8319, `/healthz` and `/readyz` both 204

`./scripts/ci-pr.sh` — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)