### PR TITLE
fix(modelcatalog): preserve configured Codex models during discovery

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -26,7 +26,7 @@
       },
       {
         "path": "internal/management/modelcatalog/availability.go",
-        "max_lines": 993
+        "max_lines": 987
       },
       {
         "path": "internal/management/settings/providers/provider_keys_extended.go",

--- a/internal/management/modelcatalog/availability.go
+++ b/internal/management/modelcatalog/availability.go
@@ -350,6 +350,10 @@ func modelIsStaleMappedOwnerLibraryRow(
 	if modelRegistry != nil {
 		sources := modelRegistry.GetModelClientSources(modelID)
 		for _, source := range sources {
+			// An OAuth discovery manifest cannot invalidate explicitly configured upstream models.
+			if sourceHasExplicitConfigModels(source, authByID) {
+				return false
+			}
 			provider := strings.ToLower(strings.TrimSpace(source.Provider))
 			if auth := authByID[strings.TrimSpace(source.ClientID)]; auth != nil && strings.TrimSpace(auth.Provider) != "" {
 				provider = strings.ToLower(strings.TrimSpace(auth.Provider))
@@ -428,6 +432,10 @@ func modelOnlyServedByDiscoveryProviders(
 		return false
 	}
 	for _, source := range sources {
+		// An OAuth discovery manifest cannot invalidate explicitly configured upstream models.
+		if sourceHasExplicitConfigModels(source, authByID) {
+			return false
+		}
 		provider := strings.ToLower(strings.TrimSpace(source.Provider))
 		if auth := authByID[strings.TrimSpace(source.ClientID)]; auth != nil && strings.TrimSpace(auth.Provider) != "" {
 			provider = strings.ToLower(strings.TrimSpace(auth.Provider))
@@ -798,20 +806,6 @@ func sourceCoveredByMappedOwners(
 	}
 	owner := mappedOwnerForSource(source, authByID, ownerMappings)
 	return owner != "" && ownerKeys[owner]
-}
-
-func sourceHasExplicitConfigModels(source registry.ModelClientSource, authByID map[string]*coreauth.Auth) bool {
-	auth := authByID[strings.TrimSpace(source.ClientID)]
-	if auth == nil || auth.Attributes == nil {
-		return false
-	}
-	if !strings.EqualFold(strings.TrimSpace(auth.Attributes["auth_kind"]), "apikey") {
-		return false
-	}
-	if strings.TrimSpace(auth.Attributes["models_hash"]) == "" {
-		return false
-	}
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(auth.Attributes["source"])), "config:")
 }
 
 func mappedOwnerForSource(source registry.ModelClientSource, authByID map[string]*coreauth.Auth, ownerMappings map[string]string) string {

--- a/internal/management/modelcatalog/discovery_authority.go
+++ b/internal/management/modelcatalog/discovery_authority.go
@@ -1,9 +1,29 @@
 package modelcatalog
 
+import (
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"strings"
+)
+
 func (s *Service) managementAuthoritativeModelKeys() map[string]bool {
 	rows, ownerKeys, _, ok := s.defaultMappedOwnerRows()
 	if !ok {
 		return nil
 	}
 	return mappedOwnerRowModelKeys(rows, ownerKeys)
+}
+
+func sourceHasExplicitConfigModels(source registry.ModelClientSource, authByID map[string]*coreauth.Auth) bool {
+	auth := authByID[strings.TrimSpace(source.ClientID)]
+	if auth == nil || auth.Attributes == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Attributes["auth_kind"]), "apikey") {
+		return false
+	}
+	if strings.TrimSpace(auth.Attributes["models_hash"]) == "" {
+		return false
+	}
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(auth.Attributes["source"])), "config:")
 }

--- a/internal/management/modelcatalog/explicit_config_discovery_test.go
+++ b/internal/management/modelcatalog/explicit_config_discovery_test.go
@@ -1,0 +1,56 @@
+package modelcatalog
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	managementauthfiles "github.com/router-for-me/CLIProxyAPI/v6/internal/management/authfiles"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher/synthesizer"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestConfiguredAvailabilityKeepsExplicitCodexModelsOutsideOAuthDiscovery(t *testing.T) {
+	const custom = "glm-5.3-flash"
+	const stale = "codex-stale-discovery-test"
+	cfg := &config.Config{CodexKey: []config.CodexKey{{
+		Name: "zcode", APIKey: "test-config-key", BaseURL: "https://example.invalid/v1",
+		Models: []config.CodexModel{{Name: custom}},
+	}}}
+	auths, err := synthesizer.NewConfigSynthesizer().Synthesize(&synthesizer.SynthesisContext{
+		Config: cfg, Now: time.Now(), IDGenerator: synthesizer.NewStableIDGenerator(),
+	})
+	if err != nil || len(auths) != 1 {
+		t.Fatalf("synthesize: auths=%d err=%v", len(auths), err)
+	}
+	oauth := &coreauth.Auth{ID: "explicit-codex-oauth", Provider: "codex", Status: coreauth.StatusActive}
+	reg := registry.GetGlobalRegistry()
+	managementauthfiles.ResetDiscoveryCacheForTest()
+	t.Cleanup(managementauthfiles.ResetDiscoveryCacheForTest)
+	t.Cleanup(func() { reg.UnregisterClient(auths[0].ID); reg.UnregisterClient(oauth.ID) })
+	reg.RegisterClient(auths[0].ID, "codex", []*registry.ModelInfo{{ID: custom, Object: "model", OwnedBy: "openai"}})
+	reg.RegisterClient(oauth.ID, "codex", []*registry.ModelInfo{{ID: stale, Object: "model", OwnedBy: "openai"}})
+	managementauthfiles.StoreDiscoveryCacheForTest("", "codex", []*registry.ModelInfo{{ID: "gpt-5.6-luna", Object: "model", OwnedBy: "openai"}})
+	manager := coreauth.NewManager(nil, nil, nil)
+	for _, auth := range []*coreauth.Auth{auths[0], oauth} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatal(err)
+		}
+	}
+	data := New(cfg, manager).ConfiguredAvailability("", "", AvailabilityFilterOptions{IgnoreGroupAllowedModels: true})["data"].([]map[string]any)
+	ids := map[string]bool{}
+	for _, item := range data {
+		ids[item["id"].(string)] = true
+	}
+	if !ids[custom] {
+		t.Errorf("explicit API-key model missing after OAuth discovery: %v", ids)
+	}
+	if ids[stale] {
+		t.Errorf("obsolete OAuth static model survived: %v", ids)
+	}
+	if !ids["gpt-5.6-luna"] {
+		t.Errorf("live OAuth model missing: %v", ids)
+	}
+}


### PR DESCRIPTION
Codex API-key models disappear from management availability when the shared OAuth discovery manifest lacks them. Preserve registry models served by credentials with explicit config models, using the existing config-source/auth-kind/models-hash predicate. OAuth-only stale catalog models are still removed.

The regression uses the real config synthesizer, registry and ConfiguredAvailability consumer. It fails before the fix (custom model missing), passes afterward, and checks that stale OAuth models remain removed and live OAuth models remain available. The explicit-config predicate is moved into the existing discovery authority file to keep the size-ratchet file shrinking; its behavior is unchanged.

Validation actually run:
- Regression test before fix: failed as expected.
- `go test ./internal/management/modelcatalog -count=1`: passed.
- `./scripts/ci-pr.sh`: passed locally (Postgres integration cases require the CI service).
- `python3 scripts/check-backend-structure.py --update-baseline`: locked the smaller availability file.
- `git diff --check`: passed.

Backend-only. Fixes #983.
