### PR TITLE
feat(quota): anchor the 5h spending window to first billed spend

### DIFF
--- a/internal/quota/period.go
+++ b/internal/quota/period.go
@@ -4,21 +4,28 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"time"
 )
 
 type Period string
 
 const (
+	// PeriodFiveHour 是首次消费锚定的固定窗口，不是滚动窗口：窗口在首笔消费时
+	// 开启，5 小时后整体失效，之后由下一笔消费重新开窗。与上游 Anthropic 的
+	// 5h session window 对齐，也让面板能给出确定的重置时刻。
 	PeriodFiveHour Period = "5h"
 	PeriodDay      Period = "day"
 	PeriodWeek     Period = "week"
 	PeriodMonth    Period = "month"
-	// PeriodLifetime is the account's cumulative spend. It is not a rolling
-	// window: it only resets when an operator explicitly grants a new allowance,
-	// which is why it is deliberately absent from OrderedPeriods (that list drives
-	// the four rolling per-period limits) while still being a resettable period.
+	// PeriodLifetime is the account's cumulative spend. It has no window at all:
+	// it only resets when an operator explicitly grants a new allowance, which is
+	// why it is deliberately absent from OrderedPeriods (that list drives the four
+	// windowed per-period limits) while still being a resettable period.
 	PeriodLifetime Period = "lifetime"
 )
+
+// FiveHourWindowDuration 是 5h 配额窗口的长度，窗口区间为 [start, start+5h)。
+const FiveHourWindowDuration = 5 * time.Hour
 
 var OrderedPeriods = [...]Period{PeriodFiveHour, PeriodDay, PeriodWeek, PeriodMonth}
 
@@ -111,14 +118,22 @@ type PeriodSpending struct {
 	Limit     float64 `json:"limit"`
 	Used      float64 `json:"used"`
 	Remaining float64 `json:"remaining"`
+	// WindowStart / ResetsAt 仅在锚定窗口（当前只有 5h）且窗口已开启时给出，
+	// 供面板显示确定的恢复时刻。日历周期的边界调用方本就能自行推导，不重复下发。
+	WindowStart *time.Time `json:"window_start,omitempty"`
+	ResetsAt    *time.Time `json:"resets_at,omitempty"`
 }
 
+// 已有字段刻意不加 json tag：重置事件表里存有历史快照，改名会让旧记录解析不一致。
 type PeriodSpendingUsage struct {
 	FiveHour float64
 	Day      float64
 	Week     float64
 	Month    float64
 	Lifetime float64
+	// FiveHourWindowStart 是当前 5h 窗口的起点（UTC）；零值表示尚未开窗或窗口已过期，
+	// 此时 FiveHour 恒为 0。
+	FiveHourWindowStart time.Time `json:"five_hour_window_start,omitempty"`
 }
 
 func NormalizeWholeUSD(value float64) (float64, error) {
@@ -256,7 +271,14 @@ func BuildPeriodSpending(limits PeriodSpendingLimits, used PeriodSpendingUsage) 
 		if remaining < 0 {
 			remaining = 0
 		}
-		out = append(out, PeriodSpending{Period: period, Limit: limit, Used: current, Remaining: remaining})
+		entry := PeriodSpending{Period: period, Limit: limit, Used: current, Remaining: remaining}
+		if period == PeriodFiveHour && !used.FiveHourWindowStart.IsZero() {
+			windowStart := used.FiveHourWindowStart.UTC()
+			resetsAt := windowStart.Add(FiveHourWindowDuration)
+			entry.WindowStart = &windowStart
+			entry.ResetsAt = &resetsAt
+		}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/internal/quota/period_test.go
+++ b/internal/quota/period_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"testing"
+	"time"
 )
 
 func TestResolveLegacyDayCompatibilityAndConflict(t *testing.T) {
@@ -27,5 +28,42 @@ func TestNormalizeWholeUSDRejectsInvalidAndCeilsPositive(t *testing.T) {
 	}
 	if got, err := NormalizeWholeUSD(10.01); err != nil || got != 11 {
 		t.Fatalf("NormalizeWholeUSD = %v, %v; want 11,nil", got, err)
+	}
+}
+
+// 固定窗口下 5h 必须给出窗口起止时刻，面板据此显示恢复倒计时；
+// 日历周期不下发，避免调用方误以为它们也由服务端锚定。
+func TestBuildPeriodSpendingExposesFiveHourWindowOnly(t *testing.T) {
+	windowStart := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	limits := PeriodSpendingLimits{FiveHour: 50, Day: 100}
+	items := BuildPeriodSpending(limits, PeriodSpendingUsage{
+		FiveHour: 12, Day: 30, FiveHourWindowStart: windowStart,
+	})
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	five, day := items[0], items[1]
+	if five.Period != PeriodFiveHour || day.Period != PeriodDay {
+		t.Fatalf("unexpected order: %+v", items)
+	}
+	if five.WindowStart == nil || !five.WindowStart.Equal(windowStart) {
+		t.Fatalf("5h window start = %v, want %v", five.WindowStart, windowStart)
+	}
+	if five.ResetsAt == nil || !five.ResetsAt.Equal(windowStart.Add(FiveHourWindowDuration)) {
+		t.Fatalf("5h resets at = %v, want %v", five.ResetsAt, windowStart.Add(FiveHourWindowDuration))
+	}
+	if day.WindowStart != nil || day.ResetsAt != nil {
+		t.Fatalf("calendar period must not carry anchored window: %+v", day)
+	}
+}
+
+// 没有活跃窗口时不能给出重置时刻，否则前端会显示一个并不存在的倒计时。
+func TestBuildPeriodSpendingOmitsWindowWhenNotOpen(t *testing.T) {
+	items := BuildPeriodSpending(PeriodSpendingLimits{FiveHour: 50}, PeriodSpendingUsage{})
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	if items[0].WindowStart != nil || items[0].ResetsAt != nil {
+		t.Fatalf("window must be absent without an anchor: %+v", items[0])
 	}
 }

--- a/internal/usage/period_spending.go
+++ b/internal/usage/period_spending.go
@@ -19,33 +19,69 @@ const (
 	periodSubjectEndUser periodSubject = "end_user_id"
 )
 
