### PR TITLE
refactor(quota): drop the obsolete 5h projection warmup gate

### DIFF
--- a/docs/internal-review/backend-structure-allowlist.json
+++ b/docs/internal-review/backend-structure-allowlist.json
@@ -10,11 +10,11 @@
     "baseline_above_800": [
       {
         "path": "internal/api/handlers/management/end_user.go",
-        "max_lines": 910
+        "max_lines": 908
       },
       {
         "path": "internal/enduser/service.go",
-        "max_lines": 1168
+        "max_lines": 1164
       },
       {
         "path": "internal/identity/service.go",

--- a/internal/api/handlers/management/api_key_settings.go
+++ b/internal/api/handlers/management/api_key_settings.go
@@ -11,7 +11,6 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/access"
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/enduser"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	apikeysettings "github.com/router-for-me/CLIProxyAPI/v6/internal/management/settings/apikey"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
@@ -187,9 +186,7 @@ func (h *Handler) PutAPIKeyPermissionProfiles(c *gin.Context) {
 
 	result, err := h.apiKeySettings(c).ReplacePermissionProfilesWithCaps(profiles, syncAccounts)
 	if err != nil {
-		if errors.Is(err, enduser.ErrFiveHourProjectionWarming) {
-			c.JSON(http.StatusConflict, gin.H{"error": gin.H{"code": "five_hour_quota_projection_warming", "message": "5-hour quota projection is still warming"}})
-		} else if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
+		if errors.Is(err, quota.ErrPeriodDayLegacyConflict) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
 		} else {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -407,9 +404,6 @@ func (h *Handler) PatchAPIKeyEntry(c *gin.Context) {
 		switch {
 		case errors.Is(err, quota.ErrPeriodDayLegacyConflict):
 			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
-			return
-		case errors.Is(err, enduser.ErrFiveHourProjectionWarming):
-			c.JSON(http.StatusConflict, gin.H{"error": gin.H{"code": "five_hour_quota_projection_warming", "message": "5-hour quota projection is still warming"}})
 			return
 		case errors.As(err, &exceeds):
 			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "key_period_limit_exceeds_account", "message": exceeds.Error(), "details": gin.H{"period": exceeds.Period, "key_limit": exceeds.KeyLimit, "account_limit": exceeds.AccountLimit}}})

--- a/internal/api/handlers/management/end_user.go
+++ b/internal/api/handlers/management/end_user.go
@@ -62,8 +62,6 @@ func endUserError(c *gin.Context, err error) {
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "not_found", "message": err.Error()}})
 	case errors.Is(err, enduser.ErrPeriodDayLegacyConflict):
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "period_day_legacy_conflict", "message": "daily-spending-limit conflicts with period-spending-limits.day"}})
-	case errors.Is(err, enduser.ErrFiveHourProjectionWarming):
-		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": gin.H{"code": "five_hour_quota_projection_warming", "message": "5-hour quota projection is still warming"}})
 	case func() bool { var target *quota.LimitExceedsAccountError; return errors.As(err, &target) }():
 		var target *quota.LimitExceedsAccountError
 		_ = errors.As(err, &target)

