### PR TITLE
fix(codex): restore native Alpha Search with scoped credential selection

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -331,6 +331,7 @@ streaming:
 # Codex API keys
 # codex-api-key:
 #   - api-key: "sk-atSM..."
+#     alpha-search: false # opt in only when this upstream supports the Codex alpha search endpoint
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
 #     headers:

--- a/internal/api/alpha_search_test.go
+++ b/internal/api/alpha_search_test.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/gin-gonic/gin"
+	proxyconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	"github.com/tidwall/gjson"
+
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAlphaSearchRouteRequiresAuthentication(t *testing.T) {
+	s := newRouteTestServer(t, nil)
+	for _, path := range []string{"/v1/alpha/search", "/codex/v1/alpha/search"} {
+		t.Run(path, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"gpt-5.6-sol","commands":{"search_query":[{"q":"test"}]}}`))
+			w := httptest.NewRecorder()
+			s.engine.ServeHTTP(w, r)
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("status=%d body=%q, want authenticated route (401)", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestAlphaSearchRealRouterAndExecutor(t *testing.T) {
+	var calls atomic.Int32
+	const response = `{"id":"search-result","results":[{"url":"https://example.org"}]}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if r.URL.Path != "/v1/alpha/search" {
+			t.Errorf("upstream path=%s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if gjson.GetBytes(body, "model").String() != "upstream-search-model" || gjson.GetBytes(body, "commands.search_query.0.q").String() != "test" || gjson.GetBytes(body, "prompt_cache_key").Exists() {
+			t.Errorf("body=%s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, response)
+	}))
+	defer upstream.Close()
+	cfg := &proxyconfig.Config{SDKConfig: sdkconfig.SDKConfig{APIKeys: []string{"test-key"}}, AuthDir: t.TempDir()}
+	cfg.CodexKey = []proxyconfig.CodexKey{{APIKey: "upstream-key", BaseURL: upstream.URL + "/v1", AlphaSearch: true, Models: []proxyconfig.CodexModel{{Name: "upstream-search-model", Alias: "search-alias"}}}}
+	cfg.Routing.IncludeDefaultGroup = true
+	cfg.Routing.ChannelGroups = []proxyconfig.RoutingChannelGroup{{Name: "search", Match: proxyconfig.ChannelGroupMatch{Channels: []string{"Search Channel"}}, AllowedModels: []string{"search-alias"}}}
+	cfg.Routing.PathRoutes = []proxyconfig.RoutingPathRoute{{Path: "/team/search", Group: "search"}}
+	cfg.SanitizeRouting()
+	manager := auth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	manager.RegisterExecutor(runtimeexecutor.NewCodexAutoExecutor(cfg))
+	a := &auth.Auth{ID: "alpha-router-auth", Label: "Search Channel", Provider: "codex", Status: auth.StatusActive, Attributes: map[string]string{"api_key": "upstream-key", "base_url": upstream.URL + "/v1", "alpha_search": "true"}}
+	if _, err := manager.Register(context.Background(), a); err != nil {
+		t.Fatal(err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(a.ID, a.Provider, []*registry.ModelInfo{{ID: "search-alias"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(a.ID) })
+	server := NewServer(cfg, manager, sdkaccess.NewManager(), filepath.Join(t.TempDir(), "config.yaml"), WithRequestLoggerFactory(nil))
+	for _, path := range []string{"/v1/alpha/search", "/search/v1/alpha/search", "/team/search/v1/alpha/search"} {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"search-alias","commands":{"search_query":[{"q":"test"}]},"prompt_cache_key":"remove"}`))
+		req.Header.Set("Authorization", "Bearer test-key")
+		rec := httptest.NewRecorder()
+		server.engine.ServeHTTP(rec, req)
+		if rec.Code != 200 || rec.Body.String() != response {
+			t.Fatalf("%s status=%d body=%s", path, rec.Code, rec.Body.String())
+		}
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("upstream calls=%d", calls.Load())
+	}
+	for _, body := range []string{`null`, `[]`, `{"commands":{}}`, `{"model":123}`, `{"model":"search-alias","stream":true}`} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer test-key")
+		rec := httptest.NewRecorder()
+		server.engine.ServeHTTP(rec, req)
+		if rec.Code != 400 {
+			t.Errorf("body=%s status=%d response=%s", body, rec.Code, rec.Body.String())
+		}
+	}
+	req := httptest.NewRequest(http.MethodPost, "/search/v1/alpha/search", strings.NewReader(`{"model":"forbidden-model","commands":{}}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rec := httptest.NewRecorder()
+	server.engine.ServeHTTP(rec, req)
+	if rec.Code != 403 || !strings.Contains(rec.Body.String(), "model_not_allowed") {
+		t.Fatalf("model gate status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	a.Attributes["alpha_search"] = "false"
+	if _, err := manager.Update(context.Background(), a); err != nil {
+		t.Fatal(err)
+	}
+	req = httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"model":"search-alias","commands":{}}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rec = httptest.NewRecorder()
+	server.engine.ServeHTTP(rec, req)
+	if rec.Code != 503 || !strings.Contains(rec.Body.String(), "alpha_search_auth_unavailable") {
+		t.Fatalf("capability status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("rejected request reached upstream, calls=%d", calls.Load())
+	}
+}
+
+func TestAlphaSearchDoesNotInjectSystemPrompt(t *testing.T) {
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("accessMetadata", map[string]string{"system-prompt": "secret prompt"})
+		c.Next()
+	}, SystemPromptMiddleware())
+	router.POST("/v1/alpha/search", func(c *gin.Context) {
+		body, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		c.Data(200, "application/json", body)
+	})
+	const body = `{"model":"test","commands":{},"messages":[],"input":"opaque extension"}`
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(body)))
+	if rec.Code != 200 || rec.Body.String() != body {
+		t.Fatalf("search body changed: %s", rec.Body.String())
+	}
+}

--- a/internal/api/handlers/management/codex_alpha_search_test.go
+++ b/internal/api/handlers/management/codex_alpha_search_test.go
@@ -1,0 +1,69 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	settingsstore "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/store"
+)
+
+func TestCodexAlphaSearchManagementPersistence(t *testing.T) {
+	initManagementModelsTestDB(t)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("logging-to-file: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h := NewHandler(&config.Config{}, path, nil)
+	put := performModelsRequest(http.MethodPut, "/codex-api-key", []byte(`[{"api-key":"test-codex","alpha-search":true}]`), h.ProviderKeys().PutCodexKeys)
+	if put.Code != http.StatusOK {
+		t.Fatalf("PUT = %d: %s", put.Code, put.Body.String())
+	}
+	assertStored := func(want bool) {
+		t.Helper()
+		var stored config.Config
+		if !settingsstore.ApplyStoredRuntimeSettings(&stored) || len(stored.CodexKey) != 1 {
+			t.Fatal("failed to reload Codex key from SQLite")
+		}
+		encoded, err := json.Marshal(stored.CodexKey[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		var fields map[string]interface{}
+		if err := json.Unmarshal(encoded, &fields); err != nil {
+			t.Fatal(err)
+		}
+		if got, _ := fields["alpha-search"].(bool); got != want {
+			t.Fatalf("persisted alpha-search != %t: %s", want, encoded)
+		}
+		// A fresh handler must expose the persisted capability through GET as well.
+		restored := NewHandler(&stored, path, nil)
+		get := performModelsRequest(http.MethodGet, "/codex-api-key", nil, restored.ProviderKeys().GetCodexKeys)
+		var payload struct {
+			Keys []struct {
+				AlphaSearch bool `json:"alpha-search"`
+			} `json:"codex-api-key"`
+		}
+		if err := json.Unmarshal(get.Body.Bytes(), &payload); err != nil || len(payload.Keys) != 1 || payload.Keys[0].AlphaSearch != want {
+			t.Fatalf("GET did not restore capability: %s", get.Body.String())
+		}
+	}
+	assertStored(true)
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{`{"prefix":"team"}`, true},
+		{`{"alpha-search":false}`, false},
+		{`{"alpha-search":true}`, true},
+	} {
+		patch := performModelsRequest(http.MethodPatch, "/codex-api-key", []byte(`{"index":0,"value":`+tc.value+`}`), h.ProviderKeys().PatchCodexKey)
+		if patch.Code != http.StatusOK {
+			t.Fatalf("PATCH = %d: %s", patch.Code, patch.Body.String())
+		}
+		assertStored(tc.want)
+	}
+}

--- a/internal/api/routes_public.go
+++ b/internal/api/routes_public.go
@@ -50,6 +50,7 @@ func (s *Server) setupRoutes() {
 		})
 		group.POST("/responses", openaiResponsesHandlers.Responses)
 		group.POST("/responses/compact", openaiResponsesHandlers.Compact)
+		group.POST("/alpha/search", openaiResponsesHandlers.AlphaSearch)
 	}
 	registerV1BetaRoutes := func(group *gin.RouterGroup) {
 		group.GET("/models", geminiHandlers.GeminiModels)

--- a/internal/api/system_prompt_middleware.go
+++ b/internal/api/system_prompt_middleware.go
@@ -14,7 +14,8 @@ import (
 
 func SystemPromptMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if c.Request.Method != http.MethodPost {
+		// Alpha Search commands must not acquire chat-only fields.
+		if c.Request.Method != http.MethodPost || strings.HasSuffix(c.FullPath(), "/alpha/search") {
 			c.Next()
 			return
 		}

--- a/internal/config/codex_alpha_search_test.go
+++ b/internal/config/codex_alpha_search_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCodexAlphaSearchConfigRoundTrip(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		input := `{"api-key":"test-codex","alpha-search":false}`
+		if enabled {
+			input = `{"api-key":"test-codex","alpha-search":true}`
+		}
+		var key CodexKey
+		if err := json.Unmarshal([]byte(input), &key); err != nil {
+			t.Fatal(err)
+		}
+		encoded, err := yaml.Marshal(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(encoded), "alpha-search: true") != enabled {
+			t.Fatalf("YAML lost opt-in: %s", encoded)
+		}
+		var restored CodexKey
+		if err := yaml.Unmarshal(encoded, &restored); err != nil {
+			t.Fatal(err)
+		}
+		encoded, err = json.Marshal(restored)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var fields map[string]interface{}
+		if err := json.Unmarshal(encoded, &fields); err != nil {
+			t.Fatal(err)
+		}
+		if got, _ := fields["alpha-search"].(bool); got != enabled {
+			t.Fatalf("JSON lost opt-in: %s", encoded)
+		}
+	}
+}
+
+func TestCodexAlphaSearchYAMLSaveCanDisable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("# operator config\ncodex-api-key:\n  - api-key: test-codex\n    alpha-search: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.CodexKey) != 1 || !cfg.CodexKey[0].AlphaSearch {
+		t.Fatal("LoadConfig lost explicit opt-in")
+	}
+	cfg.CodexKey[0].AlphaSearch = false
+	if err := SaveConfigPreserveComments(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	restored, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(restored.CodexKey) != 1 || restored.CodexKey[0].AlphaSearch {
+		t.Fatal("YAML save retained stale alpha-search opt-in")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "# operator config") {
+		t.Fatal("YAML save lost operator comment")
+	}
+}

--- a/internal/config/provider_keys.go
+++ b/internal/config/provider_keys.go
@@ -89,6 +89,10 @@ type CodexKey struct {
 	// Websockets enables the Responses API websocket transport for this credential.
 	Websockets bool `yaml:"websockets,omitempty" json:"websockets,omitempty"`
 
+	// AlphaSearch explicitly opts this credential into Codex's optional search endpoint.
+	// Keep disabled unless the configured upstream supports that endpoint.
+	AlphaSearch bool `yaml:"alpha-search,omitempty" json:"alpha-search,omitempty"`
+
 	// ProxyURL overrides the global proxy setting for this API key if provided.
 	ProxyURL string `yaml:"proxy-url" json:"proxy-url"`
 

--- a/internal/management/settings/providers/provider_keys_primary.go
+++ b/internal/management/settings/providers/provider_keys_primary.go
@@ -253,6 +253,7 @@ func (s *Service) DeleteClaudeKeyByIndex(index int) bool {
 }
 
 type CodexKeyPatch struct {
+	AlphaSearch    *bool                `json:"alpha-search"`
 	APIKey         *string              `json:"api-key"`
 	Prefix         *string              `json:"prefix"`
 	BaseURL        *string              `json:"base-url"`
@@ -318,6 +319,9 @@ func (s *Service) PatchCodexKey(index *int, match *string, patch CodexKeyPatch) 
 	}
 
 	entry := s.cfg.CodexKey[targetIndex]
+	if patch.AlphaSearch != nil {
+		entry.AlphaSearch = *patch.AlphaSearch
+	}
 	if patch.APIKey != nil {
 		entry.APIKey = strings.TrimSpace(*patch.APIKey)
 	}

--- a/internal/runtime/executor/codex_alpha_search.go
+++ b/internal/runtime/executor/codex_alpha_search.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+)
+
+// Alpha Search has its own wire schema. Translation, payload overrides and the
+// Responses cache helper would add fields the search upstream rejects.
+func (e *CodexExecutor) executeAlphaSearch(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{})
+	reporter := execCtx.Reporter()
+	defer reporter.trackFailure(execCtx.Context, &err)
+	if opts.Stream {
+		return resp, statusErr{code: http.StatusBadRequest, msg: "Alpha Search does not support streaming"}
+	}
+	if !cliproxyauth.SupportsCodexAlphaSearch(auth) {
+		return resp, statusErr{code: http.StatusBadRequest, msg: "credential does not support Codex Alpha Search"}
+	}
+	if err = enforceCodexClientAdmission(execCtx.Context, e.cfg, auth); err != nil {
+		return resp, err
+	}
+	var payload map[string]json.RawMessage
+	if json.Unmarshal(req.Payload, &payload) != nil || payload == nil || strings.TrimSpace(execCtx.BaseModel) == "" {
+		return resp, statusErr{code: http.StatusBadRequest, msg: "Alpha Search requires a JSON object and model"}
+	}
+	if string(bytes.TrimSpace(payload["stream"])) == "true" {
+		return resp, statusErr{code: http.StatusBadRequest, msg: "Alpha Search does not support streaming"}
+	}
+	// Manager has resolved any permitted OAuth/API-key alias before execution.
+	payload["model"], err = json.Marshal(execCtx.BaseModel)
+	if err != nil {
+		return resp, err
+	}
+	delete(payload, "prompt_cache_key")
+	delete(payload, "prompt_cache_retention")
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return resp, err
+	}
+	token, baseURL := codexCreds(auth)
+	if strings.TrimSpace(auth.Attributes["api_key"]) == "" {
+		// An OAuth token must never be sent to a caller/config supplied relay URL.
+		baseURL = "https://chatgpt.com/backend-api/codex"
+	}
+	url := strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/alpha/search"
+	httpReq, err := http.NewRequestWithContext(execCtx.Context, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return resp, err
+	}
+	applyCodexHeaders(httpReq, e.cfg, auth, token, false)
+	recorder := execCtx.Recorder()
+	recorder.RecordRequest(url, http.MethodPost, httpReq.Header.Clone(), body)
+	//nolint:bodyclose // The response body is closed by the defer below.
+	httpResp, err := execCtx.HTTPClient(0).Do(httpReq)
+	if err != nil {
+		recorder.RecordResponseError(err)
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, err.Error())
+		return resp, err
+	}
+	defer func() {
+		if closeErr := httpResp.Body.Close(); closeErr != nil {
+			log.Errorf("codex alpha search: close response body: %v", closeErr)
+		}
+	}()
+	recorder.RecordResponseMetadata(httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		data := readUpstreamErrorBody(e.Identifier(), httpResp.Body)
+		recorder.AppendResponseChunk(data)
+		reporter.publishFailureWithContentBytes(execCtx.Context, req.Payload, string(data))
+		return resp, newCodexStatusErr(httpResp.StatusCode, data, httpResp.Header)
+	}
+	data, err := readUpstreamResponseBody(e.Identifier(), httpResp.Body)
+	if err != nil {
+		recorder.RecordResponseError(err)
+		return resp, err
+	}
+	recorder.AppendResponseChunk(data)
+	// Publish successful requests even when this protocol returns no token usage.
+	reporter.publishWithContentBytes(execCtx.Context, parseOpenAIUsage(data), req.Payload, string(data))
+	reporter.ensurePublished(execCtx.Context)
+	return cliproxyexecutor.Response{Payload: data, Headers: httpResp.Header.Clone()}, nil
+}