+// PeriodWindowKeys 只承载与 subject 无关的日历窗口。5h 窗口的起点是
+// per-subject 的消费锚点（见 period_window_anchor.go），因此这里只保留上界。
 type PeriodWindowKeys struct {
-	FiveHourFrom string
-	FiveHourTo   string
-	Day          string
-	WeekFrom     string
-	MonthFrom    string
-	DayTo        string
+	FiveHourTo string
+	Day        string
+	WeekFrom   string
+	MonthFrom  string
+	DayTo      string
 }
 
 func PeriodWindowKeysAt(now time.Time, loc *time.Location) PeriodWindowKeys {
 	if loc == nil {
 		loc = time.Local
 	}
-	nowMinute := now.UTC().Truncate(time.Minute)
 	localNow := now.In(loc)
 	localMidnight := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, loc)
 	weekdayOffset := (int(localMidnight.Weekday()) + 6) % 7
 	weekStart := localMidnight.AddDate(0, 0, -weekdayOffset)
 	monthStart := time.Date(localNow.Year(), localNow.Month(), 1, 0, 0, 0, 0, loc)
 	return PeriodWindowKeys{
-		FiveHourFrom: nowMinute.Add(-5 * time.Hour).Format("2006-01-02T15:04"),
-		FiveHourTo:   nowMinute.Add(time.Minute).Format("2006-01-02T15:04"),
-		Day:          localDayKeyAtLocation(now, loc),
-		WeekFrom:     localDayKeyAtLocation(weekStart, loc),
-		MonthFrom:    localDayKeyAtLocation(monthStart, loc),
-		DayTo:        localDayKeyAtLocation(localMidnight.AddDate(0, 0, 1), loc),
+		// 上界取下一分钟，保证当前这一分钟的消费桶被计入。
+		FiveHourTo: quotaMinuteKey(now.Add(time.Minute)),
+		Day:        localDayKeyAtLocation(now, loc),
+		WeekFrom:   localDayKeyAtLocation(weekStart, loc),
+		MonthFrom:  localDayKeyAtLocation(monthStart, loc),
+		DayTo:      localDayKeyAtLocation(localMidnight.AddDate(0, 0, 1), loc),
 	}
