### PR TITLE
chore: ignore Python bytecode repo-wide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,12 @@ node_modules/
 tools*/**/node_modules/
 tools*/**/.profiles/
 tools*/**/data/
-tools*/**/__pycache__/
-tools*/**/*.pyc
+
+# Python bytecode — repo-wide, not scoped to tools*: every tracked .py lives in
+# scripts/ (structure-debt gate, PR/issue agents) and running them leaves a
+# scripts/__pycache__ that `git add -A` would otherwise sweep into a commit.
+__pycache__/
+*.pyc
 
 # Tooling metadata
 .vscode/*


### PR DESCRIPTION
## 问题

`.gitignore` 的 Python 缓存规则只覆盖了 `tools*/**/__pycache__/` 和 `tools*/**/*.pyc`，但**本仓库根本没有 `tools*` 目录**，`origin/dev` 上全部被追踪的 `.py` 文件都在 `scripts/` 下：

```
scripts/check-backend-structure.py    # 结构债棘轮门禁
scripts/issue_triage_agent.py
scripts/pr_review_agent.py
scripts/test_agent_model_config.py
```

也就是说，那两条规则保护的是空集，而真正会产生字节码缓存的目录反而没被覆盖。

任何人跑一次结构检查脚本（AGENTS.md 明确要求文件变小后跑 `--update-baseline`）或 PR/issue agent 脚本，就会在 `scripts/__pycache__/` 留下 `.pyc`，随后的 `git add -A` 会把它们扫进提交。这在 #1014 的准备过程中真实发生过一次，只是在推送前才被发现并从 commit 中剔除。

## 改动

把两条失效的 `tools*` 规则替换为仓库全局的 `__pycache__/` 与 `*.pyc`——后者是前者的严格超集，不损失任何既有覆盖范围。

保留 `tools*/**/node_modules/` 等其余 `tools*` 规则不动，本 PR 不扩大范围。选择全局而非逐目录列举，是因为逐目录正是这次漏掉 `scripts/` 的原因；同一区块里 `node_modules/` 本来就已经是全局规则。

## 影响范围

- 只改 `.gitignore`，不涉及任何运行时代码、配置或 CI。
- `origin/dev` 上不存在被误提交的 `.pyc` / `__pycache__` 追踪文件，因此**不需要** `git rm --cached` 清理。

## 验证

按 AGENTS.md 的「低风险本地变更」分级，执行了与改动直接相关的检查，**未**运行完整 `./scripts/ci-pr.sh`：

- `python3 -m py_compile scripts/*.py` 生成 4 个真实 `.pyc` 后，`git status --short` 只显示 ` M .gitignore`，缓存文件不再出现；`git check-ignore -v` 确认由 `.gitignore:61:__pycache__/` 命中。
- 反向对照：在未改动的主工作区对同一路径跑 `git check-ignore`，无任何规则命中——确认修复前 `git add -A` 确实会提交它。
- 未误伤既有文件：`git ls-files --ignored --exclude-standard -c` 在改动前后都返回同样的 20 个路径（全部来自既有的 `docs/*` 规则），差集为空。
- `python3 scripts/check-backend-structure.py` → `Result: passed`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)