### PR TITLE
fix(codex): prevent stale fingerprint refreshes from replacing new state

### DIFF
--- a/internal/runtime/executor/codex_fingerprint_refresh_order_test.go
+++ b/internal/runtime/executor/codex_fingerprint_refresh_order_test.go
@@ -1,0 +1,229 @@
+package executor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identityfingerprint"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestCodexFingerprintRefreshCannotReplaceUnpersistedLearning(t *testing.T) {
+	initIdentityFingerprintRuntimeDB(t)
+	const learnedUA = "codex_cli_rs/0.153.4 (Mac OS 26.3.1; arm64) learned"
+	cfg := &config.Config{IdentityFingerprint: config.IdentityFingerprintConfig{
+		Codex: config.CodexIdentityFingerprintConfig{Enabled: true},
+	}}
+	auth := &cliproxyauth.Auth{ID: "refresh-order", Provider: "codex", Metadata: map[string]any{
+		"access_token": "test-token", "account_id": "refresh-order-account",
+	}}
+	accountKey := authSubjectKey(t, auth)
+	persistRelease, refreshRelease := make(chan struct{}), make(chan struct{})
+	refreshStarted := make(chan struct{})
+	var persistOnce, refreshOnce, startedOnce sync.Once
+	var persisted atomic.Bool
+	var reads atomic.Int32
+	stored := refreshOrderProfile(accountKey, "codex_cli_rs", "0.153.4")
+	stored.Fields[identityfingerprint.FieldUserAgent] = learnedUA
+	defer func() {
+		persistOnce.Do(func() { close(persistRelease) })
+		refreshOnce.Do(func() { close(refreshRelease) })
+		eventually(t, time.Second, func() bool {
+			runtimeIdentityFingerprintAsync.Lock()
+			defer runtimeIdentityFingerprintAsync.Unlock()
+			return len(runtimeIdentityFingerprintAsync.persists) == 0
+		})
+		waitCodexFingerprintRefreshIdle(t, accountKey)
+	}()
+	runtimeIdentityFingerprintStoreFuncMu.Lock()
+	runtimeObserveIdentityFingerprint = func(identityfingerprint.LearnInput) (*identityfingerprint.LearnedRecord, identityfingerprint.MergeResult, error) {
+		<-persistRelease
+		persisted.Store(true)
+		return &stored, identityfingerprint.MergeResult{}, nil
+	}
+	runtimeListCodexIdentityFingerprintProfiles = func(identityfingerprint.Provider, string) ([]identityfingerprint.LearnedRecord, error) {
+		reads.Add(1)
+		startedOnce.Do(func() { close(refreshStarted) })
+		<-refreshRelease
+		if persisted.Load() {
+			return []identityfingerprint.LearnedRecord{stored}, nil
+		}
+		return nil, nil // Snapshot read before the first learned profile is persisted.
+	}
+	runtimeGetCodexIdentityFingerprintAccountPolicy = func(identityfingerprint.Provider, string) (identityfingerprint.AccountPolicy, error) {
+		return identityfingerprint.AccountPolicy{}, nil
+	}
+	runtimeIdentityFingerprintStoreFuncMu.Unlock()
+	ctx := contextWithInboundHeaders(http.MethodPost, "/v1/responses", http.Header{
+		"User-Agent": {learnedUA}, "Version": {"0.153.4"}, "Originator": {"codex_cli_rs"},
+	})
+	first := httptest.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil).WithContext(ctx)
+	applyCodexHeaders(first, cfg, auth, "test-token", false)
+	if got := first.Header.Get("User-Agent"); got != learnedUA {
+		t.Fatalf("first request UA=%q, want %q", got, learnedUA)
+	}
+	select {
+	case <-refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("background snapshot did not start")
+	}
+	refreshOnce.Do(func() { close(refreshRelease) })
+	waitCodexFingerprintRefreshIdle(t, accountKey)
+	replay := httptest.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
+	applyCodexHeaders(replay, cfg, auth, "test-token", false)
+	if got := replay.Header.Get("User-Agent"); got != learnedUA {
+		t.Fatalf("old empty snapshot replaced learned UA: got %q, want %q", got, learnedUA)
+	}
+	persistOnce.Do(func() { close(persistRelease) })
+	eventually(t, time.Second, func() bool {
+		return reads.Load() >= 2
+	})
+	waitCodexFingerprintRefreshIdle(t, accountKey)
+	selection, ok := getCachedCodexIdentityFingerprintSelection(accountKey)
+	if !ok || selection.Profile == nil || selection.Profile.Fields[identityfingerprint.FieldUserAgent] != learnedUA {
+		t.Fatalf("learning completion did not refresh the persisted selection: %+v", selection)
+	}
+}
+
+func waitCodexFingerprintRefreshIdle(t *testing.T, accountKey string) {
+	t.Helper()
+	eventually(t, time.Second, func() bool {
+		codexIdentityFingerprintSelectionCache.Lock()
+		defer codexIdentityFingerprintSelectionCache.Unlock()
+		_, refreshing := codexIdentityFingerprintSelectionCache.refreshing[accountKey]
+		return !refreshing
+	})
+}
+
+func TestCodexFingerprintInvalidationDuringRefreshMakesProgress(t *testing.T) {
+	for _, deletion := range []bool{false, true} {
+		name := "active policy"
+		if deletion {
+			name = "deleted profiles"
+		}
+		t.Run(name, func(t *testing.T) {
+			initIdentityFingerprintRuntimeDB(t)
+			const accountKey = "refresh-invalidated-account"
+			old := refreshOrderProfile(accountKey, "codex_cli_rs", "0.150.0")
+			next := refreshOrderProfile(accountKey, "codex_vscode", "0.153.4")
+			next.ProfileFamily = identityfingerprint.ProfileFamilyIDE
+			setCachedCodexIdentityFingerprintSelection(accountKey, identityfingerprint.ProfileSelection{Profile: &old})
+			// A cached profile must not resurrect after the latest store snapshot
+			// deletes it. The cache is deliberately left populated in this test.
+			setCachedRuntimeIdentityFingerprint(identityfingerprint.ProviderCodex, accountKey, old.ProfileKey, "", &old, time.Minute)
+			started, release := make(chan struct{}), make(chan struct{})
+			var releaseOnce sync.Once
+			var lists atomic.Int32
+			defer func() {
+				releaseOnce.Do(func() { close(release) })
+				waitCodexFingerprintRefreshIdle(t, accountKey)
+			}()
+			runtimeIdentityFingerprintStoreFuncMu.Lock()
+			runtimeListCodexIdentityFingerprintProfiles = func(identityfingerprint.Provider, string) ([]identityfingerprint.LearnedRecord, error) {
+				if lists.Add(1) == 1 {
+					close(started)
+					<-release
+					return []identityfingerprint.LearnedRecord{old}, nil
+				}
+				if deletion {
+					return nil, nil
+				}
+				return []identityfingerprint.LearnedRecord{old, next}, nil
+			}
+			runtimeGetCodexIdentityFingerprintAccountPolicy = func(identityfingerprint.Provider, string) (identityfingerprint.AccountPolicy, error) {
+				return identityfingerprint.AccountPolicy{AccountKey: accountKey, Strategy: identityfingerprint.AccountStrategyActiveProfile, ActiveProfileKey: next.ProfileKey, Revision: 2}, nil
+			}
+			runtimeIdentityFingerprintStoreFuncMu.Unlock()
+			scheduleCodexIdentityFingerprintSelectionRefresh(accountKey)
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("old refresh did not start")
+			}
+			invalidateCachedCodexIdentityFingerprintSelection(accountKey)
+			releaseOnce.Do(func() { close(release) })
+			eventually(t, time.Second, func() bool {
+				selection, ok := getCachedCodexIdentityFingerprintSelection(accountKey)
+				if !ok || selection.Policy.Revision != 2 {
+					return false
+				}
+				if deletion {
+					return selection.Profile == nil && selection.Reason == "no_profile"
+				}
+				return selection.Profile != nil && selection.Profile.ProfileKey == next.ProfileKey && selection.Reason == "active_profile"
+			})
+			if lists.Load() < 2 {
+				t.Fatal("invalidation was lost instead of refreshing the latest snapshot")
+			}
+		})
+	}
+}
+
+func refreshOrderProfile(accountKey, product, version string) identityfingerprint.LearnedRecord {
+	return identityfingerprint.LearnedRecord{
+		Provider: identityfingerprint.ProviderCodex, AccountKey: accountKey,
+		ProfileKey: product, ProfileFamily: identityfingerprint.ProfileFamilyCLI,
+		ClientProduct: product, ClientVariant: product, Version: version,
+		Fields: map[string]string{
+			identityfingerprint.FieldUserAgent:       product + "/" + version,
+			identityfingerprint.FieldCodexVersion:    version,
+			identityfingerprint.FieldCodexOriginator: product,
+		},
+		LastSeenAt: time.Now().UTC(),
+	}
+}
+
+func TestCodexFingerprintDisabledSkipsLearningAndSelection(t *testing.T) {
+	initIdentityFingerprintRuntimeDB(t)
+	var calls atomic.Int32
+	runtimeIdentityFingerprintStoreFuncMu.Lock()
+	runtimeObserveIdentityFingerprint = func(identityfingerprint.LearnInput) (*identityfingerprint.LearnedRecord, identityfingerprint.MergeResult, error) {
+		calls.Add(1)
+		return nil, identityfingerprint.MergeResult{}, nil
+	}
+	runtimeListCodexIdentityFingerprintProfiles = func(identityfingerprint.Provider, string) ([]identityfingerprint.LearnedRecord, error) {
+		calls.Add(1)
+		return nil, nil
+	}
+	runtimeIdentityFingerprintStoreFuncMu.Unlock()
+	ctx := contextWithInboundHeaders(http.MethodPost, "/v1/responses", http.Header{"User-Agent": {"codex_cli_rs/0.153.4"}})
+	_, enabled := codexIdentityFingerprint(&config.Config{}, &cliproxyauth.Auth{Provider: "codex", ID: "disabled"}, ctx)
+	if enabled || calls.Load() != 0 {
+		t.Fatalf("disabled fingerprint enabled=%v store calls=%d", enabled, calls.Load())
+	}
+	codexIdentityFingerprintSelectionCache.Lock()
+	defer codexIdentityFingerprintSelectionCache.Unlock()
+	if len(codexIdentityFingerprintSelectionCache.refreshing) != 0 {
+		t.Fatal("disabled fingerprint started a refresh")
+	}
+}
+
+func resetIdentityFingerprintRuntimeStateForTest() {
+	runtimeIdentityFingerprintCache.Lock()
+	runtimeIdentityFingerprintCache.records = map[string]identityFingerprintCacheEntry{}
+	runtimeIdentityFingerprintCache.Unlock()
+
+	runtimeIdentityFingerprintAsync.Lock()
+	runtimeIdentityFingerprintAsync.loads = map[string]struct{}{}
+	runtimeIdentityFingerprintAsync.persists = map[string]struct{}{}
+	runtimeIdentityFingerprintAsync.Unlock()
+
+	codexIdentityFingerprintSelectionCache.Lock()
+	codexIdentityFingerprintSelectionCache.entries = map[string]codexIdentityFingerprintSelectionEntry{}
+	codexIdentityFingerprintSelectionCache.refreshing = map[string]struct{}{}
+	codexIdentityFingerprintSelectionCache.states = map[string]*codexIdentityFingerprintRefreshState{}
+	codexIdentityFingerprintSelectionCache.Unlock()
+
+	runtimeIdentityFingerprintStoreFuncMu.Lock()
+	runtimeGetIdentityFingerprint = usage.GetIdentityFingerprint
+	runtimeObserveIdentityFingerprint = usage.ObserveIdentityFingerprint
+	runtimeListCodexIdentityFingerprintProfiles = usage.ListIdentityFingerprintProfiles
+	runtimeGetCodexIdentityFingerprintAccountPolicy = usage.GetIdentityFingerprintAccountPolicy
+	runtimeIdentityFingerprintStoreFuncMu.Unlock()
+}

