### PR TITLE
fix(warmup): use regular Codex quota model

### DIFF
--- a/internal/management/warmup/driver_codex.go
+++ b/internal/management/warmup/driver_codex.go
@@ -33,9 +33,10 @@ func (d *CodexDriver) Provider() string {
 func (d *CodexDriver) GetTargets(auth *coreauth.Auth) []Target {
 	return []Target{
 		{
-			PoolID:      "codex:5h",
-			PoolLabel:   "Codex (5h Pool)",
-			TargetModel: "gpt-5.3-codex-spark",
+			PoolID:    "codex:5h",
+			PoolLabel: "Codex (5h Pool)",
+			// Spark has a separate, tier-restricted quota; warm the regular Codex pool.
+			TargetModel: "gpt-5.6-luna",
 			Window:      5 * time.Hour,
 		},
 	}

--- a/internal/management/warmup/driver_codex_pipeline_test.go
+++ b/internal/management/warmup/driver_codex_pipeline_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+
+	"github.com/tidwall/gjson"
 	"testing"
 	"time"
 
@@ -24,6 +26,11 @@ func TestCodexDriverRealPipeline(t *testing.T) {
 		authHeader = r.Header.Get("Authorization")
 		b, _ := io.ReadAll(r.Body)
 		requestedBody = string(b)
+
+		if gjson.GetBytes(b, "model").String() == "gpt-5.3-codex-spark" {
+			http.Error(w, `{"detail":"The Spark model is not supported for this ChatGPT account."}`, http.StatusBadRequest)
+			return
+		}
 
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n"))
@@ -63,8 +70,10 @@ func TestCodexDriverRealPipeline(t *testing.T) {
 	if !strings.HasPrefix(authHeader, "Bearer eyJ") {
 		t.Fatalf("missing or invalid Authorization header: %s", authHeader)
 	}
-	if !strings.Contains(requestedBody, "gpt-5.3-codex-spark") {
-		t.Fatalf("expected spark model in request, got: %s", requestedBody)
+	if gjson.Get(requestedBody, "model").String() != "gpt-5.6-luna" {
+		t.Fatalf("expected regular Codex model in request, got: %s", requestedBody)
 	}
-	_ = requestedPath
+	if requestedPath != "/responses" {
+		t.Fatalf("unexpected path: %s", requestedPath)
+	}
 }


### PR DESCRIPTION
The generic `codex:5h` warmup selected Spark, which can be rejected by ChatGPT accounts and represents a separate model quota. Use `gpt-5.6-luna` for the regular pool.

The real driver/executor pipeline test now simulates an upstream that rejects Spark, checks the outgoing model and `/responses` endpoint, and verifies successful warmup. It failed before the production change and passes afterward.

Validation actually run:
- `go test ./internal/management/warmup -run TestCodexDriverRealPipeline -count=1`: failed before the fix as expected.
- `go test ./internal/management/warmup -count=1`: passed after the fix.
- `python3 scripts/check-backend-structure.py`: passed.
- `git diff --check`: passed.

No live provider credentials were used. Full GitHub Actions checks remain required before merge. Fixes #996.