--- a/internal/runtime/executor/codex_alpha_search_test.go
+++ b/internal/runtime/executor/codex_alpha_search_test.go
@@ -1,0 +1,158 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+	"github.com/tidwall/gjson"
+)
+
+type alphaSearchTransport func(*http.Request) (*http.Response, error)
+
+func (f alphaSearchTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestAlphaSearchExecutorOAuthAndWebsocketDispatch(t *testing.T) {
+	for _, transport := range []string{"http", "auto-websocket", "websocket"} {
+		t.Run(transport, func(t *testing.T) {
+			auth := codexOAuthAdmissionTestAuth(true, nil)
+			auth.Attributes = map[string]string{"base_url": "https://untrusted.invalid", "websockets": "true"}
+			ctx := contextWithCodexAdmissionHeaders(http.Header{"User-Agent": {"codex_cli_rs/0.153.4"}, "Authorization": {"Bearer downstream-secret"}, "Chatgpt-Account-Id": {"untrusted-account"}})
+			ctx = cliproxyexecutor.WithDownstreamWebsocket(ctx)
+			calls := 0
+			const response = `{"id":"search-session","results":[{"url":"https://example.org","opaque":{"key":1}}]}`
+			ctx = cliproxyexecutor.WithRoundTripper(ctx, alphaSearchTransport(func(r *http.Request) (*http.Response, error) {
+				calls++
+				if r.URL.String() != "https://chatgpt.com/backend-api/codex/alpha/search" {
+					t.Errorf("URL=%s", r.URL)
+				}
+				if r.Method != http.MethodPost || r.Header.Get("Accept") != "application/json" || r.Header.Get("Authorization") != "Bearer codex-access-token" || r.Header.Get("Chatgpt-Account-Id") != "acct-test" {
+					t.Errorf("incorrect method or credential headers")
+				}
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					return nil, err
+				}
+				if gjson.GetBytes(body, "model").String() != "upstream-model" {
+					t.Errorf("alias not rewritten: %s", body)
+				}
+				for _, key := range []string{"prompt_cache_key", "prompt_cache_retention", "instructions", "store", "reasoning"} {
+					if gjson.GetBytes(body, key).Exists() {
+						t.Errorf("unexpected %s in %s", key, body)
+					}
+				}
+				if gjson.GetBytes(body, "commands.search_query.0.q").String() != "test" || gjson.GetBytes(body, "settings.external_web_access").Type != gjson.True || gjson.GetBytes(body, "commands.prompt_cache_key").String() != "nested-preserved" {
+					t.Errorf("search payload changed: %s", body)
+				}
+				return &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {"application/json"}}, Body: io.NopCloser(strings.NewReader(response))}, nil
+			}))
+			req := cliproxyexecutor.Request{Model: "upstream-model", Payload: []byte(`{"id":"search-session","model":"alias","commands":{"search_query":[{"q":"test"}],"prompt_cache_key":"nested-preserved"},"settings":{"external_web_access":true},"prompt_cache_key":"remove","prompt_cache_retention":"24h"}`)}
+			opts := cliproxyexecutor.Options{Alt: "alpha/search"}
+			var resp cliproxyexecutor.Response
+			var err error
+			switch transport {
+			case "http":
+				resp, err = NewCodexExecutor(&config.Config{}).Execute(ctx, auth, req, opts)
+			case "auto-websocket":
+				resp, err = NewCodexAutoExecutor(&config.Config{}).Execute(ctx, auth, req, opts)
+			case "websocket":
+				resp, err = NewCodexWebsocketsExecutor(&config.Config{}).Execute(ctx, auth, req, opts)
+			}
+			if err != nil || string(resp.Payload) != response || calls != 1 {
+				t.Fatalf("calls=%d body=%s err=%v", calls, resp.Payload, err)
+			}
+		})
+	}
+}
+
+func TestAlphaSearchExecutorFailuresAndUsage(t *testing.T) {
+	auth := &cliproxyauth.Auth{ID: "search-key", Provider: "codex", Attributes: map[string]string{"api_key": "upstream-key", "alpha_search": "true", "base_url": "https://search.example/v1/"}}
+	const model = "alpha-search-usage-test"
+	req := cliproxyexecutor.Request{Model: model, Payload: []byte(`{"model":"alpha-search-usage-test","commands":{"search_query":[{"q":"test"}]}}`)}
+	opts := cliproxyexecutor.Options{Alt: "alpha/search"}
+	for _, status := range []int{200, 401, 429} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			plugin := &tenantUsageCapturePlugin{records: make(chan coreusage.Record, 16)}
+			coreusage.RegisterPlugin(plugin)
+			ctx := cliproxyexecutor.WithRoundTripper(context.Background(), alphaSearchTransport(func(r *http.Request) (*http.Response, error) {
+				if r.URL.String() != "https://search.example/v1/alpha/search" || r.Header.Get("Authorization") != "Bearer upstream-key" {
+					t.Errorf("incorrect target/auth")
+				}
+				return &http.Response{StatusCode: status, Header: http.Header{"Retry-After": {"7"}}, Body: io.NopCloser(strings.NewReader(`{"id":"search-result"}`))}, nil
+			}))
+			resp, err := NewCodexExecutor(&config.Config{}).Execute(ctx, auth, req, opts)
+			if status == 200 {
+				if err != nil || string(resp.Payload) != `{"id":"search-result"}` {
+					t.Fatalf("resp=%s err=%v", resp.Payload, err)
+				}
+			} else {
+				var coded interface{ StatusCode() int }
+				if !errors.As(err, &coded) || coded.StatusCode() != status {
+					t.Fatalf("status=%d err=%v", status, err)
+				}
+			}
+			timeout := time.After(2 * time.Second)
+			for {
+				select {
+				case record := <-plugin.records:
+					if record.Model != model {
+						continue
+					}
+					if record.Failed != (status != 200) || record.Detail.TotalTokens != 0 {
+						t.Fatalf("incorrect usage: %+v", record)
+					}
+					return
+				case <-timeout:
+					t.Fatal("no usage record")
+				}
+			}
+		})
+	}
+	t.Run("cancel", func(t *testing.T) {
+		started := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ctx = cliproxyexecutor.WithRoundTripper(ctx, alphaSearchTransport(func(r *http.Request) (*http.Response, error) {
+			close(started)
+			<-r.Context().Done()
+			return nil, r.Context().Err()
+		}))
+		result := make(chan error, 1)
+		go func() { _, err := NewCodexExecutor(&config.Config{}).Execute(ctx, auth, req, opts); result <- err }()
+		select {
+		case <-started:
+			cancel()
+		case <-time.After(2 * time.Second):
+			t.Fatal("transport not reached")
+		}
+		select {
+		case err := <-result:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("err=%v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("cancellation not propagated")
+		}
+	})
+	t.Run("admission", func(t *testing.T) {
+		oauth := codexOAuthAdmissionTestAuth(true, nil)
+		ctx := contextWithCodexAdmissionHeaders(http.Header{"User-Agent": {"curl/8"}})
+		ctx = cliproxyexecutor.WithRoundTripper(ctx, alphaSearchTransport(func(*http.Request) (*http.Response, error) {
+			t.Error("denied request reached upstream")
+			return nil, errors.New("unexpected network")
+		}))
+		_, err := NewCodexExecutor(&config.Config{}).Execute(ctx, oauth, req, opts)
+		var coded interface{ StatusCode() int }
+		if !errors.As(err, &coded) || coded.StatusCode() != 403 {
+			t.Fatalf("err=%v", err)
+		}
+	})
+}