--- a/internal/enduser/period_quota.go
+++ b/internal/enduser/period_quota.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/quota"
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/usage"
 )
 
 func (s *Service) CreateKeyWithPeriodLimits(ctx context.Context, tenantID, endUserID, name string, patch *quota.PeriodSpendingLimitsPatch) (CreateKeyResult, error) {
@@ -26,9 +25,6 @@ func (s *Service) CreateKeyWithPeriodLimits(ctx context.Context, tenantID, endUs
 		return result, fmt.Errorf("%w: %v", ErrValidation, err)
 	}
 	limits := quota.ApplyPatch(quota.PeriodSpendingLimits{}, patch)
-	if limits.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
-		return result, ErrFiveHourProjectionWarming
-	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return result, err
@@ -105,9 +101,6 @@ func (s *Service) UpdateKey(ctx context.Context, tenantID, endUserID, keyID stri
 	patch, err := quota.NormalizePatch(patch)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrValidation, err)
-	}
-	if patch != nil && patch.FiveHour != nil && *patch.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
-		return ErrFiveHourProjectionWarming
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/enduser/service.go
+++ b/internal/enduser/service.go
@@ -24,23 +24,22 @@ import (
 )
 
 var (
-	ErrInvalidCredentials        = errors.New("invalid credentials")
-	ErrAccountDisabled           = errors.New("account disabled")
-	ErrAccountLocked             = errors.New("account locked")
-	ErrLoginCooldowned           = errors.New("login cooldown")
-	ErrMustChangePassword        = errors.New("must change password")
-	ErrSessionExpired            = errors.New("session expired")
-	ErrSessionRevoked            = errors.New("session revoked")
-	ErrPermissionDenied          = errors.New("permission denied")
-	ErrTenantScope               = errors.New("tenant scope forbidden")
-	ErrTenantSuspended           = errors.New("tenant suspended")
-	ErrTenantExpired             = errors.New("tenant expired")
-	ErrValidation                = errors.New("validation failed")
-	ErrDuplicateKeyName          = errors.New("duplicate key name")
-	ErrLastKey                   = errors.New("cannot delete last api key")
-	ErrNotFound                  = errors.New("not found")
-	ErrFiveHourProjectionWarming = errors.New("five hour quota projection warming")
-	ErrPeriodDayLegacyConflict   = errors.New("period day legacy conflict")
+	ErrInvalidCredentials      = errors.New("invalid credentials")
+	ErrAccountDisabled         = errors.New("account disabled")
+	ErrAccountLocked           = errors.New("account locked")
+	ErrLoginCooldowned         = errors.New("login cooldown")
+	ErrMustChangePassword      = errors.New("must change password")
+	ErrSessionExpired          = errors.New("session expired")
+	ErrSessionRevoked          = errors.New("session revoked")
+	ErrPermissionDenied        = errors.New("permission denied")
+	ErrTenantScope             = errors.New("tenant scope forbidden")
+	ErrTenantSuspended         = errors.New("tenant suspended")
+	ErrTenantExpired           = errors.New("tenant expired")
+	ErrValidation              = errors.New("validation failed")
+	ErrDuplicateKeyName        = errors.New("duplicate key name")
+	ErrLastKey                 = errors.New("cannot delete last api key")
+	ErrNotFound                = errors.New("not found")
+	ErrPeriodDayLegacyConflict = errors.New("period day legacy conflict")
 )
 
 const (
@@ -655,9 +654,6 @@ func (s *Service) UpdateUser(ctx context.Context, actor identity.Principal, tena
 		}
 		if resolvedPeriodPatch != nil {
 			if resolvedPeriodPatch.FiveHour != nil {
-				if *resolvedPeriodPatch.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
-					return User{}, ErrFiveHourProjectionWarming
-				}
 				sets = append(sets, "five_hour_spending_limit = ?")
 				args = append(args, *resolvedPeriodPatch.FiveHour)
 			}

--- a/internal/management/settings/apikey/service.go
+++ b/internal/management/settings/apikey/service.go
@@ -218,9 +218,6 @@ func (s *Service) normalizePermissionProfiles(profiles []usage.APIKeyPermissionP
 			day = limits.Day
 		}
 		limits.Day = day
-		if limits.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
-			return nil, enduser.ErrFiveHourProjectionWarming
-		}
 		normalized[idx].DailySpendingLimit = day
 		normalized[idx].PeriodSpendingLimits = limits
 		if s != nil && s.sanitizeChannels != nil {
@@ -541,9 +538,6 @@ func (s *Service) prepareEntryForSave(entry config.APIKeyEntry) (config.APIKeyEn
 		day = limits.Day
 	}
 	limits.Day = day
-	if limits.FiveHour > 0 && !usage.FiveHourQuotaProjectionReady() {
-		return config.APIKeyEntry{}, enduser.ErrFiveHourProjectionWarming
-	}
 	entry.DailySpendingLimit = day
 	entry.PeriodSpendingLimits = limits
 	entry.AllowedChannelGroups = normalizeChannelGroups(entry.AllowedChannelGroups)

--- a/internal/usage/period_spending_test.go
+++ b/internal/usage/period_spending_test.go
@@ -68,29 +68,6 @@ func TestQueryPeriodSpendingWeekAndFiveHourBoundaries(t *testing.T) {
 	}
 }
 