+}
+
+// subjectPeriodWindows 把日历窗口与 per-subject 的 5h 锚点合并成一份窗口视图，
+// 让用量查询和重置基线校验共用同一套窗口标识，避免两处各算一次导致漂移。
+type subjectPeriodWindows struct {
+	keys            PeriodWindowKeys
+	fiveHourAnchors map[string]string
+}
+
+// windowKey 返回某个 subject 在指定周期下的窗口标识；空串表示当前没有有效窗口
+// （5h 从未开窗或已过期），此时该周期的重置基线一律失效。
+func (w subjectPeriodWindows) windowKey(subjectID string, period quota.Period) string {
+	switch period {
+	case quota.PeriodFiveHour:
+		return w.fiveHourAnchors[subjectID]
+	case quota.PeriodDay:
+		return w.keys.Day
+	case quota.PeriodWeek:
+		return w.keys.WeekFrom
+	case quota.PeriodMonth:
+		return w.keys.MonthFrom
+	case quota.PeriodLifetime:
+		// 累计消费没有窗口可滚动，基线在下次授予前一直有效。常量键让通用的
+		// 「是否同一窗口」校验对该周期恒成立。
+		return lifetimeWindowKey
+	default:
+		return ""
+	}
+}
+
+func loadSubjectPeriodWindows(tenantID string, subject periodSubject, ids []string, now time.Time) (subjectPeriodWindows, error) {
+	anchors, err := listActiveFiveHourAnchors(tenantID, subject, ids, now)
+	if err != nil {
+		return subjectPeriodWindows{}, err
+	}
+	return subjectPeriodWindows{keys: PeriodWindowKeysAt(now, getUsageLocation()), fiveHourAnchors: anchors}, nil
 }
 
 func QueryPeriodSpendingByAPIKeyIDForTenant(tenantID, apiKeyID string) (quota.PeriodSpendingUsage, error) {
@@ -80,7 +116,10 @@ func QueryPeriodSpendingByEndUsersForTenant(tenantID string, endUserIDs []string
 	return QueryPeriodSpendingByEndUsersForTenantAt(tenantID, endUserIDs, time.Now())
 }
 
-func queryRawPeriodSpendingForSubjects(tenantID string, subject periodSubject, ids []string, now time.Time) (map[string]quota.PeriodSpendingUsage, error) {
+// subjectChunkSize 限制单条 IN 列表的主体数量，避免撑爆驱动的参数上限。
+const subjectChunkSize = 300
+
+func queryRawPeriodSpendingForSubjects(tenantID string, subject periodSubject, ids []string, now time.Time, windows subjectPeriodWindows) (map[string]quota.PeriodSpendingUsage, error) {
 	ids = dedupeExactStrings(ids)
 	out := make(map[string]quota.PeriodSpendingUsage, len(ids))
 	for _, id := range ids {
@@ -91,7 +130,6 @@ func queryRawPeriodSpendingForSubjects(tenantID string, subject periodSubject, i
 	if len(out) == 0 {
 		return out, nil
 	}
-	const subjectChunkSize = 300
 	if len(out) > subjectChunkSize {
 		cleanIDs := make([]string, 0, len(out))
 		for id := range out {
@@ -103,7 +141,7 @@ func queryRawPeriodSpendingForSubjects(tenantID string, subject periodSubject, i
 			if end > len(cleanIDs) {
 				end = len(cleanIDs)
 			}
-			part, err := queryRawPeriodSpendingForSubjects(tenantID, subject, cleanIDs[start:end], now)
+			part, err := queryRawPeriodSpendingForSubjects(tenantID, subject, cleanIDs[start:end], now, windows)
 			if err != nil {
 				return nil, err
 			}
@@ -117,17 +155,15 @@ func queryRawPeriodSpendingForSubjects(tenantID string, subject periodSubject, i
 	for id := range out {
 		ids = append(ids, id)
 	}
-	windows := PeriodWindowKeysAt(now, getUsageLocation())
 	queries := []struct {
 		kind string
 		from string
 		to   string
 		set  func(*quota.PeriodSpendingUsage, float64)
 	}{
-		{rollupBucketQuotaMinuteUTC, windows.FiveHourFrom, windows.FiveHourTo, func(v *quota.PeriodSpendingUsage, n float64) { v.FiveHour = n }},
-		{rollupBucketDay, windows.Day, windows.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Day = n }},
-		{rollupBucketDay, windows.WeekFrom, windows.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Week = n }},
-		{rollupBucketDay, windows.MonthFrom, windows.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Month = n }},
+		{rollupBucketDay, windows.keys.Day, windows.keys.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Day = n }},
+		{rollupBucketDay, windows.keys.WeekFrom, windows.keys.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Week = n }},
+		{rollupBucketDay, windows.keys.MonthFrom, windows.keys.DayTo, func(v *quota.PeriodSpendingUsage, n float64) { v.Month = n }},
 		{rollupBucketLifetime, "", "", func(v *quota.PeriodSpendingUsage, n float64) { v.Lifetime = n }},
 	}
 	for _, query := range queries {
@@ -141,12 +177,30 @@ func queryRawPeriodSpendingForSubjects(tenantID string, subject periodSubject, i
 			out[id] = current
 		}
 	}
+	// 5h 每个 subject 的窗口起点不同，无法并进上面的统一区间查询。
+	fiveHour, err := queryFiveHourCostByAnchors(tenantID, subject, ids, windows)
+	if err != nil {
+		return nil, err
+	}
+	for id, current := range out {
+		if anchor, ok := windows.fiveHourAnchors[id]; ok {
+			if windowStart, parsed := parseQuotaMinuteKey(anchor); parsed {
+				current.FiveHourWindowStart = windowStart
+			}
+		}
+		current.FiveHour = fiveHour[id]
+		out[id] = current
+	}
 
 	return out, nil
 }
 
 func queryPeriodSpendingForSubjects(tenantID string, subject periodSubject, ids []string, now time.Time) (map[string]quota.PeriodSpendingUsage, error) {
-	out, err := queryRawPeriodSpendingForSubjects(tenantID, subject, ids, now)
+	windows, err := loadSubjectPeriodWindows(tenantID, subject, dedupeExactStrings(ids), now)
+	if err != nil {
+		return nil, err
+	}
+	out, err := queryRawPeriodSpendingForSubjects(tenantID, subject, ids, now, windows)
 	if err != nil || len(out) == 0 {
 		return out, err
 	}
@@ -154,7 +208,6 @@ func queryPeriodSpendingForSubjects(tenantID string, subject periodSubject, ids 
 	for id := range out {
 		cleanIDs = append(cleanIDs, id)
 	}
-	windows := PeriodWindowKeysAt(now, getUsageLocation())
 	baselines, err := listEffectivePeriodBaselines(tenantID, subject, cleanIDs, windows)
 	if err != nil {
 		return nil, fmt.Errorf("%w: period baselines: %v", ErrQuotaUsageUnavailable, err)
@@ -169,7 +222,7 @@ func queryPeriodSpendingForSubjects(tenantID string, subject periodSubject, ids 
 	return out, nil
 }
 
-func listEffectivePeriodBaselines(tenantID string, subject periodSubject, ids []string, windows PeriodWindowKeys) (map[string]map[quota.Period]float64, error) {
+func listEffectivePeriodBaselines(tenantID string, subject periodSubject, ids []string, windows subjectPeriodWindows) (map[string]map[quota.Period]float64, error) {
 	const baselineChunkSize = 300
 	if len(ids) > baselineChunkSize {
 		combined := make(map[string]map[quota.Period]float64)
@@ -194,9 +247,9 @@ func listEffectivePeriodBaselines(tenantID string, subject periodSubject, ids []
 	}
 	var legacy map[string]float64
 	if subject == periodSubjectAPIKey {
-		legacy, err = listDailySpendingResetBaselinesAt(tenantID, ids, windows.Day)
+		legacy, err = listDailySpendingResetBaselinesAt(tenantID, ids, windows.keys.Day)
 	} else {
-		legacy, err = listEndUserDailySpendingResetBaselines(tenantID, ids, windows.Day)
+		legacy, err = listEndUserDailySpendingResetBaselines(tenantID, ids, windows.keys.Day)
 	}
 	if err != nil {
 		return nil, err
@@ -253,6 +306,60 @@ func queryGroupedPeriodCost(tenantID string, subject periodSubject, ids []string
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("%w: rows %s %s: %v", ErrQuotaUsageUnavailable, subject, kind, err)
+	}
+	return out, nil
+}
+
+// queryFiveHourCostByAnchors 按每个 subject 各自的窗口起点求和。起点不同导致无法
+// 共用一个区间条件，因此把 (subject, anchor) 展开成 OR 组合塞进同一条查询：既保持
+// 单次往返，也让 (tenant_id, bucket_kind, <subject>, bucket_start) 索引仍然可用。
+// 没有活跃窗口的 subject 不参与查询，其用量按 0 处理。
+func queryFiveHourCostByAnchors(tenantID string, subject periodSubject, ids []string, windows subjectPeriodWindows) (map[string]float64, error) {
+	out := make(map[string]float64, len(ids))
+	pairs := make([][2]string, 0, len(ids))
+	for _, id := range ids {
+		if anchor := windows.fiveHourAnchors[id]; anchor != "" {
+			pairs = append(pairs, [2]string{id, anchor})
+		}
+	}
+	if len(pairs) == 0 {
+		return out, nil
+	}
+	column := string(subject)
+	if subject != periodSubjectAPIKey && subject != periodSubjectEndUser {
+		return nil, fmt.Errorf("%w: invalid subject", ErrQuotaUsageUnavailable)
+	}
+	db := getReadDB()
+	if db == nil {
+		return nil, ErrQuotaUsageUnavailable
+	}
+	var b strings.Builder
+	b.WriteString(`SELECT ` + column + `, COALESCE(SUM(cost_total), 0) FROM usage_rollup_buckets WHERE tenant_id = ? AND bucket_kind = ? AND bucket_start < ? AND (`)
+	args := make([]any, 0, len(pairs)*2+3)
+	args = append(args, normalizeTenantID(tenantID), rollupBucketQuotaMinuteUTC, windows.keys.FiveHourTo)
+	for i, pair := range pairs {
+		if i > 0 {
+			b.WriteString(` OR `)
+		}
+		b.WriteString(`(` + column + ` = ? AND bucket_start >= ?)`)
+		args = append(args, pair[0], pair[1])
+	}
+	b.WriteString(`) GROUP BY ` + column)
+	rows, err := db.Query(b.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("%w: query %s 5h: %v", ErrQuotaUsageUnavailable, subject, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var value float64
+		if err := rows.Scan(&id, &value); err != nil {
+			return nil, fmt.Errorf("%w: scan %s 5h: %v", ErrQuotaUsageUnavailable, subject, err)
+		}
+		out[id] = value
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("%w: rows %s 5h: %v", ErrQuotaUsageUnavailable, subject, err)
 	}
 	return out, nil
 }

--- a/internal/usage/period_spending_reset.go
+++ b/internal/usage/period_spending_reset.go
@@ -61,7 +61,7 @@ func bootstrapPeriodSpendingResets(db *sql.DB) error {
 	if _, err := db.Exec(periodSpendingResetEventsTableSQL); err != nil {
 		return fmt.Errorf("usage: ensure period_spending_reset_events: %w", err)
 	}
-	return nil
+	return ensurePeriodWindowAnchors(db)
 }
 
 type PeriodSpendingResetResult struct {
@@ -109,26 +109,6 @@ func periodResetSubjectType(subject periodSubject) (string, error) {
 // lifetimeWindowKey is the constant window key stored for cumulative-spend resets.
 const lifetimeWindowKey = "lifetime"
 
-func periodWindowKey(period quota.Period, windows PeriodWindowKeys) string {
-	switch period {
-	case quota.PeriodFiveHour:
-		return windows.FiveHourFrom
-	case quota.PeriodDay:
-		return windows.Day
-	case quota.PeriodWeek:
-		return windows.WeekFrom
-	case quota.PeriodMonth:
-		return windows.MonthFrom
-	case quota.PeriodLifetime:
-		// Cumulative spend has no window to roll over, so its baseline stays in
-		// force until the next grant. A constant key makes the generic
-		// "same window?" validity check always hold for this period.
-		return lifetimeWindowKey
-	default:
-		return ""
-	}
-}
-
 func setPeriodUsageValue(used *quota.PeriodSpendingUsage, period quota.Period, value float64) {
 	if value < 0 {
 		value = 0
@@ -151,7 +131,7 @@ func applyPeriodBaseline(used *quota.PeriodSpendingUsage, period quota.Period, b
 	setPeriodUsageValue(used, period, used.Value(period)-baseline)
 }
 
-func listPeriodSpendingResetBaselines(tenantID string, subject periodSubject, ids []string, windows PeriodWindowKeys) (map[string]map[quota.Period]float64, error) {
+func listPeriodSpendingResetBaselines(tenantID string, subject periodSubject, ids []string, windows subjectPeriodWindows) (map[string]map[quota.Period]float64, error) {
 	out := make(map[string]map[quota.Period]float64)
 	if len(ids) == 0 {
 		return out, nil
@@ -183,7 +163,10 @@ func listPeriodSpendingResetBaselines(tenantID string, subject periodSubject, id
 			return nil, err
 		}
 		period := quota.Period(rawPeriod)
-		if periodWindowKey(period, windows) == "" || strings.TrimSpace(windowKey) != periodWindowKey(period, windows) {
+		// 窗口标识不一致说明基线属于已经翻篇的窗口，直接作废。5h 的标识是该
+		// subject 的消费锚点，窗口内保持不变，跨窗口才失效。
+		expected := windows.windowKey(id, period)
+		if expected == "" || strings.TrimSpace(windowKey) != expected {
 			continue
 		}
 		if out[id] == nil {
@@ -204,12 +187,15 @@ func resetPeriodSpendingForSubject(tenantID string, subject periodSubject, subje
 		return PeriodSpendingResetResult{}, fmt.Errorf("usage: subject_id is required")
 	}
 	tenantID = normalizeTenantID(tenantID)
-	rawByID, err := queryRawPeriodSpendingForSubjects(tenantID, subject, []string{subjectID}, now)
+	windows, err := loadSubjectPeriodWindows(tenantID, subject, []string{subjectID}, now)
+	if err != nil {
+		return PeriodSpendingResetResult{}, err
+	}
+	rawByID, err := queryRawPeriodSpendingForSubjects(tenantID, subject, []string{subjectID}, now, windows)
 	if err != nil {
 		return PeriodSpendingResetResult{}, err
 	}
 	raw := rawByID[subjectID]
-	windows := PeriodWindowKeysAt(now, getUsageLocation())
 	baselinesByID, err := listEffectivePeriodBaselines(tenantID, subject, []string{subjectID}, windows)
 	if err != nil {
 		return PeriodSpendingResetResult{}, fmt.Errorf("%w: period baselines: %v", ErrQuotaUsageUnavailable, err)
@@ -236,7 +222,7 @@ func resetPeriodSpendingForSubject(tenantID string, subject periodSubject, subje
 	defer func() { _ = tx.Rollback() }()
 	resetAt := now.UTC().Format(time.RFC3339Nano)
 	for _, period := range periods {
-		windowKey := periodWindowKey(period, windows)
+		windowKey := windows.windowKey(subjectID, period)
 		baseline := raw.Value(period)
 		if _, err := tx.Exec(`
 			INSERT INTO period_spending_resets

--- a/internal/usage/period_spending_test.go
+++ b/internal/usage/period_spending_test.go
@@ -15,8 +15,9 @@ func TestPeriodWindowKeysAtUsesProjectTimezoneMondayWeek(t *testing.T) {
 	if got.WeekFrom != "2026-07-20" || got.MonthFrom != "2026-07-01" || got.DayTo != "2026-07-23" {
 		t.Fatalf("windows = %+v, want Monday 2026-07-20, month 2026-07-01, tomorrow 2026-07-23", got)
 	}
-	if got.FiveHourFrom != "2026-07-22T07:30" || got.FiveHourTo != "2026-07-22T12:31" {
-		t.Fatalf("5h windows = [%s,%s), want [2026-07-22T07:30,2026-07-22T12:31)", got.FiveHourFrom, got.FiveHourTo)
+	// 5h 的下界是 per-subject 锚点，这里只校验「含当前分钟」的上界。
+	if got.FiveHourTo != "2026-07-22T12:31" {
+		t.Fatalf("5h upper bound = %q, want 2026-07-22T12:31", got.FiveHourTo)
 	}
 }
 
@@ -36,20 +37,34 @@ func TestQueryPeriodSpendingWeekAndFiveHourBoundaries(t *testing.T) {
 	insert(rollupBucketDay, "2026-07-19", 100) // previous Sunday: excluded from week
 	insert(rollupBucketDay, "2026-07-20", 10)  // Monday inclusive
 	insert(rollupBucketDay, "2026-07-22", 5)
-	insert(rollupBucketDay, "2026-07-23", 20) // tomorrow exclusive
-	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T07:29", 100)
-	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T07:30", 3)   // cutoff minute included
+	insert(rollupBucketDay, "2026-07-23", 20)                   // tomorrow exclusive
+	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T07:59", 100) // before window start
+	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T08:00", 3)   // window start included
 	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T12:30", 4)   // current minute included
 	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T12:31", 100) // exclusive upper bound
 	insert(rollupBucketLifetime, rollupLifetimeStart, 999)
 
+	// 没有锚点就没有活跃窗口，5h 用量按 0 计，其余周期照常。
 	got, err := QueryPeriodSpendingByAPIKeyIDsForTenantAt(systemTenantID, []string{keyID}, now)
+	if err != nil {
+		t.Fatalf("QueryPeriodSpending: %v", err)
+	}
+	if used := got[keyID]; used.FiveHour != 0 || !used.FiveHourWindowStart.IsZero() {
+		t.Fatalf("without anchor used = %+v, want 5h=0 and zero window start", used)
+	}
+
+	// 窗口 [08:00,13:00) 仍在有效期内，只统计窗口内到当前分钟为止的消费。
+	seedFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, keyID, "2026-07-22T08:00")
+	got, err = QueryPeriodSpendingByAPIKeyIDsForTenantAt(systemTenantID, []string{keyID}, now)
 	if err != nil {
 		t.Fatalf("QueryPeriodSpending: %v", err)
 	}
 	used := got[keyID]
 	if used.FiveHour != 7 || used.Day != 5 || used.Week != 15 || used.Month != 115 || used.Lifetime != 999 {
 		t.Fatalf("used = %+v, want 5h=7 day=5 week=15 month=115 lifetime=999", used)
+	}
+	if want := time.Date(2026, 7, 22, 8, 0, 0, 0, time.UTC); !used.FiveHourWindowStart.Equal(want) {
+		t.Fatalf("window start = %v, want %v", used.FiveHourWindowStart, want)
 	}
 }
 
@@ -104,6 +119,8 @@ func TestPeriodSpendingResetWeekOnlyAndMultiplePeriods(t *testing.T) {
 	insert(rollupBucketDay, "2026-07-20", "monday", 10)
 	insert(rollupBucketDay, "2026-07-22", "today", 5)
 	insert(rollupBucketQuotaMinuteUTC, "2026-07-22T12:30", "minute", 7)
+	// 5h 需要活跃窗口才有用量，窗口 [12:00,17:00) 覆盖上面这一分钟。
+	seedFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, keyID, "2026-07-22T12:00")
 
 	reset, err := resetPeriodSpendingForSubject(systemTenantID, periodSubjectAPIKey, keyID, []quota.Period{quota.PeriodWeek}, PeriodSpendingResetActor{Kind: "test"}, now)
 	if err != nil {

--- a/internal/usage/period_window_anchor.go
+++ b/internal/usage/period_window_anchor.go
@@ -1,0 +1,145 @@
+package usage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+)
+
+// 5 小时配额窗口是「首次消费锚定的固定窗口」，不是滚动窗口：
+// 窗口区间为 [window_start, window_start+5h)，窗口内用量累计，窗口过期后
+// 由下一笔实际消费开启新窗口（间隔期不计时）。这与上游 Anthropic 的
+// 5h session window 语义一致，也让面板能给出确定的重置时刻；滚动窗口
+// 做不到这一点，用户被限流后无法知道何时恢复。
+//
+// day/week/month 仍然是日历对齐的固定窗口，锚点机制只服务 5h。
+// 与 usage_rollup_buckets 的 quota_minute_utc 桶键同格式，锚点可直接参与
+// bucket_start 的字符串比较，无需转换。固定宽度保证字典序等于时间序。
+const quotaMinuteKeyLayout = "2006-01-02T15:04"
+
+const periodWindowAnchorsTableSQL = `
+CREATE TABLE IF NOT EXISTS period_window_anchors (
+  tenant_id     TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001',
+  subject_type  TEXT NOT NULL,
+  subject_id    TEXT NOT NULL,
+  period        TEXT NOT NULL,
+  window_start  TEXT NOT NULL,
+  updated_at    TIMESTAMP NOT NULL,
+  PRIMARY KEY (tenant_id, subject_type, subject_id, period)
+);
+`
+
+func ensurePeriodWindowAnchors(db *sql.DB) error {
+	if db == nil {
+		return nil
+	}
+	if _, err := db.Exec(periodWindowAnchorsTableSQL); err != nil {
+		return fmt.Errorf("usage: ensure period_window_anchors: %w", err)
+	}
+	return nil
+}
+
+// quotaMinuteKey 把时刻截断到 UTC 分钟，得到与消费桶对齐的窗口键。
+func quotaMinuteKey(at time.Time) string {
+	return at.UTC().Truncate(time.Minute).Format(quotaMinuteKeyLayout)
+}
+
+// fiveHourExpiryThreshold 返回「锚点早于等于该键即视为窗口已过期」的边界。
+// 窗口 [anchor, anchor+5h) 过期等价于 now >= anchor+5h，即 anchor <= now-5h。
+func fiveHourExpiryThreshold(now time.Time) string {
+	return quotaMinuteKey(now.Add(-quota.FiveHourWindowDuration))
+}
+
+// touchFiveHourWindowAnchorTx 在首次消费时开窗，窗口未过期则保持原锚点不动。
+// 条件 UPDATE 让并发落账天然幂等：同一窗口内的后续消费不会推移窗口起点。
+func touchFiveHourWindowAnchorTx(tx *sql.Tx, tenantID, subjectType, subjectID string, at time.Time) error {
+	subjectID = strings.TrimSpace(subjectID)
+	if tx == nil || subjectID == "" {
+		return nil
+	}
+	windowStart := quotaMinuteKey(at)
+	_, err := tx.Exec(`
+		INSERT INTO period_window_anchors
+		 (tenant_id, subject_type, subject_id, period, window_start, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT (tenant_id, subject_type, subject_id, period) DO UPDATE SET
+		  window_start = excluded.window_start,
+		  updated_at = excluded.updated_at
+		 WHERE period_window_anchors.window_start <= ?
+	`, normalizeTenantID(tenantID), subjectType, subjectID, string(quota.PeriodFiveHour),
+		windowStart, at.UTC().Format(time.RFC3339Nano), fiveHourExpiryThreshold(at))
+	if err != nil {
+		return fmt.Errorf("usage: upsert 5h window anchor: %w", err)
+	}
+	return nil
+}
+
+// listActiveFiveHourAnchors 返回仍在有效期内的窗口起点；已过期或从未开窗的
+// subject 不会出现在结果里，调用方据此把 5h 用量视为 0。
+func listActiveFiveHourAnchors(tenantID string, subject periodSubject, ids []string, now time.Time) (map[string]string, error) {
+	out := make(map[string]string, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	// 与用量查询用同一个分片大小，避免 IN 列表撑爆驱动的参数上限。
+	if len(ids) > subjectChunkSize {
+		for start := 0; start < len(ids); start += subjectChunkSize {
+			end := start + subjectChunkSize
+			if end > len(ids) {
+				end = len(ids)
+			}
+			part, err := listActiveFiveHourAnchors(tenantID, subject, ids[start:end], now)
+			if err != nil {
+				return nil, err
+			}
+			for id, anchor := range part {
+				out[id] = anchor
+			}
+		}
+		return out, nil
+	}
+	db := getReadDB()
+	if db == nil {
+		return nil, ErrQuotaUsageUnavailable
+	}
+	subjectType, err := periodResetSubjectType(subject)
+	if err != nil {
+		return nil, err
+	}
+	query := `SELECT subject_id, window_start FROM period_window_anchors
+		WHERE tenant_id = ? AND subject_type = ? AND period = ? AND window_start > ?
+		  AND subject_id IN (` + placeholders(len(ids)) + `)`
+	args := make([]any, 0, len(ids)+4)
+	args = append(args, normalizeTenantID(tenantID), subjectType, string(quota.PeriodFiveHour), fiveHourExpiryThreshold(now))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("%w: query 5h anchors: %v", ErrQuotaUsageUnavailable, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, windowStart string
+		if err := rows.Scan(&id, &windowStart); err != nil {
+			return nil, fmt.Errorf("%w: scan 5h anchor: %v", ErrQuotaUsageUnavailable, err)
+		}
+		out[id] = windowStart
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("%w: rows 5h anchors: %v", ErrQuotaUsageUnavailable, err)
+	}
+	return out, nil
+}
+
+// parseQuotaMinuteKey 把窗口键还原成时刻，用于对外暴露窗口起止时间。
+func parseQuotaMinuteKey(key string) (time.Time, bool) {
+	parsed, err := time.ParseInLocation(quotaMinuteKeyLayout, strings.TrimSpace(key), time.UTC)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}

--- a/internal/usage/period_window_anchor_test.go
+++ b/internal/usage/period_window_anchor_test.go
@@ -1,0 +1,236 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
+)
+
+func seedFiveHourAnchor(t *testing.T, tenantID, subjectType, subjectID, windowStart string) {
+	t.Helper()
+	db := getDB()
+	if db == nil {
+		t.Fatal("usage db not initialised")
+	}
+	if _, err := db.Exec(`INSERT INTO period_window_anchors
+		(tenant_id, subject_type, subject_id, period, window_start, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT (tenant_id, subject_type, subject_id, period) DO UPDATE SET
+		 window_start = excluded.window_start`,
+		tenantID, subjectType, subjectID, string(quota.PeriodFiveHour), windowStart,
+		time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("seed 5h anchor: %v", err)
+	}
+}
+
+func readFiveHourAnchor(t *testing.T, tenantID, subjectType, subjectID string) string {
+	t.Helper()
+	var windowStart string
+	err := getDB().QueryRow(`SELECT window_start FROM period_window_anchors
+		WHERE tenant_id = ? AND subject_type = ? AND subject_id = ? AND period = ?`,
+		tenantID, subjectType, subjectID, string(quota.PeriodFiveHour)).Scan(&windowStart)
+	if err != nil {
+		return ""
+	}
+	return windowStart
+}
+
+func recordBilledUsage(t *testing.T, tenantID, apiKeyID, endUserID string, cost float64, at time.Time) {
+	t.Helper()
+	tx, err := getDB().Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := commitLogWithProjections(tx, rollupEvent{
+		TenantID: tenantID, APIKeyID: apiKeyID, EndUserID: endUserID,
+		Model: "test-model", Cost: cost, At: at,
+	}); err != nil {
+		t.Fatalf("commit usage: %v", err)
+	}
+}
+
+// 首笔计费消费开窗；同一窗口内的后续消费不得推移窗口起点，否则窗口会被
+// 持续续期，退化成永不结束的滚动窗口。
+func TestFiveHourWindowAnchorOpensOnFirstBilledSpendAndHolds(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	keyID := "anchor-key"
+	first := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+
+	recordBilledUsage(t, systemTenantID, keyID, "", 1, first)
+	if got := readFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, keyID); got != "2026-07-22T12:00" {
+		t.Fatalf("anchor after first spend = %q, want 2026-07-22T12:00", got)
+	}
+
+	recordBilledUsage(t, systemTenantID, keyID, "", 1, first.Add(3*time.Hour))
+	if got := readFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, keyID); got != "2026-07-22T12:00" {
+		t.Fatalf("anchor after in-window spend = %q, want it to stay at 2026-07-22T12:00", got)
+	}
+}
+
+// 窗口过期后由下一笔消费重新开窗（间隔期不计时）。
+func TestFiveHourWindowAnchorReopensAfterExpiry(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	keyID := "reopen-key"
+	first := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+
+	recordBilledUsage(t, systemTenantID, keyID, "", 1, first)
+	// 恰好 5 小时后窗口已过期，属于新窗口的第一笔消费。
+	recordBilledUsage(t, systemTenantID, keyID, "", 1, first.Add(5*time.Hour))
+	if got := readFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, keyID); got != "2026-07-22T17:00" {
+		t.Fatalf("anchor after expiry = %q, want 2026-07-22T17:00", got)
+	}
+}
+
+// 5h 是美元额度，零成本请求不应提前吃掉窗口。
+func TestFiveHourWindowAnchorIgnoresZeroCostRequests(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	keyID := "free-key"
+	at := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+
+	recordBilledUsage(t, systemTenantID, keyID, "", 0, at)
+	if got := readFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, keyID); got != "" {
+		t.Fatalf("anchor after free request = %q, want none", got)
+	}
+
+	recordBilledUsage(t, systemTenantID, keyID, "", 0.5, at.Add(time.Minute))
+	if got := readFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, keyID); got != "2026-07-22T12:01" {
+		t.Fatalf("anchor after billed request = %q, want 2026-07-22T12:01", got)
+	}
+}
+
+// 账号（end_user）与 Key 各自独立开窗。
+func TestFiveHourWindowAnchorTracksKeyAndAccountSeparately(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	keyID, userID := "dual-key", "dual-user"
+	at := time.Date(2026, 7, 22, 9, 15, 0, 0, time.UTC)
+
+	recordBilledUsage(t, systemTenantID, keyID, userID, 2, at)
+	if got := readFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, keyID); got != "2026-07-22T09:15" {
+		t.Fatalf("key anchor = %q", got)
+	}
+	if got := readFiveHourAnchor(t, systemTenantID, periodResetSubjectEndUser, userID); got != "2026-07-22T09:15" {
+		t.Fatalf("account anchor = %q", got)
+	}
+}
+
+// 固定窗口的核心行为：窗口一到期，用量整体归零，而不是逐分钟滑出。
+func TestFiveHourUsageResetsWhenWindowExpires(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	keyID := "expiry-key"
+	windowStart := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+
+	recordBilledUsage(t, systemTenantID, keyID, "", 30, windowStart)
+	recordBilledUsage(t, systemTenantID, keyID, "", 12, windowStart.Add(2*time.Hour))
+
+	at := func(d time.Duration) quota.PeriodSpendingUsage {
+		t.Helper()
+		got, err := QueryPeriodSpendingByAPIKeyIDsForTenantAt(systemTenantID, []string{keyID}, windowStart.Add(d))
+		if err != nil {
+			t.Fatalf("query +%v: %v", d, err)
+		}
+		return got[keyID]
+	}
+
+	if used := at(4 * time.Hour); used.FiveHour != 42 {
+		t.Fatalf("in-window used = %v, want 42", used.FiveHour)
+	}
+	// 4h59m 仍在窗口内：滚动窗口在这里会只剩 12，固定窗口必须仍是 42。
+	if used := at(4*time.Hour + 59*time.Minute); used.FiveHour != 42 {
+		t.Fatalf("late-window used = %v, want 42", used.FiveHour)
+	}
+	if used := at(5 * time.Hour); used.FiveHour != 0 || !used.FiveHourWindowStart.IsZero() {
+		t.Fatalf("expired used = %+v, want 0 with no window", used)
+	}
+}
+
+// 回归：5h 重置基线曾以滚动窗口下界作为窗口标识，导致重置在 1 分钟后失效。
+// 锚定窗口内的标识恒定，重置必须在整个窗口内持续有效。
+func TestPeriodSpendingResetFiveHourHoldsForWholeWindow(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	keyID := "5h-reset-key"
+	windowStart := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	resetAt := windowStart.Add(30 * time.Minute)
+
+	recordBilledUsage(t, systemTenantID, keyID, "", 42, windowStart)
+	if _, err := resetPeriodSpendingForSubject(systemTenantID, periodSubjectAPIKey, keyID,
+		[]quota.Period{quota.PeriodFiveHour}, PeriodSpendingResetActor{Kind: "test"}, resetAt); err != nil {
+		t.Fatalf("reset 5h: %v", err)
+	}
+
+	usedAt := func(at time.Time) float64 {
+		t.Helper()
+		got, err := QueryPeriodSpendingByAPIKeyIDsForTenantAt(systemTenantID, []string{keyID}, at)
+		if err != nil {
+			t.Fatalf("query at %v: %v", at, err)
+		}
+		return got[keyID].FiveHour
+	}
+
+	for _, delta := range []time.Duration{0, time.Minute, 10 * time.Minute, 4 * time.Hour} {
+		if got := usedAt(resetAt.Add(delta)); got != 0 {
+			t.Fatalf("used at reset+%v = %v, want 0 (baseline must survive the whole window)", delta, got)
+		}
+	}
+
+	// 重置后新增的消费仍要照常计入当前窗口。
+	recordBilledUsage(t, systemTenantID, keyID, "", 5, resetAt.Add(time.Hour))
+	if got := usedAt(resetAt.Add(2 * time.Hour)); got != 5 {
+		t.Fatalf("post-reset spend = %v, want 5", got)
+	}
+}
+
+// 窗口翻篇后旧基线必须失效，不能继续抵扣新窗口的消费。
+func TestPeriodSpendingResetFiveHourExpiresWithWindow(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	keyID := "5h-reset-expiry-key"
+	windowStart := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+
+	recordBilledUsage(t, systemTenantID, keyID, "", 42, windowStart)
+	if _, err := resetPeriodSpendingForSubject(systemTenantID, periodSubjectAPIKey, keyID,
+		[]quota.Period{quota.PeriodFiveHour}, PeriodSpendingResetActor{Kind: "test"}, windowStart.Add(time.Minute)); err != nil {
+		t.Fatalf("reset 5h: %v", err)
+	}
+
+	// 窗口过期后的新消费开启新窗口，42 的旧基线不应再参与抵扣。
+	next := windowStart.Add(6 * time.Hour)
+	recordBilledUsage(t, systemTenantID, keyID, "", 7, next)
+	got, err := QueryPeriodSpendingByAPIKeyIDsForTenantAt(systemTenantID, []string{keyID}, next.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("query new window: %v", err)
+	}
+	if used := got[keyID]; used.FiveHour != 7 {
+		t.Fatalf("new window used = %v, want 7", used.FiveHour)
+	}
+}
+
+// 批量查询下每个 subject 用自己的窗口起点求和，不能互相串味。
+func TestQueryFiveHourUsesPerSubjectAnchors(t *testing.T) {
+	initTestUsageDB(t, config.RequestLogStorageConfig{})
+	now := time.Date(2026, 7, 22, 14, 0, 0, 0, time.UTC)
+	early, late, stale := "early-key", "late-key", "stale-key"
+
+	// early 的窗口 [10:00,15:00) 覆盖两笔；late 的窗口 [13:00,18:00) 只覆盖第二笔。
+	for _, keyID := range []string{early, late, stale} {
+		recordBilledUsage(t, systemTenantID, keyID, "", 10, time.Date(2026, 7, 22, 11, 0, 0, 0, time.UTC))
+		recordBilledUsage(t, systemTenantID, keyID, "", 4, time.Date(2026, 7, 22, 13, 30, 0, 0, time.UTC))
+	}
+	seedFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, early, "2026-07-22T10:00")
+	seedFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, late, "2026-07-22T13:00")
+	seedFiveHourAnchor(t, systemTenantID, periodResetSubjectAPIKey, stale, "2026-07-22T08:00") // 已过期
+
+	got, err := QueryPeriodSpendingByAPIKeyIDsForTenantAt(systemTenantID, []string{early, late, stale}, now)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got[early].FiveHour != 14 {
+		t.Fatalf("early used = %v, want 14", got[early].FiveHour)
+	}
+	if got[late].FiveHour != 4 {
+		t.Fatalf("late used = %v, want 4", got[late].FiveHour)
+	}
+	if got[stale].FiveHour != 0 {
+		t.Fatalf("stale used = %v, want 0 (window expired)", got[stale].FiveHour)
+	}
+}

--- a/internal/usage/usage_rollup.go
+++ b/internal/usage/usage_rollup.go
@@ -511,10 +511,33 @@ func commitLogWithProjections(tx *sql.Tx, ev rollupEvent) error {
 			return fmt.Errorf("project shared auth subject usage: %w", err)
 		}
 	}
+	// 5h 窗口锚点只在实时落账时推进，不放进 projectUsageRollupTx：后者也服务
+	// 全量重建，重放历史事件会把锚点改写成过去的时刻。锚点是运行时状态，重建
+	// 消费桶时不应被回退。
+	if err := touchFiveHourWindowAnchorsTx(tx, ev); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
 	if err := tx.Commit(); err != nil {
 		return err
 	}
 	return nil
+}
+
+// touchFiveHourWindowAnchorsTx 为本次消费涉及的 Key 与账号各自开窗。只有真正
+// 产生费用的请求才开窗：5h 是美元额度，让零成本请求提前开窗会白白吃掉窗口。
+func touchFiveHourWindowAnchorsTx(tx *sql.Tx, ev rollupEvent) error {
+	if ev.Cost <= 0 {
+		return nil
+	}
+	at := ev.At
+	if at.IsZero() {
+		at = time.Now()
+	}
+	if err := touchFiveHourWindowAnchorTx(tx, ev.TenantID, periodResetSubjectAPIKey, ev.APIKeyID, at); err != nil {
+		return err
+	}
+	return touchFiveHourWindowAnchorTx(tx, ev.TenantID, periodResetSubjectEndUser, ev.EndUserID, at)
 }
 
 // cleanupExpiredUsageRollupBuckets prunes minute/hour/day buckets past retention.


### PR DESCRIPTION
## 背景

客户反馈：「五小时是就是五小时的范围，而不是从首次开始使用往后算五小时」。

定位下来属实。`PeriodWindowKeysAt` 每次都以当前时刻往回数 5 小时去 `quota_minute_utc` 分钟桶求和，是滚动窗口——没有锚点，也没有整窗清零。结果是既给不出确定的恢复时刻（面板做不了倒计时），一次突发消费还会让 Key 在整整五小时里半死不活地卡着。上游 Anthropic 的 5h 是 session window（首条消息开窗、五小时后整窗清零），本 PR 让子配额与之对齐。

顺带修掉一个在定位过程中发现的确定 bug（详见下）。

## 改动

**锚定窗口。** 新增 `period_window_anchors` 表，按 tenant/subject 记录当前 5h 窗口的开启时刻。用量统计区间从 `[now-5h, now]` 改为 `[anchor, now]`，没有活跃窗口的主体报 0。

- 锚点在**首笔计费消费**时落，窗口内不再推移——否则窗口会被持续续期，退化回滚动窗口。
- 零成本请求不开窗：5h 是美元额度，让免费请求提前吃掉窗口没道理。
- 锚点只写实时落账路径，**不写 `projectUsageRollupTx`**。后者同时服务全量重建，重放历史事件会把锚点改写成过去的时刻。
- Key 与账号（end_user）各自独立开窗，与现有两个 scope 对齐。

**批量查询。** 5h 的窗口起点变成 per-subject，无法再共用一个区间条件。按 `(subject, anchor)` 展开成 OR 组合塞进同一条 SQL，保持单次往返，`(tenant_id, bucket_kind, <subject>, bucket_start)` 索引照常可用——管理列表页一次 300 个主体的路径不会退化成 N 次查询。

**顺带修复：手动重置 5h 配额只活 1 分钟。** 重置基线按「这是哪个窗口」来判定有效性，而 5h 过去给的是滚动窗口下界——一个每分钟都在变的值。于是基线几乎立刻失配，被清零的用量原样跳回，管理员点完重置下一分钟 Key 就又被限住了。锚点在窗口内恒定，基线因此一直有效、跨窗口才失效，与 day/week/month 行为一致。校验逻辑本身一行未改。

**暴露窗口边界。** `BuildPeriodSpending` 为 5h 输出 `window_start` / `resets_at`，面板据此显示真实倒计时。日历周期不下发——边界本就可推导，凭空给一个服务端并未锚定的倒计时是误导。

## 上线注意

存量主体在上线后会有一次性放松：所有人的 5h 用量归零，直到各自下一笔消费才重新开窗。这是锚定窗口的必然结果。

## 遗留（已单独跟进，不在本 PR）

`usage.FiveHourQuotaProjectionReady` 仍在拦「分钟桶覆盖不足 5 小时时禁止配置 5h 限额」。这个保护是滚动窗口的产物（回看需要历史数据）；锚定窗口的 anchor 由实时落账写入、与分钟桶同事务，必然不早于覆盖起点，因此该门禁已无技术必要，只会让全新部署的实例前 5 小时配不了 5h 限额。移除它涉及 5 个调用点和前端错误码，与本 PR 不是一回事，单独处理。

## 影响目录

仅 `CliRelay/`：`internal/usage`、`internal/quota`。无前端改动。

新表走 `bootstrapPeriodSpendingResets` 建立，与 `period_spending_resets` 同一路径；SQLite 与 Postgres 均由 `compatdriver` 覆盖，无需新增 migration。

## 验证

`./scripts/ci-pr.sh` 全绿：结构扫描、gofmt、密钥扫描、`go vet ./...`、`go test ./...`、golangci-lint v1.64.5。

新增测试覆盖：首笔消费开窗且窗口内不推移、过期后重新开窗、零成本不开窗、Key/账号独立开窗、窗口到期用量整体归零（含 4h59m 边界，滚动窗口在此处会只剩尾巴）、重置基线在整个窗口内持续有效（bug 回归）、跨窗口后基线失效、批量查询各用各的锚点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)