--- a/internal/runtime/executor/codex_auto_executor.go
+++ b/internal/runtime/executor/codex_auto_executor.go
@@ -54,7 +54,7 @@ func (e *CodexAutoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth
 	if e == nil || e.httpExec == nil || e.wsExec == nil {
 		return cliproxyexecutor.Response{}, fmt.Errorf("codex auto executor: executor is nil")
 	}
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
+	if opts.Alt != "alpha/search" && cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
 		return e.wsExec.Execute(ctx, auth, req, opts)
 	}
 	return e.httpExec.Execute(ctx, auth, req, opts)
@@ -64,7 +64,7 @@ func (e *CodexAutoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 	if e == nil || e.httpExec == nil || e.wsExec == nil {
 		return nil, fmt.Errorf("codex auto executor: executor is nil")
 	}
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
+	if opts.Alt != "alpha/search" && cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
 		return e.wsExec.ExecuteStream(ctx, auth, req, opts)
 	}
 	return e.httpExec.ExecuteStream(ctx, auth, req, opts)

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -113,6 +113,9 @@ func (e *CodexExecutor) ProbeQuotaRecovery(ctx context.Context, auth *cliproxyau
 }
 
 func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	if opts.Alt == "alpha/search" {
+		return e.executeAlphaSearch(ctx, auth, req, opts)
+	}
 	if opts.Alt == codexImageGenerationAlt || opts.Alt == codexImageEditsAlt {
 		return e.executeImageGeneration(ctx, auth, req, opts)
 	}