-func TestFiveHourQuotaProjectionReadinessRequiresFullCoverage(t *testing.T) {
-	initTestUsageDB(t, config.RequestLogStorageConfig{})
-	db := getDB()
-	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
-	ensureUsageProjectionMarkerTable(db)
-	set := func(start time.Time) {
-		t.Helper()
-		if _, err := db.Exec(`INSERT INTO usage_projection_markers(marker_key,marker_value,updated_at)
-			VALUES(?,?,?) ON CONFLICT(marker_key) DO UPDATE SET marker_value=excluded.marker_value,updated_at=excluded.updated_at`,
-			quotaMinuteCoverageStartMarker, start.Format(time.RFC3339), now); err != nil {
-			t.Fatalf("set marker: %v", err)
-		}
-	}
-	set(now.Add(-4*time.Hour - 59*time.Minute))
-	if FiveHourQuotaProjectionReadyAt(now) {
-		t.Fatal("projection should still be warming before five hours")
-	}
-	set(now.Add(-5 * time.Hour))
-	if !FiveHourQuotaProjectionReadyAt(now) {
-		t.Fatal("projection should be ready at full five-hour coverage")
-	}
-}
-
 func TestRollupBucketStartsProjectsQuotaMinuteInUTC(t *testing.T) {
 	loc := time.FixedZone("UTC+8", 8*60*60)
 	at := time.Date(2026, 7, 22, 23, 59, 30, 0, loc)

--- a/internal/usage/usage_rollup.go
+++ b/internal/usage/usage_rollup.go
@@ -75,10 +75,9 @@ CREATE INDEX IF NOT EXISTS idx_usage_rollup_tenant_subject_day
   ON usage_rollup_buckets(tenant_id, bucket_kind, auth_subject_id, bucket_start);
 `
 	// Bump marker when rebuild semantics change so upgrades re-run once.
-	usageRollupBackfillMarker      = "usage_rollup_buckets_v4"
-	quotaMinuteCoverageStartMarker = "quota_minute_utc_coverage_start"
-	rollupMarkerPending            = "pending"
-	rollupMarkerDone               = "done"
+	usageRollupBackfillMarker = "usage_rollup_buckets_v4"
+	rollupMarkerPending       = "pending"
+	rollupMarkerDone          = "done"
 )
 
 type rollupEvent struct {
@@ -339,16 +338,7 @@ func runUsageRollupBackfillAtInitDB(db *sql.DB, loc *time.Location, finalMarker 
 			return err
 		}
 	}
-	nowTime := time.Now().UTC()
-	now := nowTime.Format(time.RFC3339Nano)
-	if _, err = tx.Exec(`
-		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
-		VALUES (?, ?, ?)
-		ON CONFLICT(marker_key) DO NOTHING
-	`, quotaMinuteCoverageStartMarker, nowTime.Truncate(time.Minute).Format(time.RFC3339), now); err != nil {
-		_ = tx.Rollback()
-		return fmt.Errorf("usage: quota minute coverage marker: %w", err)
-	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
 	if _, err = tx.Exec(`
 		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
 		VALUES (?, ?, ?)
@@ -462,15 +452,6 @@ func projectUsageRollupTx(tx *sql.Tx, ev rollupEvent) error {
 			updated_at = excluded.updated_at
 	`
 
-	coverageStart := ev.At.UTC().Truncate(time.Minute).Format(time.RFC3339)
-	if _, err := tx.Exec(`
-		INSERT INTO usage_projection_markers (marker_key, marker_value, updated_at)
-		VALUES (?, ?, ?)
-		ON CONFLICT(marker_key) DO NOTHING
-	`, quotaMinuteCoverageStartMarker, coverageStart, now); err != nil {
-		return fmt.Errorf("usage: record quota minute coverage start: %w", err)
-	}
-
 	// Fixed order avoids Postgres deadlocks when concurrent writers UPSERT the same key.
 	for _, kind := range []string{rollupBucketMinute, rollupBucketQuotaMinuteUTC, rollupBucketHour, rollupBucketDay, rollupBucketLifetime} {
 		start := starts[kind]
@@ -573,24 +554,4 @@ func cleanupExpiredUsageRollupBuckets(db *sql.DB) (int64, error) {
 		deleted += n
 	}
 	return deleted, nil
-}
-
-func FiveHourQuotaProjectionReadyAt(now time.Time) bool {
-	db := getReadDB()
-	if db == nil {
-		return false
-	}
-	raw := strings.TrimSpace(projectionMarkerValue(db, quotaMinuteCoverageStartMarker))
-	if raw == "" {
-		return false
-	}
-	started, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		return false
-	}
-	return !started.After(now.UTC().Truncate(time.Minute).Add(-5 * time.Hour))
-}
-
-func FiveHourQuotaProjectionReady() bool {
-	return FiveHourQuotaProjectionReadyAt(time.Now())
 }


### PR DESCRIPTION
移除 5 小时配额的 `FiveHourQuotaProjectionReady` 门禁。它是滚动窗口时代的保护，在固定窗口下已无技术必要。

## 为什么它现在是多余的

滚动窗口时代，5h 用量 = 过去五小时 `quota_minute_utc` 分钟桶之和。回看五小时需要五小时的历史，所以在分钟桶覆盖不足时禁止配置 5h 限额，否则用量会被低估。这个判断由 `usage.FiveHourQuotaProjectionReady()` 做出，背后是 `quota_minute_utc_coverage_start` marker，不满足时返回 409 `five_hour_quota_projection_warming`。

#1013 之后，窗口锚定在首次计费消费上：用量统计区间是 `[anchor, now]`，而 anchor 由实时写入路径在 `commitLogWithProjections` 里与分钟桶**同一事务**写入。anchor 因此不可能早于覆盖起点，区间永远完整落在分钟桶覆盖范围内，用量不会被低估。

门禁只剩一个实际效果：全新部署的实例在前五小时内无法配置 5h 限额。

## 改了什么

- 删除 `FiveHourQuotaProjectionReadyAt` / `FiveHourQuotaProjectionReady` 与全部 5 处调用（`enduser/period_quota.go` ×2、`enduser/service.go`、`management/settings/apikey/service.go` ×2）
- 删除 `ErrFiveHourProjectionWarming` 及其 3 处 HTTP 映射（`api_key_settings.go` ×2、`end_user.go`），错误码 `five_hour_quota_projection_warming` 不再返回
- 删除 `quotaMinuteCoverageStartMarker`：确认过唯一读取方就是上面的就绪检查，`usage_projection_markers` 的其他 marker 各有自己的消费者，不受影响。顺带从每请求计费事务里省掉一次 INSERT
- 删除 `TestFiveHourQuotaProjectionReadinessRequiresFullCoverage`
- 更新结构基线：`end_user.go` 910→908、`enduser/service.go` 1168→1164

## 遗留数据

已写入的 `quota_minute_utc_coverage_start` 行留在 `usage_projection_markers` 里不动。已无任何读取方，留着无害；为它加一条 DELETE 迁移是纯粹的迁移风险，没有收益。

## 验证

本地完整执行 `./scripts/ci-pr.sh`，全绿：结构扫描、gofmt、secret scan、`go vet`、`go test ./...`、golangci-lint。

rebase 到含 #1013 的最新 `dev` 后代码树与跑 CI 的版本逐字节一致（仅移除了误加入的 `__pycache__` 文件），并重新确认 `go build ./...` 通过。

## 关联

前端配套 PR（删除该错误码的处理与文案）：kittors/codeProxy 侧 `chore/remove-five-hour-projection-gate`，按 expand/contract 顺序在本 PR 合入后再合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)