--- a/internal/runtime/executor/codex_identity_fingerprint.go
+++ b/internal/runtime/executor/codex_identity_fingerprint.go
@@ -46,13 +46,20 @@ type codexIdentityFingerprintSelectionEntry struct {
 	expiresAt time.Time
 }
 
+type codexIdentityFingerprintRefreshState struct {
+	revision uint64
+	learning int
+}
+
 var codexIdentityFingerprintSelectionCache = struct {
 	sync.Mutex
 	entries    map[string]codexIdentityFingerprintSelectionEntry
 	refreshing map[string]struct{}
+	states     map[string]*codexIdentityFingerprintRefreshState
 }{
 	entries:    map[string]codexIdentityFingerprintSelectionEntry{},
 	refreshing: map[string]struct{}{},
+	states:     map[string]*codexIdentityFingerprintRefreshState{},
 }
 
 func init() {
@@ -94,7 +101,18 @@ func codexIdentityFingerprint(cfg *config.Config, auth *cliproxyauth.Auth, ctx c
 	}
 	scheduleCodexIdentityFingerprintSelectionRefresh(accountKey)
 	selection := codexIdentityFingerprintSelectionFromRuntimeCache(accountKey, observed)
-	setCachedCodexIdentityFingerprintSelection(accountKey, selection)
+	// A store refresh may have completed while we assembled the provisional
+	// profile. Never overwrite its explicit account policy with default policy.
+	codexIdentityFingerprintSelectionCache.Lock()
+	if entry, exists := codexIdentityFingerprintSelectionCache.entries[accountKey]; exists {
+		selection = cloneCodexIdentityFingerprintSelection(entry.selection)
+	} else {
+		codexIdentityFingerprintSelectionCache.entries[accountKey] = codexIdentityFingerprintSelectionEntry{
+			selection: cloneCodexIdentityFingerprintSelection(selection),
+			expiresAt: time.Now().Add(codexIdentityFingerprintSelectionCacheTTL),
+		}
+	}
+	codexIdentityFingerprintSelectionCache.Unlock()
 	if selection.Profile != nil {
 		resolved, _ := identityfingerprint.ResolveCodexProfile(cfg.IdentityFingerprint.Codex, selection.Profile)
 		return resolved, true
@@ -144,6 +162,7 @@ func invalidateCachedCodexIdentityFingerprintSelection(accountKey string) {
 	}
 	now := time.Now().Add(-time.Second)
 	codexIdentityFingerprintSelectionCache.Lock()
+	codexIdentityFingerprintRefreshStateLocked(accountKey).revision++
 	if entry, ok := codexIdentityFingerprintSelectionCache.entries[accountKey]; ok {
 		entry.expiresAt = now
 		codexIdentityFingerprintSelectionCache.entries[accountKey] = entry
@@ -163,13 +182,25 @@ func scheduleCodexIdentityFingerprintSelectionRefresh(accountKey string) {
 		return
 	}
 	codexIdentityFingerprintSelectionCache.refreshing[accountKey] = struct{}{}
+	state := codexIdentityFingerprintRefreshStateLocked(accountKey)
+	revision := state.revision
+	learning := state.learning
 	codexIdentityFingerprintSelectionCache.Unlock()
 
 	go func() {
 		defer func() {
 			codexIdentityFingerprintSelectionCache.Lock()
-			delete(codexIdentityFingerprintSelectionCache.refreshing, accountKey)
+			current := codexIdentityFingerprintSelectionCache.states[accountKey] == state
+			if current {
+				delete(codexIdentityFingerprintSelectionCache.refreshing, accountKey)
+			}
+			// Invalidation during a read cannot be dropped by single-flight
+			// suppression. Learning completion schedules its own refresh.
+			retry := current && state.revision != revision && state.learning == 0
 			codexIdentityFingerprintSelectionCache.Unlock()
+			if retry {
+				scheduleCodexIdentityFingerprintSelectionRefresh(accountKey)
+			}
 		}()
 		profiles, err := callRuntimeListCodexIdentityFingerprintProfiles(identityfingerprint.ProviderCodex, accountKey)
 		if err != nil {
@@ -181,8 +212,49 @@ func scheduleCodexIdentityFingerprintSelectionRefresh(accountKey string) {
 			log.WithError(err).Warn("identity fingerprint: load Codex account policy")
 		}
 		selection := identityfingerprint.SelectCodexProfile(profiles, policy)
-		setCachedCodexIdentityFingerprintSelection(accountKey, selection)
+		codexIdentityFingerprintSelectionCache.Lock()
+		// A snapshot read before learning commits is incomplete, even when it
+		// finishes later. Fresh empty snapshots remain authoritative for deletes.
+		if codexIdentityFingerprintSelectionCache.states[accountKey] == state && state.revision == revision && learning == 0 && state.learning == 0 {
+			codexIdentityFingerprintSelectionCache.entries[accountKey] = codexIdentityFingerprintSelectionEntry{
+				selection: cloneCodexIdentityFingerprintSelection(selection),
+				expiresAt: time.Now().Add(codexIdentityFingerprintSelectionCacheTTL),
+			}
+		}
+		codexIdentityFingerprintSelectionCache.Unlock()
 	}()
+}
+
+// Caller holds the selection-cache mutex.
+func codexIdentityFingerprintRefreshStateLocked(accountKey string) *codexIdentityFingerprintRefreshState {
+	state := codexIdentityFingerprintSelectionCache.states[accountKey]
+	if state == nil {
+		state = &codexIdentityFingerprintRefreshState{}
+		codexIdentityFingerprintSelectionCache.states[accountKey] = state
+	}
+	return state
+}
+
+func beginCodexIdentityFingerprintLearning(provider identityfingerprint.Provider, accountKey string) func() {
+	if provider != identityfingerprint.ProviderCodex {
+		return func() {}
+	}
+	codexIdentityFingerprintSelectionCache.Lock()
+	state := codexIdentityFingerprintRefreshStateLocked(accountKey)
+	state.revision++
+	state.learning++
+	codexIdentityFingerprintSelectionCache.Unlock()
+	return func() {
+		codexIdentityFingerprintSelectionCache.Lock()
+		current := codexIdentityFingerprintSelectionCache.states[accountKey] == state
+		state.learning--
+		state.revision++
+		ready := current && state.learning == 0
+		codexIdentityFingerprintSelectionCache.Unlock()
+		if ready {
+			scheduleCodexIdentityFingerprintSelectionRefresh(accountKey)
+		}
+	}
 }
 
 func codexIdentityFingerprintSelectionFromRuntimeCache(accountKey string, observed *identityfingerprint.LearnedRecord) identityfingerprint.ProfileSelection {

--- a/internal/runtime/executor/identity_fingerprint_runtime.go
+++ b/internal/runtime/executor/identity_fingerprint_runtime.go
@@ -193,10 +193,12 @@ func scheduleRuntimeIdentityFingerprintPersist(input identityfingerprint.LearnIn
 		return
 	}
 	runtimeIdentityFingerprintAsync.persists[key] = struct{}{}
+	finishLearning := beginCodexIdentityFingerprintLearning(provider, accountKey)
 	runtimeIdentityFingerprintAsync.Unlock()
 
 	go func() {
 		defer func() {
+			finishLearning()
 			runtimeIdentityFingerprintAsync.Lock()
 			delete(runtimeIdentityFingerprintAsync.persists, key)
 			runtimeIdentityFingerprintAsync.Unlock()

--- a/internal/runtime/executor/identity_fingerprint_runtime_test.go
+++ b/internal/runtime/executor/identity_fingerprint_runtime_test.go
@@ -37,29 +37,6 @@ func initIdentityFingerprintRuntimeDB(t *testing.T) {
 	})
 }
 
-func resetIdentityFingerprintRuntimeStateForTest() {
-	runtimeIdentityFingerprintCache.Lock()
-	runtimeIdentityFingerprintCache.records = map[string]identityFingerprintCacheEntry{}
-	runtimeIdentityFingerprintCache.Unlock()
-
-	runtimeIdentityFingerprintAsync.Lock()
-	runtimeIdentityFingerprintAsync.loads = map[string]struct{}{}
-	runtimeIdentityFingerprintAsync.persists = map[string]struct{}{}
-	runtimeIdentityFingerprintAsync.Unlock()
-
-	codexIdentityFingerprintSelectionCache.Lock()
-	codexIdentityFingerprintSelectionCache.entries = map[string]codexIdentityFingerprintSelectionEntry{}
-	codexIdentityFingerprintSelectionCache.refreshing = map[string]struct{}{}
-	codexIdentityFingerprintSelectionCache.Unlock()
-
-	runtimeIdentityFingerprintStoreFuncMu.Lock()
-	runtimeGetIdentityFingerprint = usage.GetIdentityFingerprint
-	runtimeObserveIdentityFingerprint = usage.ObserveIdentityFingerprint
-	runtimeListCodexIdentityFingerprintProfiles = usage.ListIdentityFingerprintProfiles
-	runtimeGetCodexIdentityFingerprintAccountPolicy = usage.GetIdentityFingerprintAccountPolicy
-	runtimeIdentityFingerprintStoreFuncMu.Unlock()
-}
-
 func eventually(t *testing.T, timeout time.Duration, check func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)


### PR DESCRIPTION
## 问题与修复

v0.5.1 发布 PR #1010 的完整 CI 暴露既有 Codex 指纹竞态：首次请求已经学到客户端 UA，但异步数据库刷新可能读到持久化前的空结果，随后覆盖较新的内存选择，导致下一请求退回默认 UA。旧刷新还可能吞掉其执行期间收到的删除或策略失效通知。

为每个账户记录刷新版本和未完成的学习持久化数量，只有仍匹配当前版本、且读取期间不存在未完成学习的数据库结果才能更新选择缓存；失效被进行中的刷新抑制时会补刷，学习完成也会主动刷新。新的空结果继续代表已删除记录，不以保留旧 profile 的方式掩盖问题；默认策略初始化也不覆盖已经完成的权威策略读取。

只修改指纹选择缓存与已有持久化任务的生命周期协调，不修改数据库结构和管理员删除的持久化语义。回归使用通道控制顺序，未添加运行时延迟或重试次数补丁。

## 验证

- 永久回归在修复前稳定失败：精确复现默认 `0.149.1` 覆盖新 UA，以及刷新中的策略变更、删除通知无法进展。
- 修复后回归与目标 `-race` 通过，真实头部重放、持久化完成后补刷、权威 active policy、合法空结果和全局关闭均有覆盖。
- `go test ./internal/runtime/executor ./internal/usage -count=1` 通过。

- `./scripts/ci-pr.sh` 完整本地 CI 通过，exit 0。
- 原失败测试与新增时序回归连续 `-count=30` 全通过。
- 架构专项审查未发现高置信度阻断。

边界：本次保证待持久化学习结束后的刷新进展；持续不同指纹学习可能延迟 selection 更新。通用 runtime profile 回写与数据库删除无 tombstone 的既有语义不在本次修改范围。

这是 #994 已合入 dev 后、正式发布门禁中发现的关联运行时问题。修复先进入 dev，再更新 #1010。