@@ -328,8 +331,8 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 }
 
 func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
-	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
+	if opts.Alt == "responses/compact" || opts.Alt == "alpha/search" {
+		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /" + opts.Alt}
 	}
 	// Shrink multi-MB Desktop history data URLs before translation/sanitize so later
 	// body-level passes never see the full base64 history.
@@ -490,6 +493,9 @@ func newCodexResponsesIncompleteError() *cliproxyauth.Error {
 }
 
 func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if opts.Alt == "alpha/search" {
+		return cliproxyexecutor.Response{}, statusErr{code: http.StatusBadRequest, msg: "token counting is not supported for Alpha Search"}
+	}
 	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{
 		TargetFormat: sdktranslator.FromString("codex"),
 	})

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -78,6 +78,9 @@ func NewCodexWebsocketsExecutor(cfg *config.Config) *CodexWebsocketsExecutor {
 }
 
 func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	if opts.Alt == "alpha/search" {
+		return e.executeAlphaSearch(ctx, auth, req, opts)
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -286,8 +289,8 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
+	if opts.Alt == "responses/compact" || opts.Alt == "alpha/search" {
+		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /" + opts.Alt}
 	}
 	execCtx := newExecutionContext(ctx, e.Identifier(), e.cfg, auth, req, opts, ExecutionOptions{
 		TargetFormat:      sdktranslator.FromString("codex"),

--- a/internal/watcher/codex_alpha_search_test.go
+++ b/internal/watcher/codex_alpha_search_test.go
@@ -1,0 +1,55 @@
+package watcher
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/watcher/diff"
+)
+
+func TestReloadCodexAlphaSearchOptIn(t *testing.T) {
+	dir := t.TempDir()
+	w := &Watcher{configPath: filepath.Join(dir, "config.yaml"), authDir: dir, mirroredAuthDir: dir}
+	w.SetConfig(&config.Config{AuthDir: dir})
+	queue := make(chan AuthUpdate, 4)
+	w.SetAuthUpdateQueue(queue)
+	t.Cleanup(func() { w.SetAuthUpdateQueue(nil) })
+	var authID string
+	for i, field := range []string{"", "    alpha-search: true\n", "    alpha-search: false\n"} {
+		previous := w.config
+		data := fmt.Sprintf("auth-dir: %s\ncodex-api-key:\n  - api-key: test-codex\n%s", dir, field)
+		if err := os.WriteFile(w.configPath, []byte(data), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !w.reloadConfig() {
+			t.Fatal("reloadConfig failed")
+		}
+		select {
+		case update := <-queue:
+			if update.Auth == nil {
+				t.Fatalf("expected auth, got %#v", update)
+			}
+			if i == 0 {
+				authID = update.Auth.ID
+			} else if update.Action != AuthUpdateActionModify || update.Auth.ID != authID {
+				t.Fatalf("expected same credential modify, got %#v", update)
+			}
+			if got := update.Auth.Attributes["alpha_search"]; (got == "true") != (i == 1) {
+				t.Fatalf("step %d: alpha_search = %q", i, got)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("step %d: no auth update on capability change", i)
+		}
+		if i > 0 {
+			changes := strings.Join(diff.BuildConfigChangeDetails(previous, w.config), "\n")
+			if !strings.Contains(changes, "codex[0].alpha-search:") {
+				t.Fatalf("capability toggle missing from diff: %s", changes)
+			}
+		}
+	}
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -193,6 +193,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 			if o.Websockets != n.Websockets {
 				changes = append(changes, fmt.Sprintf("codex[%d].websockets: %t -> %t", i, o.Websockets, n.Websockets))
 			}
+			if o.AlphaSearch != n.AlphaSearch {
+				changes = append(changes, fmt.Sprintf("codex[%d].alpha-search: %t -> %t", i, o.AlphaSearch, n.AlphaSearch))
+			}
 			if strings.TrimSpace(o.APIKey) != strings.TrimSpace(n.APIKey) {
 				changes = append(changes, fmt.Sprintf("codex[%d].api-key: updated", i))
 			}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -285,6 +285,9 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 		if ck.Websockets {
 			attrs["websockets"] = "true"
 		}
+		if ck.AlphaSearch {
+			attrs["alpha_search"] = "true"
+		}
 		if hash := diff.ComputeCodexModelsHash(ck.Models); hash != "" {
 			attrs["models_hash"] = hash
 		}

--- a/sdk/api/handlers/openai/openai_alpha_search.go
+++ b/sdk/api/handlers/openai/openai_alpha_search.go
@@ -1,0 +1,35 @@
+package openai
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	"github.com/tidwall/gjson"
+)
+
+// AlphaSearch is a separate Codex JSON protocol, not a Responses translation.
+func (h *OpenAIResponsesAPIHandler) AlphaSearch(c *gin.Context) {
+	body, ok := handlers.ReadJSONRequestBody(c)
+	if !ok {
+		return
+	}
+	model := gjson.GetBytes(body, "model")
+	if !gjson.ParseBytes(body).IsObject() || model.Type != gjson.String || strings.TrimSpace(model.String()) == "" || gjson.GetBytes(body, "stream").Type == gjson.True {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{Error: handlers.ErrorDetail{Message: "Alpha Search requires a JSON object with a non-empty model and does not support streaming", Type: "invalid_request_error"}})
+		return
+	}
+	body, _, _ = rewriteCcSwitchOpenAIRequestModel(body, c)
+	c.Header("Content-Type", "application/json")
+	ctx, cancel := h.GetContextWithCancel(h, c, c.Request.Context())
+	resp, headers, errMsg := h.ExecuteWithAuthManager(ctx, h.HandlerType(), gjson.GetBytes(body, "model").String(), body, "alpha/search")
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		cancel(errMsg.Error)
+		return
+	}
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), headers)
+	_, _ = c.Writer.Write(resp)
+	cancel()
+}

--- a/sdk/cliproxy/auth/alpha_search.go
+++ b/sdk/cliproxy/auth/alpha_search.go
@@ -1,0 +1,16 @@
+package auth
+
+import "strings"
+
+// SupportsCodexAlphaSearch keeps this independent protocol off generic Responses
+// channels. API keys require an operator opt-in; OAuth uses the Codex endpoint.
+func SupportsCodexAlphaSearch(a *Auth) bool {
+	if a == nil || a.Provider != "codex" {
+		return false
+	}
+	if strings.TrimSpace(a.Attributes["api_key"]) != "" {
+		return a.Attributes["alpha_search"] == "true" && strings.TrimSpace(a.Attributes["base_url"]) != ""
+	}
+	token, _ := a.Metadata["access_token"].(string)
+	return strings.TrimSpace(token) != ""
+}

--- a/sdk/cliproxy/auth/alpha_search_test.go
+++ b/sdk/cliproxy/auth/alpha_search_test.go
@@ -1,0 +1,205 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+const alphaSearchTestModel = "gpt-alpha-search-test"
+
+func alphaSearchTestOAuth(id string) *Auth {
+	return &Auth{ID: id, Provider: "codex", Label: id, Status: StatusActive,
+		Metadata: map[string]any{"access_token": "test-oauth-token"}}
+}
+
+func alphaSearchTestManager(t *testing.T, candidates ...*Auth) *Manager {
+	t.Helper()
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{Routing: internalconfig.RoutingConfig{IncludeDefaultGroup: true}})
+	models := make(map[string][]string, len(candidates))
+	for _, candidate := range candidates {
+		manager.RegisterExecutorForTenant(normalizedTenantID(candidate.TenantID), &stubExecutor{id: candidate.Provider})
+		if _, err := manager.Register(context.Background(), candidate); err != nil {
+			t.Fatalf("register %s: %v", candidate.ID, err)
+		}
+		models[candidate.ID] = []string{alphaSearchTestModel}
+	}
+	manager.SetModelRegistry(&scopedModelRegistry{byClient: models})
+	return manager
+}
+
+func alphaSearchTestPick(manager *Manager, mixed bool, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, error) {
+	if mixed {
+		selected, _, _, err := manager.pickNextMixed(context.Background(), []string{"codex", "openai"}, alphaSearchTestModel, opts, tried)
+		return selected, err
+	}
+	selected, _, err := manager.pickNext(context.Background(), "codex", alphaSearchTestModel, opts, tried)
+	return selected, err
+}
+
+func TestAlphaSearchCredentialPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		auth *Auth
+		want bool
+	}{
+		{name: "oauth", auth: alphaSearchTestOAuth("oauth"), want: true},
+		{name: "missing token", auth: &Auth{ID: "missing", Provider: "codex", Metadata: map[string]any{"email": "test@example.invalid"}}},
+		{name: "api key disabled by default", auth: &Auth{ID: "key", Provider: "codex", Attributes: map[string]string{"api_key": "test-key", "base_url": "https://example.invalid/v1"}}},
+		{name: "email and OAuth token do not bypass API key opt in", auth: &Auth{ID: "email-key", Provider: "codex", Attributes: map[string]string{"api_key": "test-key", "base_url": "https://example.invalid/v1"}, Metadata: map[string]any{"email": "test@example.invalid", "access_token": "test-token", "alpha_search": true}}},
+		{name: "API key explicit opt in", auth: &Auth{ID: "enabled-key", Provider: "codex", Attributes: map[string]string{"api_key": "test-key", "base_url": "https://example.invalid/v1", "alpha_search": "true"}}, want: true},
+		{name: "API key opt in without base URL", auth: &Auth{ID: "no-base", Provider: "codex", Attributes: map[string]string{"api_key": "test-key", "alpha_search": "true"}}},
+		{name: "other provider cannot opt in", auth: &Auth{ID: "openai", Provider: "openai", Attributes: map[string]string{"api_key": "test-key", "base_url": "https://example.invalid/v1", "alpha_search": "true"}, Metadata: map[string]any{"access_token": "test-token"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := SupportsCodexAlphaSearch(test.auth); got != test.want {
+				t.Fatalf("SupportsCodexAlphaSearch = %v, want %v", got, test.want)
+			}
+			for _, mixed := range []bool{false, true} {
+				manager := alphaSearchTestManager(t, test.auth)
+				// Both selector entry points must apply the policy before scheduling.
+				manager.RegisterExecutor(&stubExecutor{id: "codex"})
+				selected, err := alphaSearchTestPick(manager, mixed, cliproxyexecutor.Options{Alt: "alpha/search"}, nil)
+				if test.want {
+					if err != nil || selected == nil || selected.ID != test.auth.ID {
+						t.Fatalf("mixed=%v selected=%v err=%v", mixed, selected, err)
+					}
+				} else if err == nil || selected != nil {
+					t.Fatalf("mixed=%v selected prohibited credential %v, err=%v", mixed, selected, err)
+				}
+			}
+		})
+	}
+	if SupportsCodexAlphaSearch(nil) {
+		t.Fatal("nil credential must not support search")
+	}
+}
+
+func TestAlphaSearchSelectionPreservesAuthorizationScopes(t *testing.T) {
+	const tenantA = "00000000-0000-0000-0000-00000000000a"
+	const tenantB = "00000000-0000-0000-0000-00000000000b"
+	tests := []struct {
+		name  string
+		setup func(*Manager, *Auth, map[string]any) map[string]struct{}
+	}{
+		{name: "tenant", setup: func(manager *Manager, candidate *Auth, meta map[string]any) map[string]struct{} {
+			meta[cliproxyexecutor.TenantMetadataKey] = tenantA
+			manager.RegisterExecutorForTenant(tenantA, &stubExecutor{id: "codex"})
+			candidate.TenantID = tenantB
+			return nil
+		}},
+		{name: "allowed channel", setup: func(_ *Manager, _ *Auth, meta map[string]any) map[string]struct{} {
+			meta["allowed-channels"] = "different-channel"
+			return nil
+		}},
+		{name: "allowed channel group", setup: func(_ *Manager, _ *Auth, meta map[string]any) map[string]struct{} {
+			meta["allowed-channel-groups"] = "different-group"
+			return nil
+		}},
+		{name: "route group", setup: func(_ *Manager, _ *Auth, meta map[string]any) map[string]struct{} {
+			meta[cliproxyexecutor.RouteGroupMetadataKey] = "different-group"
+			return nil
+		}},
+		{name: "registered model", setup: func(manager *Manager, candidate *Auth, _ map[string]any) map[string]struct{} {
+			manager.SetModelRegistry(&scopedModelRegistry{byClient: map[string][]string{candidate.ID: {"different-model"}}})
+			return nil
+		}},
+		{name: "group allowed models", setup: func(manager *Manager, _ *Auth, _ map[string]any) map[string]struct{} {
+			manager.SetConfig(&internalconfig.Config{Routing: internalconfig.RoutingConfig{IncludeDefaultGroup: true,
+				ChannelGroups: []internalconfig.RoutingChannelGroup{{Name: "default", AllowedModels: []string{"different-model"}}}}})
+			return nil
+		}},
+		{name: "pinned", setup: func(_ *Manager, _ *Auth, meta map[string]any) map[string]struct{} {
+			meta[cliproxyexecutor.PinnedAuthMetadataKey] = "different-auth"
+			return nil
+		}},
+		{name: "tried", setup: func(_ *Manager, candidate *Auth, _ map[string]any) map[string]struct{} {
+			return map[string]struct{}{candidate.ID: {}}
+		}},
+		{name: "disabled", setup: func(_ *Manager, candidate *Auth, _ map[string]any) map[string]struct{} {
+			candidate.Disabled = true
+			return nil
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, mixed := range []bool{false, true} {
+				candidate := alphaSearchTestOAuth("scoped-oauth")
+				manager := alphaSearchTestManager(t, candidate)
+				opts := cliproxyexecutor.Options{Alt: "alpha/search", Metadata: map[string]any{}}
+				if selected, err := alphaSearchTestPick(manager, mixed, opts, nil); err != nil || selected == nil {
+					t.Fatalf("positive control mixed=%v selected=%v err=%v", mixed, selected, err)
+				}
+				tried := test.setup(manager, candidate, opts.Metadata)
+				if _, err := manager.Register(context.Background(), candidate); err != nil {
+					t.Fatal(err)
+				}
+				selected, err := alphaSearchTestPick(manager, mixed, opts, tried)
+				if err == nil || selected != nil {
+					t.Fatalf("mixed=%v scope bypass: selected=%v err=%v", mixed, selected, err)
+				}
+			}
+		})
+	}
+}
+
+func TestAlphaSearchManagerExecuteSkipsIneligibleCandidates(t *testing.T) {
+	oauth := alphaSearchTestOAuth("z-eligible-oauth")
+	key := alphaSearchTestOAuth("a-ineligible-key")
+	key.Attributes = map[string]string{"api_key": "test-key", "base_url": "https://example.invalid/v1"}
+	other := alphaSearchTestOAuth("b-other-provider")
+	other.Provider = "openai"
+	manager := alphaSearchTestManager(t, key, other, oauth)
+	executor := &executionMetadataExecutor{}
+	manager.RegisterExecutor(executor)
+	opts := cliproxyexecutor.Options{Alt: "alpha/search", Metadata: map[string]any{}}
+	response, err := manager.Execute(context.Background(), []string{"openai", "codex"}, cliproxyexecutor.Request{
+		Model: alphaSearchTestModel, Payload: []byte(`{"model":"gpt-alpha-search-test","commands":{"search_query":[{"q":"test"}]}}`),
+	}, opts)
+	if err != nil || string(response.Payload) != "ok" || executor.seenSelectedAuthID != oauth.ID {
+		t.Fatalf("Execute payload=%q selected=%q err=%v", response.Payload, executor.seenSelectedAuthID, err)
+	}
+	// Pinning must narrow the eligible set, never grant a missing capability.
+	opts.Metadata[cliproxyexecutor.PinnedAuthMetadataKey] = key.ID
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: alphaSearchTestModel}, opts); err == nil {
+		t.Fatal("pinning selected a default-disabled API key")
+	}
+	// The API key remains eligible for its original Responses capability.
+	selected, err := alphaSearchTestPick(manager, false, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.PinnedAuthMetadataKey: key.ID,
+	}}, nil)
+	if err != nil || selected == nil || selected.ID != key.ID {
+		t.Fatalf("ordinary request selected=%v err=%v", selected, err)
+	}
+}
+
+func TestAlphaSearchRouteFallbackStillFiltersCapabilityAndCallerScope(t *testing.T) {
+	for _, mixed := range []bool{false, true} {
+		key := alphaSearchTestOAuth("primary-key")
+		key.Attributes = map[string]string{"api_key": "test-key", "base_url": "https://example.invalid/v1"}
+		oauth := alphaSearchTestOAuth("fallback-oauth")
+		manager := alphaSearchTestManager(t, key, oauth)
+		manager.SetConfig(&internalconfig.Config{Routing: internalconfig.RoutingConfig{
+			IncludeDefaultGroup: true,
+			ChannelGroups: []internalconfig.RoutingChannelGroup{{
+				Name: "primary", ExcludeFromDefault: true,
+				Match: internalconfig.ChannelGroupMatch{Channels: []string{key.Label}},
+			}},
+		}})
+		opts := cliproxyexecutor.Options{Alt: "alpha/search", Metadata: map[string]any{
+			cliproxyexecutor.RouteGroupMetadataKey: "primary", cliproxyexecutor.RouteFallbackMetadataKey: "default",
+		}}
+		selected, err := alphaSearchTestPick(manager, mixed, opts, nil)
+		if err != nil || selected == nil || selected.ID != oauth.ID {
+			t.Fatalf("mixed=%v fallback selected=%v err=%v", mixed, selected, err)
+		}
+		opts.Metadata["allowed-channels"] = key.Label
+		if selected, err := alphaSearchTestPick(manager, mixed, opts, nil); err == nil || selected != nil {
+			t.Fatalf("mixed=%v fallback bypassed caller channel scope: selected=%v err=%v", mixed, selected, err)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/conductor_selector_service.go
+++ b/sdk/cliproxy/auth/conductor_selector_service.go
@@ -246,6 +246,14 @@ func (s selectorService) pickLocked(
 	tried map[string]struct{},
 	includeCandidate func(candidate *Auth) bool,
 ) (*Auth, string, error) {
+	// Capability filtering happens before scheduling and after the same tenant,
+	// channel and model gates as every other execution path.
+	if opts.Alt == "alpha/search" {
+		original := includeCandidate
+		includeCandidate = func(candidate *Auth) bool {
+			return SupportsCodexAlphaSearch(candidate) && (original == nil || original(candidate))
+		}
+	}
 	registryRef := s.manager.modelRegistry
 	var diagnosis error
 	for _, selectorRouteGroup := range scope.routeGroupsToTry() {
@@ -274,6 +282,9 @@ func (s selectorService) pickLocked(
 	// "the account is missing" when the account is present and healthy.
 	if diagnosis != nil {
 		return nil, "", diagnosis
+	}
+	if opts.Alt == "alpha/search" {
+		return nil, "", &Error{Code: "alpha_search_auth_unavailable", Message: "no eligible Codex Alpha Search credential for this model and scope; use Codex OAuth or an API key with alpha-search enabled and a base-url", HTTPStatus: 503}
 	}
 	return nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 }


### PR DESCRIPTION
## 问题与行为

Codex CLI/Desktop 调用 `/v1/alpha/search` 时，CliRelay 缺少路由，直接返回空 404。本 PR 将独立 Alpha Search JSON 协议接入现有鉴权、租户、模型、渠道、重试、并发与日志执行链，标准路径与渠道分组/嵌套路径均可使用。

- OAuth 只发送到官方 Codex 搜索端点；API key 默认不参与搜索，必须显式配置 `alpha-search: true` 和 `base-url`，包括配置持久化、PATCH 和热更新撤销。
- 调度前筛选搜索能力，保留全部已有权限；没有匹配凭据时返回明确的 503 错误，其他 Responses 请求不受影响。
- 绕过 Responses 翻译、缓存注入和系统提示词注入；按已授权模型别名改写 model，仅移除顶层 `prompt_cache_key`、`prompt_cache_retention`，保留搜索 JSON 结果。
- 保留 Codex 客户端准入、凭据请求头、代理、取消、失败记录和成功用量；拒绝 streaming/token counting。

## 验证

- `go test ./internal/api -run TestAlphaSearchRouteRequiresAuthentication -count=1`：修复前标准/分组路由真实返回空 404，新增断言失败；修复后通过。
- `go test ./internal/api -run TestAlphaSearch -count=1`：真实路由→manager→executor→本地 HTTP 上游通过，覆盖别名、嵌套路由、model 权限和能力撤销。
- `go test ./internal/runtime/executor -run TestAlphaSearch -count=1`：OAuth 固定地址、凭据隔离、三种传输入口、协议保留、401/429、取消、客户端准入及零 token 成功用量通过。
- `go test ./sdk/cliproxy/auth -count=1` 及 Alpha 目标 `-race`：能力、租户/模型/渠道/分组/pinned/tried/回退隔离通过。
- 配置、watcher、providers、management 全包测试，以及 watcher Alpha 热更新 `-race` 通过；配置回归已运行 red→green。
- `./scripts/ci-pr.sh`：完整本地 CI 通过（结构、secret scan、gofmt、vet、全量测试、updater、golangci-lint、build）。

安全与架构专项审查完成。未修改 translator 或放宽门禁。测试上游为本地 HTTP/受控 RoundTripper；未使用真实官方 OAuth 账号进行搜索。暂不宣称所有上游都支持此协议。

Refs #994
