### PR TITLE
feat(auth): queue requests on saturated accounts instead of failing them

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -248,6 +248,17 @@ request-retry: 3
 # Maximum wait time in seconds for a cooled-down credential before triggering a retry.
 max-retry-interval: 30
 
+# Behavior when an AI account reaches the `concurrency_limit` set on its auth file.
+# Requests first fail over to any account with a free slot; only when every candidate
+# is busy do they queue here, in arrival order, and resume as soon as a slot frees up.
+account-concurrency:
+  # Seconds a request may queue before giving up with HTTP 429. Default is 30.
+  # Set to 0 to disable queuing and fail as soon as all candidate accounts are busy.
+  wait-timeout-seconds: 30
+  # Maximum queued requests per account; 0 means unbounded. Set this when a stalled
+  # upstream should shed load instead of letting callers pile up behind it.
+  max-queue-depth: 0
+
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded

--- a/internal/api/server_config_reload.go
+++ b/internal/api/server_config_reload.go
@@ -146,6 +146,7 @@ func (s *Server) applyAuthRuntimeConfig(oldCfg, cfg *config.Config) {
 	}
 	if s.handlers != nil && s.handlers.AuthManager != nil {
 		s.handlers.AuthManager.SetRetryConfig(cfg.RequestRetry, time.Duration(cfg.MaxRetryInterval)*time.Second)
+		s.handlers.AuthManager.SetAccountConcurrencyConfig(cfg.AccountConcurrency.WaitTimeout(), cfg.AccountConcurrency.QueueDepth())
 	}
 }
 

--- a/internal/api/server_constructor_helpers.go
+++ b/internal/api/server_constructor_helpers.go
@@ -160,6 +160,7 @@ func (s *Server) applyInitialRuntimeConfig(cfg *config.Config, authManager *auth
 	s.applyAccessConfig(nil, cfg)
 	if authManager != nil {
 		authManager.SetRetryConfig(cfg.RequestRetry, time.Duration(cfg.MaxRetryInterval)*time.Second)
+		authManager.SetAccountConcurrencyConfig(cfg.AccountConcurrency.WaitTimeout(), cfg.AccountConcurrency.QueueDepth())
 	}
 	managementasset.SetCurrentConfig(cfg)
 	auth.SetQuotaCooldownDisabled(cfg.DisableCooling)

--- a/internal/config/account_concurrency.go
+++ b/internal/config/account_concurrency.go
@@ -1,0 +1,43 @@
+package config
+
+import "time"
+
+// DefaultAccountConcurrencyWaitSeconds is how long a request waits for a busy
+// account when the config omits the field. Queuing is the default because a
+// per-account limit is meant to pace traffic, not to reject it: without a wait
+// the request after the limit fails even though the account frees up moments later.
+const DefaultAccountConcurrencyWaitSeconds = 30
+
+// AccountConcurrencyConfig controls what happens once an AI account reaches the
+// `concurrency_limit` recorded on its auth file.
+type AccountConcurrencyConfig struct {
+	// WaitTimeoutSeconds is how long a request may queue for a saturated account
+	// before giving up with a 429. Omit it for the default; set 0 to disable
+	// queuing and fail as soon as every candidate account is busy.
+	WaitTimeoutSeconds *int `yaml:"wait-timeout-seconds,omitempty" json:"wait-timeout-seconds,omitempty"`
+
+	// MaxQueueDepth caps how many requests may queue per account. 0 means
+	// unbounded; set it when a stalled upstream should shed load instead of
+	// letting callers pile up behind it.
+	MaxQueueDepth int `yaml:"max-queue-depth,omitempty" json:"max-queue-depth,omitempty"`
+}
+
+// WaitTimeout resolves the configured queue timeout. A zero duration disables queuing.
+func (c AccountConcurrencyConfig) WaitTimeout() time.Duration {
+	seconds := DefaultAccountConcurrencyWaitSeconds
+	if c.WaitTimeoutSeconds != nil {
+		seconds = *c.WaitTimeoutSeconds
+	}
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// QueueDepth resolves the per-account queue cap, treating negatives as unbounded.
+func (c AccountConcurrencyConfig) QueueDepth() int {
+	if c.MaxQueueDepth < 0 {
+		return 0
+	}
+	return c.MaxQueueDepth
+}

--- a/internal/config/account_concurrency_test.go
+++ b/internal/config/account_concurrency_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeConfigFile(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestAccountConcurrency_DefaultsToQueuing(t *testing.T) {
+	cfg, err := LoadConfig(writeConfigFile(t, "port: 8317\n"))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if got := cfg.AccountConcurrency.WaitTimeout(); got != DefaultAccountConcurrencyWaitSeconds*time.Second {
+		t.Fatalf("expected default queue timeout %ds, got %s", DefaultAccountConcurrencyWaitSeconds, got)
+	}
+	if depth := cfg.AccountConcurrency.QueueDepth(); depth != 0 {
+		t.Fatalf("expected unbounded queue by default, got %d", depth)
+	}
+}
+
+func TestAccountConcurrency_ExplicitZeroDisablesQueuing(t *testing.T) {
+	// An omitted field and an explicit 0 must not mean the same thing: operators
+	// need a way to keep the old fail-fast behaviour.
+	cfg, err := LoadConfig(writeConfigFile(t, "port: 8317\naccount-concurrency:\n  wait-timeout-seconds: 0\n"))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if got := cfg.AccountConcurrency.WaitTimeout(); got != 0 {
+		t.Fatalf("expected queuing disabled, got %s", got)
+	}
+}
+
+func TestAccountConcurrency_ReadsConfiguredValues(t *testing.T) {
+	cfg, err := LoadConfig(writeConfigFile(t, "port: 8317\naccount-concurrency:\n  wait-timeout-seconds: 45\n  max-queue-depth: 8\n"))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if got := cfg.AccountConcurrency.WaitTimeout(); got != 45*time.Second {
+		t.Fatalf("expected 45s queue timeout, got %s", got)
+	}
+	if depth := cfg.AccountConcurrency.QueueDepth(); depth != 8 {
+		t.Fatalf("expected queue depth 8, got %d", depth)
+	}
+}
+
+func TestAccountConcurrency_NegativeValuesAreClamped(t *testing.T) {
+	cfg, err := LoadConfig(writeConfigFile(t, "port: 8317\naccount-concurrency:\n  wait-timeout-seconds: -5\n  max-queue-depth: -3\n"))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if got := cfg.AccountConcurrency.WaitTimeout(); got != 0 {
+		t.Fatalf("expected negative timeout to disable queuing, got %s", got)
+	}
+	if depth := cfg.AccountConcurrency.QueueDepth(); depth != 0 {
+		t.Fatalf("expected negative depth to mean unbounded, got %d", depth)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,6 +117,10 @@ type Config struct {
 	// MaxRetryInterval defines the maximum wait time in seconds before retrying a cooled-down credential.
 	MaxRetryInterval int `yaml:"max-retry-interval" json:"max-retry-interval"`
 
+	// AccountConcurrency controls how requests queue for AI accounts that are at
+	// their per-account concurrency limit.
+	AccountConcurrency AccountConcurrencyConfig `yaml:"account-concurrency,omitempty" json:"account-concurrency,omitempty"`
+
 	// QuotaExceeded defines the behavior when a quota is exceeded.
 	QuotaExceeded QuotaExceeded `yaml:"quota-exceeded" json:"quota-exceeded"`
 

--- a/sdk/cliproxy/auth/account_concurrency.go
+++ b/sdk/cliproxy/auth/account_concurrency.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 )
 
@@ -13,15 +12,22 @@ var (
 
 // AccountConcurrencyLimiter manages in-flight request slots per auth ID.
 // It supports querying active load, checking availability, acquiring slots, and releasing slots.
+//
+// Saturated accounts do not fail immediately: callers may queue through
+// AcquireSlotWait, and ReleaseSlot hands a freed slot straight to the
+// longest-waiting caller (see account_concurrency_queue.go).
 type AccountConcurrencyLimiter struct {
 	mu     sync.RWMutex
 	active map[string]int
+	// waiters holds the FIFO queue of callers blocked on each auth ID.
+	waiters map[string][]*slotWaiter
 }
 
 // NewAccountConcurrencyLimiter creates a new thread-safe concurrency limiter.
 func NewAccountConcurrencyLimiter() *AccountConcurrencyLimiter {
 	return &AccountConcurrencyLimiter{
-		active: make(map[string]int),
+		active:  make(map[string]int),
+		waiters: make(map[string][]*slotWaiter),
 	}
 }
 
@@ -60,44 +66,59 @@ func (l *AccountConcurrencyLimiter) HasAvailableSlot(auth *Auth) bool {
 	return l.active[auth.ID] < limit
 }
 
-// AcquireSlot attempts to acquire a concurrency slot for the given auth.
+// AcquireSlot attempts to acquire a concurrency slot for the given auth without waiting.
 // Returns a release function and an error. If acquired, the caller MUST call the returned release function.
-// If the limit is reached, it returns nil and ErrAccountConcurrencyExceeded.
+// If the limit is reached, it returns nil and an *AccountConcurrencyError wrapping ErrAccountConcurrencyExceeded.
 func (l *AccountConcurrencyLimiter) AcquireSlot(auth *Auth) (func(), error) {
 	if l == nil || auth == nil {
 		return func() {}, nil
 	}
-	authID := auth.ID
-	limit := auth.ConcurrencyLimit()
 
 	l.mu.Lock()
-	if limit > 0 {
-		current := l.active[authID]
-		if current >= limit {
-			l.mu.Unlock()
-			return nil, fmt.Errorf("%w: account %s active=%d max=%d", ErrAccountConcurrencyExceeded, authID, current, limit)
-		}
+	if !l.tryAcquireLocked(auth) {
+		err := l.saturatedErrorLocked(auth, 0)
+		l.mu.Unlock()
+		return nil, err
 	}
-	l.active[authID]++
 	l.mu.Unlock()
 
-	var once sync.Once
-	release := func() {
-		once.Do(func() {
-			l.ReleaseSlot(authID)
-		})
-	}
-	return release, nil
+	return l.releaseFunc(auth.ID), nil
 }
 
 // ReleaseSlot decrements the in-flight count for the given auth ID.
+//
+// When callers are queued on this account the slot is transferred to the
+// longest-waiting one instead of being released and re-contended: without the
+// handoff a burst of fresh requests could keep overtaking a queued caller.
 func (l *AccountConcurrencyLimiter) ReleaseSlot(authID string) {
 	if l == nil || authID == "" {
 		return
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
+
 	current := l.active[authID]
+	if current <= 0 {
+		return
+	}
+	// Handing the slot over keeps the in-flight count unchanged, so it is only
+	// safe while that count still fits the account's current limit. A limit
+	// lowered mid-flight must drain instead, otherwise the account would stay
+	// above its new ceiling for as long as requests keep queuing.
+	for {
+		waiter := l.peekWaiterLocked(authID)
+		if waiter == nil {
+			break
+		}
+		if limit := waiter.limitFor(authID); limit > 0 && current > limit {
+			break
+		}
+		l.popWaiterLocked(authID)
+		if waiter.tryGrant(authID) {
+			return
+		}
+	}
+
 	if current <= 1 {
 		delete(l.active, authID)
 	} else {
@@ -132,4 +153,27 @@ func (l *AccountConcurrencyLimiter) FilterAvailableCandidates(candidates []*Auth
 	}
 	// If all candidates are saturated, return all candidates so selector can fail or attempt fallback
 	return candidates
+}
+
+// tryAcquireLocked takes a slot when the account has room. Callers must hold l.mu.
+func (l *AccountConcurrencyLimiter) tryAcquireLocked(auth *Auth) bool {
+	if auth == nil || auth.ID == "" {
+		return false
+	}
+	limit := auth.ConcurrencyLimit()
+	if limit > 0 && l.active[auth.ID] >= limit {
+		return false
+	}
+	l.active[auth.ID]++
+	return true
+}
+
+// releaseFunc builds an idempotent release closure for an owned slot.
+func (l *AccountConcurrencyLimiter) releaseFunc(authID string) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			l.ReleaseSlot(authID)
+		})
+	}
 }

--- a/sdk/cliproxy/auth/account_concurrency_execution_test.go
+++ b/sdk/cliproxy/auth/account_concurrency_execution_test.go
@@ -1,0 +1,362 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+// newQueueTestManager wires a manager whose only provider blocks until released,
+// so tests can hold an account at its concurrency limit deterministically.
+func newQueueTestManager(t *testing.T, waitTimeout time.Duration, auths ...*Auth) (*Manager, *blockingExecutor) {
+	t.Helper()
+	mgr := NewManager(nil, &FillFirstSelector{}, nil)
+	mgr.SetAccountConcurrencyConfig(waitTimeout, 0)
+	for _, auth := range auths {
+		if _, err := mgr.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", auth.ID, err)
+		}
+	}
+	exec := &blockingExecutor{
+		started: make(chan struct{}, 16),
+		release: make(chan struct{}),
+	}
+	mgr.RegisterExecutor(exec)
+	return mgr, exec
+}
+
+func queueTestAuth(id string, limit int) *Auth {
+	return &Auth{
+		ID:         id,
+		Provider:   "blocking",
+		Status:     StatusActive,
+		Attributes: map[string]string{"concurrency_limit": strconv.Itoa(limit)},
+	}
+}
+
+// TestManagerExecute_QueuesWhenAllCandidatesSaturated covers the reported failure:
+// a single account at its limit used to return an error immediately, so a client
+// sending one request more than the limit got a hard failure instead of waiting.
+func TestManagerExecute_QueuesWhenAllCandidatesSaturated(t *testing.T) {
+	auth := queueTestAuth("auth-queue-exec", 1)
+	mgr, exec := newQueueTestManager(t, 5*time.Second, auth)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+		firstDone <- err
+	}()
+	<-exec.started
+
+	queuedDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+		queuedDone <- err
+	}()
+
+	// The second request must be waiting on the account, not failing.
+	waitForQueueDepth(t, mgr.ConcurrencyLimiter(), auth.ID, 1)
+	select {
+	case err := <-queuedDone:
+		t.Fatalf("second request failed instead of queuing: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(exec.release)
+
+	for _, done := range []chan error{firstDone, queuedDone} {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("request never completed after the account freed a slot")
+		}
+	}
+
+	if calls := exec.callCount.Load(); calls != 2 {
+		t.Fatalf("expected both requests to reach the upstream, got %d calls", calls)
+	}
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight(auth.ID); inFlight != 0 {
+		t.Fatalf("expected in-flight 0 after both requests, got %d", inFlight)
+	}
+}
+
+func TestManagerExecute_QueueTimeoutReportsRateLimit(t *testing.T) {
+	auth := queueTestAuth("auth-queue-timeout-exec", 1)
+	mgr, exec := newQueueTestManager(t, 100*time.Millisecond, auth)
+	defer close(exec.release)
+
+	go func() {
+		_, _ = mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+	}()
+	<-exec.started
+
+	start := time.Now()
+	_, err := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected the queued request to fail once the wait timed out")
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Fatalf("request gave up after %s, before the configured wait elapsed", elapsed)
+	}
+	if !errors.Is(err, ErrAccountConcurrencyExceeded) {
+		t.Fatalf("expected ErrAccountConcurrencyExceeded, got %v", err)
+	}
+	// A busy account is a rate limit, not a server fault: a 500 here would tell
+	// the client the proxy broke and skip its own backoff.
+	if status := statusCodeFromError(err); status != http.StatusTooManyRequests {
+		t.Fatalf("expected HTTP 429 to be reported, got %d (err=%v)", status, err)
+	}
+	// The HTTP layer reads the status through a bare type assertion on the error
+	// it receives, so the error must not be wrapped on its way out of Execute.
+	statusCoder, ok := err.(interface{ StatusCode() int })
+	if !ok {
+		t.Fatalf("error reaching the HTTP layer does not expose StatusCode(): %T", err)
+	}
+	if code := statusCoder.StatusCode(); code != http.StatusTooManyRequests {
+		t.Fatalf("HTTP layer would answer %d instead of 429", code)
+	}
+}
+
+func TestManagerExecute_QueueStopsWhenClientDisconnects(t *testing.T) {
+	auth := queueTestAuth("auth-queue-cancel-exec", 1)
+	mgr, exec := newQueueTestManager(t, time.Minute, auth)
+	defer close(exec.release)
+
+	go func() {
+		_, _ = mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+	}()
+	<-exec.started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := mgr.Execute(ctx, []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+		errCh <- err
+	}()
+
+	waitForQueueDepth(t, mgr.ConcurrencyLimiter(), auth.ID, 1)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued request kept waiting after the client disconnected")
+	}
+	if depth := mgr.ConcurrencyLimiter().QueueDepth(auth.ID); depth != 0 {
+		t.Fatalf("expected the abandoned request to leave the queue, got depth %d", depth)
+	}
+}
+
+func TestManagerExecute_PrefersIdleAccountOverQueuing(t *testing.T) {
+	busy := queueTestAuth("auth-busy", 1)
+	busy.Attributes["priority"] = "10"
+	idle := queueTestAuth("auth-idle", 5)
+	idle.Attributes["priority"] = "5"
+
+	mgr, exec := newQueueTestManager(t, time.Minute, busy, idle)
+
+	go func() {
+		_, _ = mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+	}()
+	<-exec.started
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+		done <- err
+	}()
+	<-exec.started
+
+	// Failover still wins over waiting: the second request runs on the idle
+	// account rather than queuing behind the saturated one.
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight(idle.ID); inFlight != 1 {
+		t.Fatalf("expected the idle account to take the request, in-flight=%d", inFlight)
+	}
+	if depth := mgr.ConcurrencyLimiter().QueueDepth(busy.ID); depth != 0 {
+		t.Fatalf("expected no queuing while an idle account exists, got depth %d", depth)
+	}
+
+	close(exec.release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("failover request failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("failover request never completed")
+	}
+}
+
+func TestManagerExecuteStream_QueuedRequestResumesAfterStreamCloses(t *testing.T) {
+	auth := queueTestAuth("auth-queue-stream", 1)
+	mgr, exec := newQueueTestManager(t, 5*time.Second, auth)
+
+	res, err := mgr.ExecuteStream(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream failed: %v", err)
+	}
+	<-exec.started
+
+	queued := make(chan error, 1)
+	go func() {
+		_, errQueued := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+		queued <- errQueued
+	}()
+	waitForQueueDepth(t, mgr.ConcurrencyLimiter(), auth.ID, 1)
+
+	// The stream holds the slot until its chunks are drained, so the queued
+	// request must resume only once the stream is fully closed.
+	close(exec.release)
+	for range res.Chunks {
+	}
+
+	select {
+	case errQueued := <-queued:
+		if errQueued != nil {
+			t.Fatalf("queued request failed after the stream closed: %v", errQueued)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued request never resumed after the stream closed")
+	}
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight(auth.ID); inFlight != 0 {
+		t.Fatalf("expected in-flight 0 after both requests, got %d", inFlight)
+	}
+}
+
+// queueThenFailExecutor holds the first request open and fails every later one,
+// which is how an account that is busy *and* broken behaves.
+type queueThenFailExecutor struct {
+	started chan struct{}
+	release chan struct{}
+	calls   atomic.Int32
+}
+
+func (e *queueThenFailExecutor) Identifier() string { return "blocking" }
+
+func (e *queueThenFailExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if e.calls.Add(1) == 1 {
+		e.started <- struct{}{}
+		select {
+		case <-e.release:
+		case <-ctx.Done():
+			return cliproxyexecutor.Response{}, ctx.Err()
+		}
+		return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+	}
+	return cliproxyexecutor.Response{}, &Error{Code: "upstream_failed", Message: "upstream rejected the request", HTTPStatus: http.StatusBadGateway}
+}
+
+func (e *queueThenFailExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{Code: "upstream_failed", Message: "upstream rejected the request", HTTPStatus: http.StatusBadGateway}
+}
+
+func (e *queueThenFailExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *queueThenFailExecutor) CountTokens(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return e.Execute(ctx, auth, req, opts)
+}
+
+func (e *queueThenFailExecutor) HttpRequest(ctx context.Context, auth *Auth, req *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+// TestManagerExecute_QueuedRequestDoesNotLoopOnFailure guards the queue against
+// re-queuing an account that already had its turn: without that, a request whose
+// upstream call keeps failing would cycle through the queue forever instead of
+// reporting the failure.
+func TestManagerExecute_QueuedRequestDoesNotLoopOnFailure(t *testing.T) {
+	auth := queueTestAuth("auth-queue-no-loop", 1)
+	mgr := NewManager(nil, &FillFirstSelector{}, nil)
+	mgr.SetAccountConcurrencyConfig(5*time.Second, 0)
+	if _, err := mgr.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	exec := &queueThenFailExecutor{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	mgr.RegisterExecutor(exec)
+
+	go func() {
+		_, _ = mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+	}()
+	<-exec.started
+
+	queued := make(chan error, 1)
+	go func() {
+		_, err := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+		queued <- err
+	}()
+	waitForQueueDepth(t, mgr.ConcurrencyLimiter(), auth.ID, 1)
+
+	close(exec.release)
+
+	select {
+	case err := <-queued:
+		if err == nil {
+			t.Fatal("expected the queued request to report the upstream failure")
+		}
+		if !strings.Contains(err.Error(), "upstream rejected the request") {
+			t.Fatalf("expected the upstream error to surface, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("queued request never returned; it is looping through the queue")
+	}
+
+	if calls := exec.calls.Load(); calls != 2 {
+		t.Fatalf("expected exactly one retry attempt per account, got %d upstream calls", calls)
+	}
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight(auth.ID); inFlight != 0 {
+		t.Fatalf("expected in-flight 0 after the failure, got %d", inFlight)
+	}
+	if depth := mgr.ConcurrencyLimiter().QueueDepth(auth.ID); depth != 0 {
+		t.Fatalf("expected an empty queue after the failure, got depth %d", depth)
+	}
+}
+
+func TestManagerCountTokens_QueuesWhenSaturated(t *testing.T) {
+	auth := queueTestAuth("auth-queue-count", 1)
+	mgr, exec := newQueueTestManager(t, 5*time.Second, auth)
+
+	go func() {
+		_, _ = mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+	}()
+	<-exec.started
+
+	counted := make(chan error, 1)
+	go func() {
+		_, err := mgr.ExecuteCount(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "test-model"}, cliproxyexecutor.Options{})
+		counted <- err
+	}()
+	waitForQueueDepth(t, mgr.ConcurrencyLimiter(), auth.ID, 1)
+
+	close(exec.release)
+	select {
+	case err := <-counted:
+		if err != nil {
+			t.Fatalf("queued count-tokens request failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued count-tokens request never resumed")
+	}
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight(auth.ID); inFlight != 0 {
+		t.Fatalf("expected in-flight 0 after both requests, got %d", inFlight)
+	}
+}

--- a/sdk/cliproxy/auth/account_concurrency_queue.go
+++ b/sdk/cliproxy/auth/account_concurrency_queue.go
@@ -1,0 +1,286 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// DefaultAccountConcurrencyWait is the queue timeout applied when the host does
+// not configure one. Queuing is what callers expect from a per-account limit:
+// failing the request outright while the account is merely busy turns a short
+// wait into a hard error for the client.
+const DefaultAccountConcurrencyWait = 30 * time.Second
+
+// AccountConcurrencyError reports that an auth credential is at its concurrency limit.
+//
+// It carries a 429 status on purpose: the account is healthy and the upstream was
+// never contacted, so surfacing a 500 would tell clients the proxy is broken and
+// suppress their own rate-limit backoff.
+type AccountConcurrencyError struct {
+	// AuthID identifies the saturated credential.
+	AuthID string
+	// Active is the in-flight count observed when the request gave up.
+	Active int
+	// Limit is the account's configured concurrency limit.
+	Limit int
+	// Waited is how long the request sat in the queue. Zero means queuing was
+	// disabled, so the request never waited at all.
+	Waited time.Duration
+}
+
+// Error implements the error interface.
+func (e *AccountConcurrencyError) Error() string {
+	if e == nil {
+		return ""
+	}
+	msg := fmt.Sprintf("%s: account %s active=%d max=%d", ErrAccountConcurrencyExceeded.Error(), e.AuthID, e.Active, e.Limit)
+	if e.Waited > 0 {
+		msg += fmt.Sprintf(" waited=%s", e.Waited.Round(time.Millisecond))
+	}
+	return msg
+}
+
+// Unwrap keeps errors.Is(err, ErrAccountConcurrencyExceeded) working for callers
+// that classify failures by sentinel.
+func (e *AccountConcurrencyError) Unwrap() error { return ErrAccountConcurrencyExceeded }
+
+// StatusCode reports the failure as a rate limit rather than a server fault.
+func (e *AccountConcurrencyError) StatusCode() int { return http.StatusTooManyRequests }
+
+// slotWaiter is a request queued for a slot on one or more accounts.
+//
+// A waiter may sit in several account queues at once so a multi-candidate request
+// resumes as soon as any of them frees a slot; claimed makes sure exactly one
+// account hands over a slot and that a timed-out waiter cannot also receive one.
+type slotWaiter struct {
+	granted chan string
+	claimed atomic.Bool
+	authIDs []string
+	// auths keeps the credential behind each queue so a release can read the
+	// account's current limit instead of the one cached when it was acquired.
+	auths map[string]*Auth
+}
+
+func newSlotWaiter(auths []*Auth) *slotWaiter {
+	waiter := &slotWaiter{
+		granted: make(chan string, 1),
+		authIDs: make([]string, 0, len(auths)),
+		auths:   make(map[string]*Auth, len(auths)),
+	}
+	for _, auth := range auths {
+		waiter.authIDs = append(waiter.authIDs, auth.ID)
+		waiter.auths[auth.ID] = auth
+	}
+	return waiter
+}
+
+// limitFor reports the account's currently configured concurrency limit,
+// 0 meaning unlimited.
+func (w *slotWaiter) limitFor(authID string) int {
+	if auth := w.auths[authID]; auth != nil {
+		return auth.ConcurrencyLimit()
+	}
+	return 0
+}
+
+// tryGrant transfers ownership of an in-flight slot to this waiter. It returns
+// false when the waiter already took a slot elsewhere or gave up, so the
+// releasing account moves on to the next queued caller. Callers must hold l.mu.
+func (w *slotWaiter) tryGrant(authID string) bool {
+	if !w.claimed.CompareAndSwap(false, true) {
+		return false
+	}
+	// Buffered by one and guarded by claimed, so this never blocks the releaser.
+	w.granted <- authID
+	return true
+}
+
+// abandon marks the waiter as gone. It returns false when a slot was handed over
+// concurrently, in which case the caller MUST take that slot: dropping it would
+// leak account capacity until the process restarts.
+func (w *slotWaiter) abandon() bool {
+	return w.claimed.CompareAndSwap(false, true)
+}
+
+// AcquireSlotWait acquires a slot for one of auths, queuing when all of them are
+// saturated. It returns the release function and the auth ID that granted the
+// slot; the caller MUST invoke the release function.
+//
+// Ordering is FIFO per account: ReleaseSlot hands the freed slot to the
+// longest-waiting caller. When timeout is <= 0 queuing is disabled and the call
+// degrades to a non-blocking attempt. maxQueueDepth caps queued callers per
+// account (0 means unlimited) so an unreachable upstream cannot pile up requests
+// without bound.
+func (l *AccountConcurrencyLimiter) AcquireSlotWait(ctx context.Context, auths []*Auth, timeout time.Duration, maxQueueDepth int) (func(), string, error) {
+	if l == nil {
+		return func() {}, "", nil
+	}
+	candidates := make([]*Auth, 0, len(auths))
+	for _, candidate := range auths {
+		if candidate != nil && candidate.ID != "" {
+			candidates = append(candidates, candidate)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, "", &AccountConcurrencyError{}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+
+	waiter, release, authID, err := l.acquireOrEnqueue(candidates, timeout, maxQueueDepth)
+	if err != nil {
+		return nil, "", err
+	}
+	if waiter == nil {
+		return release, authID, nil
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	start := time.Now()
+
+	select {
+	case granted := <-waiter.granted:
+		// Leave the queues of the accounts that did not serve us; a stale entry
+		// would still count against their queue depth.
+		l.dequeue(waiter)
+		return l.releaseFunc(granted), granted, nil
+	case <-ctx.Done():
+		return l.giveUp(waiter, candidates, ctx.Err(), time.Since(start))
+	case <-timer.C:
+		return l.giveUp(waiter, candidates, nil, time.Since(start))
+	}
+}
+
+// QueueDepth reports how many callers are queued for the given auth ID.
+func (l *AccountConcurrencyLimiter) QueueDepth(authID string) int {
+	if l == nil || authID == "" {
+		return 0
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return len(l.waiters[authID])
+}
+
+// acquireOrEnqueue takes a free slot when one exists, otherwise enqueues a waiter.
+// Both happen under a single lock hold so a slot released in between cannot be
+// missed, which would otherwise make the caller wait for the *next* release.
+func (l *AccountConcurrencyLimiter) acquireOrEnqueue(candidates []*Auth, timeout time.Duration, maxQueueDepth int) (*slotWaiter, func(), string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for _, candidate := range candidates {
+		if l.tryAcquireLocked(candidate) {
+			return nil, l.releaseFunc(candidate.ID), candidate.ID, nil
+		}
+	}
+	if timeout <= 0 {
+		return nil, nil, "", l.saturatedErrorLocked(candidates[0], 0)
+	}
+
+	queueable := candidates
+	if maxQueueDepth > 0 {
+		queueable = make([]*Auth, 0, len(candidates))
+		for _, candidate := range candidates {
+			if len(l.waiters[candidate.ID]) < maxQueueDepth {
+				queueable = append(queueable, candidate)
+			}
+		}
+		if len(queueable) == 0 {
+			return nil, nil, "", l.saturatedErrorLocked(candidates[0], 0)
+		}
+	}
+
+	waiter := newSlotWaiter(queueable)
+	for _, authID := range waiter.authIDs {
+		l.waiters[authID] = append(l.waiters[authID], waiter)
+	}
+	return waiter, nil, "", nil
+}
+
+// giveUp abandons a queued waiter after a timeout or context cancellation.
+func (l *AccountConcurrencyLimiter) giveUp(waiter *slotWaiter, candidates []*Auth, cause error, waited time.Duration) (func(), string, error) {
+	if !waiter.abandon() {
+		// A slot was handed over at the same moment we gave up. Take it rather
+		// than let it leak; the caller still gets a usable slot.
+		granted := <-waiter.granted
+		return l.releaseFunc(granted), granted, nil
+	}
+	l.dequeue(waiter)
+	if cause != nil {
+		return nil, "", cause
+	}
+	l.mu.Lock()
+	err := l.saturatedErrorLocked(candidates[0], waited)
+	l.mu.Unlock()
+	return nil, "", err
+}
+
+// dequeue drops an abandoned waiter from every queue it joined.
+func (l *AccountConcurrencyLimiter) dequeue(waiter *slotWaiter) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, authID := range waiter.authIDs {
+		queue := l.waiters[authID]
+		for i, queued := range queue {
+			if queued == waiter {
+				queue = append(queue[:i], queue[i+1:]...)
+				break
+			}
+		}
+		if len(queue) == 0 {
+			delete(l.waiters, authID)
+		} else {
+			l.waiters[authID] = queue
+		}
+	}
+}
+
+// peekWaiterLocked returns the longest-waiting caller for an auth ID without
+// dequeuing it, so a release can check the account's limit before committing to
+// a handoff. Callers must hold l.mu.
+func (l *AccountConcurrencyLimiter) peekWaiterLocked(authID string) *slotWaiter {
+	queue := l.waiters[authID]
+	if len(queue) == 0 {
+		return nil
+	}
+	return queue[0]
+}
+
+// popWaiterLocked removes and returns the longest-waiting caller for an auth ID.
+// Callers must hold l.mu.
+func (l *AccountConcurrencyLimiter) popWaiterLocked(authID string) *slotWaiter {
+	queue := l.waiters[authID]
+	if len(queue) == 0 {
+		return nil
+	}
+	waiter := queue[0]
+	if len(queue) == 1 {
+		delete(l.waiters, authID)
+	} else {
+		queue[0] = nil // drop the reference so a long queue cannot pin dead waiters
+		l.waiters[authID] = queue[1:]
+	}
+	return waiter
+}
+
+// saturatedErrorLocked builds the error reported when no slot could be obtained.
+// Callers must hold l.mu.
+func (l *AccountConcurrencyLimiter) saturatedErrorLocked(auth *Auth, waited time.Duration) *AccountConcurrencyError {
+	if auth == nil {
+		return &AccountConcurrencyError{Waited: waited}
+	}
+	return &AccountConcurrencyError{
+		AuthID: auth.ID,
+		Active: l.active[auth.ID],
+		Limit:  auth.ConcurrencyLimit(),
+		Waited: waited,
+	}
+}

--- a/sdk/cliproxy/auth/account_concurrency_queue_test.go
+++ b/sdk/cliproxy/auth/account_concurrency_queue_test.go
@@ -1,0 +1,445 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func limitedAuth(id string, limit int) *Auth {
+	return &Auth{
+		ID:         id,
+		Attributes: map[string]string{"concurrency_limit": strconv.Itoa(limit)},
+	}
+}
+
+func TestAcquireSlotWait_QueuesUntilSlotReleased(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth := limitedAuth("auth-queue-1", 1)
+
+	release, err := limiter.AcquireSlot(auth)
+	if err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+
+	type waitResult struct {
+		release func()
+		authID  string
+		err     error
+	}
+	results := make(chan waitResult, 1)
+	go func() {
+		rel, id, errWait := limiter.AcquireSlotWait(context.Background(), []*Auth{auth}, 2*time.Second, 0)
+		results <- waitResult{release: rel, authID: id, err: errWait}
+	}()
+
+	// The waiter must actually block instead of failing fast.
+	select {
+	case res := <-results:
+		t.Fatalf("expected caller to queue, got early result: authID=%q err=%v", res.authID, res.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if depth := limiter.QueueDepth(auth.ID); depth != 1 {
+		t.Fatalf("expected queue depth 1, got %d", depth)
+	}
+	if inFlight := limiter.GetInFlight(auth.ID); inFlight != 1 {
+		t.Fatalf("expected in-flight 1 while queued, got %d", inFlight)
+	}
+
+	release()
+
+	select {
+	case res := <-results:
+		if res.err != nil {
+			t.Fatalf("queued acquire failed: %v", res.err)
+		}
+		if res.authID != auth.ID {
+			t.Fatalf("expected slot on %q, got %q", auth.ID, res.authID)
+		}
+		// The slot is handed over, never dropped: in-flight stays at the limit.
+		if inFlight := limiter.GetInFlight(auth.ID); inFlight != 1 {
+			t.Fatalf("expected in-flight 1 after handoff, got %d", inFlight)
+		}
+		res.release()
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued caller was not granted the released slot")
+	}
+
+	if inFlight := limiter.GetInFlight(auth.ID); inFlight != 0 {
+		t.Fatalf("expected in-flight 0 after final release, got %d", inFlight)
+	}
+	if depth := limiter.QueueDepth(auth.ID); depth != 0 {
+		t.Fatalf("expected empty queue, got depth %d", depth)
+	}
+}
+
+func TestAcquireSlotWait_TimeoutReportsRateLimit(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth := limitedAuth("auth-queue-timeout", 2)
+
+	rel1, _ := limiter.AcquireSlot(auth)
+	rel2, _ := limiter.AcquireSlot(auth)
+	defer rel1()
+	defer rel2()
+
+	start := time.Now()
+	release, authID, err := limiter.AcquireSlotWait(context.Background(), []*Auth{auth}, 80*time.Millisecond, 0)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		if release != nil {
+			release()
+		}
+		t.Fatalf("expected timeout error, got slot on %q", authID)
+	}
+	if elapsed < 80*time.Millisecond {
+		t.Fatalf("returned before the timeout elapsed: %s", elapsed)
+	}
+	if !errors.Is(err, ErrAccountConcurrencyExceeded) {
+		t.Fatalf("expected ErrAccountConcurrencyExceeded, got %v", err)
+	}
+
+	var concErr *AccountConcurrencyError
+	if !errors.As(err, &concErr) {
+		t.Fatalf("expected *AccountConcurrencyError, got %T", err)
+	}
+	if concErr.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("expected status 429, got %d", concErr.StatusCode())
+	}
+	if concErr.AuthID != auth.ID || concErr.Active != 2 || concErr.Limit != 2 {
+		t.Fatalf("unexpected error detail: %+v", concErr)
+	}
+	if concErr.Waited <= 0 {
+		t.Fatalf("expected recorded wait duration, got %s", concErr.Waited)
+	}
+	// statusCodeFromError drives the HTTP response, so the queue timeout must not
+	// fall through to a generic 500.
+	if status := statusCodeFromError(err); status != http.StatusTooManyRequests {
+		t.Fatalf("expected statusCodeFromError 429, got %d", status)
+	}
+	if depth := limiter.QueueDepth(auth.ID); depth != 0 {
+		t.Fatalf("expected abandoned waiter to leave the queue, got depth %d", depth)
+	}
+}
+
+func TestAcquireSlotWait_ContextCancellationStopsWaiting(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth := limitedAuth("auth-queue-cancel", 1)
+
+	release, _ := limiter.AcquireSlot(auth)
+	defer release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, errWait := limiter.AcquireSlotWait(ctx, []*Auth{auth}, time.Minute, 0)
+		errCh <- errWait
+	}()
+
+	// Give the caller time to enqueue, then hang up like a disconnected client.
+	waitForQueueDepth(t, limiter, auth.ID, 1)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled caller kept waiting")
+	}
+	if depth := limiter.QueueDepth(auth.ID); depth != 0 {
+		t.Fatalf("expected cancelled waiter to leave the queue, got depth %d", depth)
+	}
+}
+
+func TestAcquireSlotWait_GrantsInFIFOOrder(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth := limitedAuth("auth-queue-fifo", 1)
+
+	release, _ := limiter.AcquireSlot(auth)
+
+	const waiters = 4
+	granted := make(chan int, waiters)
+	releases := make(chan func(), waiters)
+	for i := 0; i < waiters; i++ {
+		// Enqueue one at a time so the expected order is unambiguous.
+		go func(idx int) {
+			rel, _, err := limiter.AcquireSlotWait(context.Background(), []*Auth{auth}, 5*time.Second, 0)
+			if err != nil {
+				granted <- -1
+				return
+			}
+			granted <- idx
+			releases <- rel
+		}(i)
+		waitForQueueDepth(t, limiter, auth.ID, i+1)
+	}
+
+	release()
+	for i := 0; i < waiters; i++ {
+		select {
+		case idx := <-granted:
+			if idx != i {
+				t.Fatalf("expected waiter %d to be served next, got %d", i, idx)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("waiter %d never got a slot", i)
+		}
+		select {
+		case rel := <-releases:
+			rel()
+		case <-time.After(5 * time.Second):
+			t.Fatalf("waiter %d never reported its release func", i)
+		}
+	}
+
+	if inFlight := limiter.GetInFlight(auth.ID); inFlight != 0 {
+		t.Fatalf("expected in-flight 0 after draining the queue, got %d", inFlight)
+	}
+}
+
+func TestAcquireSlotWait_ResumesOnWhicheverAccountFreesFirst(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	first := limitedAuth("auth-multi-1", 1)
+	second := limitedAuth("auth-multi-2", 1)
+
+	relFirst, _ := limiter.AcquireSlot(first)
+	relSecond, _ := limiter.AcquireSlot(second)
+
+	type waitResult struct {
+		release func()
+		authID  string
+		err     error
+	}
+	results := make(chan waitResult, 1)
+	go func() {
+		rel, id, err := limiter.AcquireSlotWait(context.Background(), []*Auth{first, second}, 5*time.Second, 0)
+		results <- waitResult{release: rel, authID: id, err: err}
+	}()
+
+	waitForQueueDepth(t, limiter, first.ID, 1)
+	waitForQueueDepth(t, limiter, second.ID, 1)
+
+	// Free the second account; the waiter must resume there, not wait for the first.
+	relSecond()
+
+	select {
+	case res := <-results:
+		if res.err != nil {
+			t.Fatalf("multi-account wait failed: %v", res.err)
+		}
+		if res.authID != second.ID {
+			t.Fatalf("expected slot on %q, got %q", second.ID, res.authID)
+		}
+		res.release()
+	case <-time.After(5 * time.Second):
+		t.Fatal("waiter did not resume on the account that freed a slot")
+	}
+
+	// The waiter must also be gone from the queue of the account it did not use,
+	// otherwise that account would hand a slot to a caller that already left.
+	if depth := limiter.QueueDepth(first.ID); depth != 0 {
+		t.Fatalf("expected waiter removed from the other queue, got depth %d", depth)
+	}
+	relFirst()
+	if inFlight := limiter.GetInFlight(first.ID); inFlight != 0 {
+		t.Fatalf("expected in-flight 0 on the untouched account, got %d", inFlight)
+	}
+}
+
+func TestAcquireSlotWait_ZeroTimeoutFailsFast(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth := limitedAuth("auth-no-queue", 1)
+
+	release, _ := limiter.AcquireSlot(auth)
+	defer release()
+
+	start := time.Now()
+	rel, _, err := limiter.AcquireSlotWait(context.Background(), []*Auth{auth}, 0, 0)
+	if err == nil {
+		if rel != nil {
+			rel()
+		}
+		t.Fatal("expected immediate failure when queuing is disabled")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("fail-fast path blocked for %s", elapsed)
+	}
+	if !errors.Is(err, ErrAccountConcurrencyExceeded) {
+		t.Fatalf("expected ErrAccountConcurrencyExceeded, got %v", err)
+	}
+	var concErr *AccountConcurrencyError
+	if errors.As(err, &concErr) && concErr.Waited != 0 {
+		t.Fatalf("expected no recorded wait when queuing is off, got %s", concErr.Waited)
+	}
+	if depth := limiter.QueueDepth(auth.ID); depth != 0 {
+		t.Fatalf("fail-fast path must not enqueue, got depth %d", depth)
+	}
+}
+
+func TestAcquireSlotWait_RejectsWhenQueueIsFull(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth := limitedAuth("auth-queue-depth", 1)
+
+	release, _ := limiter.AcquireSlot(auth)
+	defer release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_, _, _ = limiter.AcquireSlotWait(ctx, []*Auth{auth}, time.Minute, 1)
+	}()
+	waitForQueueDepth(t, limiter, auth.ID, 1)
+
+	rel, _, err := limiter.AcquireSlotWait(context.Background(), []*Auth{auth}, time.Minute, 1)
+	if err == nil {
+		if rel != nil {
+			rel()
+		}
+		t.Fatal("expected rejection once the queue is full")
+	}
+	if !errors.Is(err, ErrAccountConcurrencyExceeded) {
+		t.Fatalf("expected ErrAccountConcurrencyExceeded, got %v", err)
+	}
+	if depth := limiter.QueueDepth(auth.ID); depth != 1 {
+		t.Fatalf("expected queue to stay at its cap, got depth %d", depth)
+	}
+}
+
+func TestReleaseSlot_SkipsHandoffWhenLimitShrank(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth := limitedAuth("auth-shrink", 2)
+
+	rel1, _ := limiter.AcquireSlot(auth)
+	rel2, _ := limiter.AcquireSlot(auth)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	waitErr := make(chan error, 1)
+	go func() {
+		_, _, err := limiter.AcquireSlotWait(ctx, []*Auth{auth}, 5*time.Second, 0)
+		waitErr <- err
+	}()
+	waitForQueueDepth(t, limiter, auth.ID, 1)
+
+	// Operator lowers the account limit while two requests are in flight.
+	auth.Attributes["concurrency_limit"] = "1"
+
+	// Releasing must drain toward the new limit rather than hand the slot on,
+	// otherwise the account would stay above its configured ceiling forever.
+	rel1()
+	if inFlight := limiter.GetInFlight(auth.ID); inFlight != 1 {
+		t.Fatalf("expected in-flight to drop to 1, got %d", inFlight)
+	}
+	select {
+	case err := <-waitErr:
+		t.Fatalf("waiter was granted a slot above the lowered limit: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Once in-flight fits the new limit the next release may hand over again.
+	rel2()
+	select {
+	case err := <-waitErr:
+		if err != nil {
+			t.Fatalf("waiter failed after the account drained: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter never resumed after the account drained to its new limit")
+	}
+}
+
+func TestAcquireSlotWait_UnlimitedAccountNeverQueues(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth := &Auth{ID: "auth-unlimited-queue"}
+
+	releases := make([]func(), 0, 16)
+	for i := 0; i < 16; i++ {
+		rel, id, err := limiter.AcquireSlotWait(context.Background(), []*Auth{auth}, time.Millisecond, 0)
+		if err != nil {
+			t.Fatalf("unlimited account rejected acquire %d: %v", i, err)
+		}
+		if id != auth.ID {
+			t.Fatalf("expected slot on %q, got %q", auth.ID, id)
+		}
+		releases = append(releases, rel)
+	}
+	if inFlight := limiter.GetInFlight(auth.ID); inFlight != 16 {
+		t.Fatalf("expected in-flight 16, got %d", inFlight)
+	}
+	for _, rel := range releases {
+		rel()
+	}
+	if inFlight := limiter.GetInFlight(auth.ID); inFlight != 0 {
+		t.Fatalf("expected in-flight 0, got %d", inFlight)
+	}
+}
+
+// TestAcquireSlotWait_NoSlotLeakUnderCancelRace hammers the window where a slot is
+// handed over at the same moment its waiter times out. Losing that race would
+// strand in-flight capacity, which is exactly how an account ends up reporting
+// active=N forever while nothing is running.
+func TestAcquireSlotWait_NoSlotLeakUnderCancelRace(t *testing.T) {
+	limiter := NewAccountConcurrencyLimiter()
+	auth := limitedAuth("auth-race", 2)
+
+	const rounds = 300
+	var wg sync.WaitGroup
+	var granted atomic.Int64
+
+	for i := 0; i < rounds; i++ {
+		hold, err := limiter.AcquireSlot(auth)
+		if err != nil {
+			t.Fatalf("round %d: holder acquire failed: %v", i, err)
+		}
+		hold2, err := limiter.AcquireSlot(auth)
+		if err != nil {
+			t.Fatalf("round %d: second holder acquire failed: %v", i, err)
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// A very short timeout lands the abandon() and tryGrant() paths in the
+			// same instant often enough to expose a lost slot.
+			rel, _, errWait := limiter.AcquireSlotWait(context.Background(), []*Auth{auth}, time.Millisecond, 0)
+			if errWait == nil {
+				granted.Add(1)
+				rel()
+			}
+		}()
+
+		time.Sleep(time.Millisecond)
+		hold()
+		hold2()
+		wg.Wait()
+
+		if inFlight := limiter.GetInFlight(auth.ID); inFlight != 0 {
+			t.Fatalf("round %d: leaked %d in-flight slots", i, inFlight)
+		}
+		if depth := limiter.QueueDepth(auth.ID); depth != 0 {
+			t.Fatalf("round %d: leaked %d queued waiters", i, depth)
+		}
+	}
+	t.Logf("cancel race: %d/%d waiters won the handoff", granted.Load(), rounds)
+}
+
+// waitForQueueDepth blocks until the account queue reaches depth, so tests never
+// race the goroutine they just started.
+func waitForQueueDepth(t *testing.T, limiter *AccountConcurrencyLimiter, authID string, depth int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if limiter.QueueDepth(authID) >= depth {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("queue for %s never reached depth %d (currently %d)", authID, depth, limiter.QueueDepth(authID))
+}

--- a/sdk/cliproxy/auth/account_concurrency_stress_test.go
+++ b/sdk/cliproxy/auth/account_concurrency_stress_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"net/http"
@@ -108,6 +109,159 @@ func TestAccountConcurrency_HighConcurrencyStress(t *testing.T) {
 	for i := 0; i < numAccounts; i++ {
 		t.Logf("Auth %d peak in-flight: %d / %d", i, maxObservedInFlight[i].Load(), limitPerAccount)
 	}
+}
+
+// TestAccountConcurrency_OverloadQueueStress drives far more requests than the
+// pool has slots. Every request must still be served: queuing turns an overload
+// into added latency instead of the errors this used to return.
+func TestAccountConcurrency_OverloadQueueStress(t *testing.T) {
+	mgr := NewManager(nil, &RoundRobinSelector{}, nil)
+	mgr.SetAccountConcurrencyConfig(30*time.Second, 0)
+
+	const (
+		limitPerAccount = 2
+		numWorkers      = 120
+	)
+	auth := &Auth{
+		ID:         "auth-overload",
+		Provider:   "blocking",
+		Status:     StatusActive,
+		Attributes: map[string]string{"concurrency_limit": fmt.Sprintf("%d", limitPerAccount)},
+	}
+	if _, err := mgr.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	mgr.RegisterExecutor(&stressDelayExecutor{minDelay: time.Millisecond, maxDelay: 5 * time.Millisecond})
+
+	limiter := mgr.ConcurrencyLimiter()
+	stopMonitor := make(chan struct{})
+	monitorDone := make(chan struct{})
+	var peakInFlight atomic.Int32
+	go func() {
+		defer close(monitorDone)
+		for {
+			select {
+			case <-stopMonitor:
+				return
+			default:
+			}
+			inFlight := int32(limiter.GetInFlight(auth.ID))
+			if inFlight > limitPerAccount {
+				t.Errorf("INVARIANT VIOLATION: in-flight=%d > limit=%d", inFlight, limitPerAccount)
+			}
+			for {
+				current := peakInFlight.Load()
+				if inFlight <= current || peakInFlight.CompareAndSwap(current, inFlight) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	var wg sync.WaitGroup
+	var succeeded, failed atomic.Int32
+	firstErr := make(chan error, numWorkers)
+	wg.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		go func(workerID int) {
+			defer wg.Done()
+			var err error
+			if workerID%2 == 0 {
+				var res *cliproxyexecutor.StreamResult
+				res, err = mgr.ExecuteStream(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "stress-model"}, cliproxyexecutor.Options{})
+				if err == nil {
+					for range res.Chunks {
+					}
+				}
+			} else {
+				_, err = mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "stress-model"}, cliproxyexecutor.Options{})
+			}
+			if err != nil {
+				failed.Add(1)
+				firstErr <- err
+				return
+			}
+			succeeded.Add(1)
+		}(i)
+	}
+
+	wg.Wait()
+	close(stopMonitor)
+	<-monitorDone
+
+	if got := failed.Load(); got != 0 {
+		t.Fatalf("%d/%d requests failed under overload; first error: %v", got, numWorkers, <-firstErr)
+	}
+	if got := succeeded.Load(); got != numWorkers {
+		t.Fatalf("expected %d successful requests, got %d", numWorkers, got)
+	}
+	if peak := peakInFlight.Load(); peak > limitPerAccount {
+		t.Fatalf("peak in-flight %d exceeded limit %d", peak, limitPerAccount)
+	}
+	if inFlight := limiter.GetInFlight(auth.ID); inFlight != 0 {
+		t.Fatalf("residual in-flight = %d, expected 0", inFlight)
+	}
+	if depth := limiter.QueueDepth(auth.ID); depth != 0 {
+		t.Fatalf("residual queue depth = %d, expected 0", depth)
+	}
+	t.Logf("overload stress finished: %d requests served through %d slots, peak in-flight %d", numWorkers, limitPerAccount, peakInFlight.Load())
+}
+
+// TestAccountConcurrency_QueueDepthShedsLoad checks the safety valve: with a
+// bounded queue, excess requests are rejected quickly instead of piling up.
+func TestAccountConcurrency_QueueDepthShedsLoad(t *testing.T) {
+	mgr := NewManager(nil, &RoundRobinSelector{}, nil)
+	mgr.SetAccountConcurrencyConfig(10*time.Second, 2)
+
+	auth := &Auth{
+		ID:         "auth-shed",
+		Provider:   "blocking",
+		Status:     StatusActive,
+		Attributes: map[string]string{"concurrency_limit": "1"},
+	}
+	if _, err := mgr.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	mgr.RegisterExecutor(&stressDelayExecutor{minDelay: 40 * time.Millisecond, maxDelay: 60 * time.Millisecond})
+
+	const numWorkers = 24
+	var wg sync.WaitGroup
+	var succeeded, shed atomic.Int32
+	wg.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := mgr.Execute(context.Background(), []string{"blocking"}, cliproxyexecutor.Request{Model: "stress-model"}, cliproxyexecutor.Options{})
+			if err == nil {
+				succeeded.Add(1)
+				return
+			}
+			if !errors.Is(err, ErrAccountConcurrencyExceeded) {
+				t.Errorf("unexpected shed reason: %v", err)
+				return
+			}
+			if status := statusCodeFromError(err); status != http.StatusTooManyRequests {
+				t.Errorf("shed request reported status %d, want 429", status)
+			}
+			shed.Add(1)
+		}()
+	}
+	wg.Wait()
+
+	if shed.Load() == 0 {
+		t.Fatal("expected the bounded queue to shed load, nothing was rejected")
+	}
+	if succeeded.Load() == 0 {
+		t.Fatal("expected queued requests to still be served")
+	}
+	if inFlight := mgr.ConcurrencyLimiter().GetInFlight(auth.ID); inFlight != 0 {
+		t.Fatalf("residual in-flight = %d, expected 0", inFlight)
+	}
+	if depth := mgr.ConcurrencyLimiter().QueueDepth(auth.ID); depth != 0 {
+		t.Fatalf("residual queue depth = %d, expected 0", depth)
+	}
+	t.Logf("queue-depth shedding: served=%d shed=%d", succeeded.Load(), shed.Load())
 }
 
 type stressDelayExecutor struct {

--- a/sdk/cliproxy/auth/account_concurrency_test.go
+++ b/sdk/cliproxy/auth/account_concurrency_test.go
@@ -269,6 +269,9 @@ func TestManagerExecute_AccountConcurrencyFailover(t *testing.T) {
 
 func TestManagerExecuteStream_AccountConcurrencySlotLifecycle(t *testing.T) {
 	mgr := NewManager(nil, &FillFirstSelector{}, nil)
+	// This case asserts slot lifecycle, not queuing: with queuing off the second
+	// request reports saturation immediately instead of waiting out the timeout.
+	mgr.SetAccountConcurrencyConfig(0, 0)
 
 	auth := &Auth{
 		ID:         "auth-stream-1",

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -172,6 +172,12 @@ type Manager struct {
 	requestRetry     atomic.Int32
 	maxRetryInterval atomic.Int64
 
+	// accountConcurrencyWait is how long a request may queue for a saturated
+	// account before failing, in nanoseconds. Zero disables queuing.
+	accountConcurrencyWait atomic.Int64
+	// accountConcurrencyQueueDepth caps queued requests per account. Zero means unlimited.
+	accountConcurrencyQueueDepth atomic.Int32
+
 	// oauthModelAlias stores tenant -> channel -> alias mappings used during OAuth execution.
 	oauthModelAlias atomic.Value
 
@@ -243,6 +249,9 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 		refreshSemaphore:      make(chan struct{}, refreshMaxConcurrency),
 		quotaProbeAfter:       make(map[string]time.Time),
 	}
+	// Hosts that never call SetAccountConcurrencyConfig still get queuing rather
+	// than hard failures on a busy account.
+	manager.accountConcurrencyWait.Store(DefaultAccountConcurrencyWait.Nanoseconds())
 	// Sticky delegates new conversations to whichever distribution the group
 	// configures, so it needs to reach the manager's singleton selectors.
 	sessionStickySelector.distribution = func(name string) Selector {
@@ -291,4 +300,16 @@ func (m *Manager) acquireAccountSlot(auth *Auth) (func(), error) {
 		return func() {}, nil
 	}
 	return m.concurrencyLimiter.AcquireSlot(auth)
+}
+
+// waitAccountSlot queues for a slot on any of the given auths. It is the fallback
+// used once every candidate is saturated, so a burst does not fail requests that
+// a short wait could serve.
+func (m *Manager) waitAccountSlot(ctx context.Context, auths []*Auth) (func(), string, error) {
+	if m == nil || m.concurrencyLimiter == nil || len(auths) == 0 {
+		return nil, "", ErrAccountConcurrencyExceeded
+	}
+	timeout := time.Duration(m.accountConcurrencyWait.Load())
+	maxQueueDepth := int(m.accountConcurrencyQueueDepth.Load())
+	return m.concurrencyLimiter.AcquireSlotWait(ctx, auths, timeout, maxQueueDepth)
 }

--- a/sdk/cliproxy/auth/conductor_execution_service.go
+++ b/sdk/cliproxy/auth/conductor_execution_service.go
@@ -2,11 +2,16 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 )
+
+// errNoSaturatedCandidate marks "there was nothing to queue on", which is an
+// internal control signal rather than the reason a request failed.
+var errNoSaturatedCandidate = errors.New("no saturated candidate to wait for")
 
 type executionService struct {
 	manager *Manager
@@ -18,6 +23,13 @@ type mixedExecutionScope struct {
 	opts            cliproxyexecutor.Options
 	singlePickRoute bool
 	tried           map[string]struct{}
+	// saturated collects candidates skipped because their account was already at
+	// its concurrency limit. Once no idle candidate is left they become the queue
+	// this request waits on.
+	saturated []*mixedExecutionCandidate
+	// lastErr keeps the most recent failover reason so an exhausted candidate list
+	// reports why every candidate was rejected instead of a generic "no auth".
+	lastErr error
 }
 
 type mixedExecutionCandidate struct {
@@ -91,23 +103,10 @@ func (s executionService) executeMixedOnce(ctx context.Context, providers []stri
 		return cliproxyexecutor.Response{}, err
 	}
 
-	var lastErr error
 	for {
-		candidate, errPick := s.nextMixedCandidate(ctx, &scope, req)
-		if errPick != nil {
-			return cliproxyexecutor.Response{}, resolveMixedPickError(lastErr, errPick)
-		}
-		if errModeration := s.manager.moderateRequest(candidate.execCtx, candidate.auth, scope.opts); errModeration != nil {
-			return cliproxyexecutor.Response{}, errModeration
-		}
-
-		releaseSlot, errSlot := s.manager.acquireAccountSlot(candidate.auth)
-		if errSlot != nil {
-			if isRequestInvalidError(errSlot) || scope.singlePickRoute {
-				return cliproxyexecutor.Response{}, errSlot
-			}
-			lastErr = errSlot
-			continue
+		candidate, releaseSlot, errReady := s.nextReadyCandidate(ctx, &scope, req)
+		if errReady != nil {
+			return cliproxyexecutor.Response{}, errReady
 		}
 
 		resp, errExec := candidate.executor.Execute(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)
@@ -131,7 +130,7 @@ func (s executionService) executeMixedOnce(ctx context.Context, providers []stri
 			if isRequestInvalidError(errExec) || scope.singlePickRoute {
 				return cliproxyexecutor.Response{}, errExec
 			}
-			lastErr = errExec
+			scope.lastErr = errExec
 			continue
 		}
 
@@ -147,23 +146,10 @@ func (s executionService) executeCountMixedOnce(ctx context.Context, providers [
 		return cliproxyexecutor.Response{}, err
 	}
 
-	var lastErr error
 	for {
-		candidate, errPick := s.nextMixedCandidate(ctx, &scope, req)
-		if errPick != nil {
-			return cliproxyexecutor.Response{}, resolveMixedPickError(lastErr, errPick)
-		}
-		if errModeration := s.manager.moderateRequest(candidate.execCtx, candidate.auth, scope.opts); errModeration != nil {
-			return cliproxyexecutor.Response{}, errModeration
-		}
-
-		releaseSlot, errSlot := s.manager.acquireAccountSlot(candidate.auth)
-		if errSlot != nil {
-			if isRequestInvalidError(errSlot) || scope.singlePickRoute {
-				return cliproxyexecutor.Response{}, errSlot
-			}
-			lastErr = errSlot
-			continue
+		candidate, releaseSlot, errReady := s.nextReadyCandidate(ctx, &scope, req)
+		if errReady != nil {
+			return cliproxyexecutor.Response{}, errReady
 		}
 
 		resp, errExec := candidate.executor.CountTokens(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)
@@ -175,7 +161,7 @@ func (s executionService) executeCountMixedOnce(ctx context.Context, providers [
 			if isRequestInvalidError(errExec) || scope.singlePickRoute {
 				return cliproxyexecutor.Response{}, errExec
 			}
-			lastErr = errExec
+			scope.lastErr = errExec
 			continue
 		}
 
@@ -189,23 +175,10 @@ func (s executionService) executeStreamMixedOnce(ctx context.Context, providers 
 		return nil, err
 	}
 
-	var lastErr error
 	for {
-		candidate, errPick := s.nextMixedCandidate(ctx, &scope, req)
-		if errPick != nil {
-			return nil, resolveMixedPickError(lastErr, errPick)
-		}
-		if errModeration := s.manager.moderateRequest(candidate.execCtx, candidate.auth, scope.opts); errModeration != nil {
-			return nil, errModeration
-		}
-
-		releaseSlot, errSlot := s.manager.acquireAccountSlot(candidate.auth)
-		if errSlot != nil {
-			if isRequestInvalidError(errSlot) || scope.singlePickRoute {
-				return nil, errSlot
-			}
-			lastErr = errSlot
-			continue
+		candidate, releaseSlot, errReady := s.nextReadyCandidate(ctx, &scope, req)
+		if errReady != nil {
+			return nil, errReady
 		}
 
 		streamResult, errStream := candidate.executor.ExecuteStream(candidate.execCtx, candidate.auth, candidate.execReq, scope.opts)
@@ -228,7 +201,7 @@ func (s executionService) executeStreamMixedOnce(ctx context.Context, providers 
 			if isRequestInvalidError(errStream) || scope.singlePickRoute {
 				return nil, errStream
 			}
-			lastErr = errStream
+			scope.lastErr = errStream
 			continue
 		}
 
@@ -251,6 +224,72 @@ func (s executionService) newMixedScope(providers []string, req cliproxyexecutor
 		singlePickRoute: isSinglePickRouteRequest(opts.Metadata),
 		tried:           make(map[string]struct{}),
 	}, nil
+}
+
+// nextReadyCandidate returns the next candidate that already owns a concurrency
+// slot, along with the release function the caller must invoke.
+//
+// Idle accounts are taken immediately so a healthy pool keeps its low latency.
+// Only when every candidate is saturated does the request queue on them, which is
+// what makes a per-account limit a throttle instead of an error: a single-pick
+// route (pinned auth or sticky session) has nowhere to fail over to, so failing
+// fast there would reject requests the account could serve moments later.
+func (s executionService) nextReadyCandidate(ctx context.Context, scope *mixedExecutionScope, req cliproxyexecutor.Request) (*mixedExecutionCandidate, func(), error) {
+	for {
+		candidate, errPick := s.nextMixedCandidate(ctx, scope, req)
+		if errPick != nil {
+			queued, releaseSlot, errWait := s.waitForSaturatedSlot(ctx, scope)
+			if errWait == nil {
+				return queued, releaseSlot, nil
+			}
+			if !errors.Is(errWait, errNoSaturatedCandidate) {
+				scope.lastErr = errWait
+			}
+			return nil, nil, resolveMixedPickError(scope.lastErr, errPick)
+		}
+		if errModeration := s.manager.moderateRequest(candidate.execCtx, candidate.auth, scope.opts); errModeration != nil {
+			return nil, nil, errModeration
+		}
+
+		releaseSlot, errSlot := s.manager.acquireAccountSlot(candidate.auth)
+		if errSlot == nil {
+			return candidate, releaseSlot, nil
+		}
+		if isRequestInvalidError(errSlot) {
+			return nil, nil, errSlot
+		}
+		scope.saturated = append(scope.saturated, candidate)
+		scope.lastErr = errSlot
+	}
+}
+
+// waitForSaturatedSlot queues on every candidate that was skipped for being at its
+// concurrency limit and resumes with whichever frees a slot first.
+func (s executionService) waitForSaturatedSlot(ctx context.Context, scope *mixedExecutionScope) (*mixedExecutionCandidate, func(), error) {
+	if len(scope.saturated) == 0 {
+		return nil, nil, errNoSaturatedCandidate
+	}
+	auths := make([]*Auth, 0, len(scope.saturated))
+	for _, candidate := range scope.saturated {
+		auths = append(auths, candidate.auth)
+	}
+	releaseSlot, authID, err := s.manager.waitAccountSlot(ctx, auths)
+	if err != nil {
+		return nil, nil, err
+	}
+	for i, candidate := range scope.saturated {
+		if candidate.auth.ID != authID {
+			continue
+		}
+		// Consume the entry: an account that has had its turn must not be queued
+		// for again, otherwise a candidate whose request keeps failing would loop
+		// through the queue instead of failing over or giving up.
+		scope.saturated = append(scope.saturated[:i], scope.saturated[i+1:]...)
+		return candidate, releaseSlot, nil
+	}
+	// Unreachable in practice; release rather than leak the slot we were granted.
+	releaseSlot()
+	return nil, nil, errNoSaturatedCandidate
 }
 
 func (s executionService) nextMixedCandidate(ctx context.Context, scope *mixedExecutionScope, req cliproxyexecutor.Request) (*mixedExecutionCandidate, error) {

--- a/sdk/cliproxy/auth/conductor_runtime_config.go
+++ b/sdk/cliproxy/auth/conductor_runtime_config.go
@@ -217,3 +217,20 @@ func (m *Manager) SetRetryConfig(retry int, maxRetryInterval time.Duration) {
 	m.requestRetry.Store(int32(retry))
 	m.maxRetryInterval.Store(maxRetryInterval.Nanoseconds())
 }
+
+// SetAccountConcurrencyConfig updates how requests queue for accounts that are at
+// their concurrency limit. A waitTimeout of 0 disables queuing and restores
+// fail-fast behavior; maxQueueDepth of 0 leaves the per-account queue unbounded.
+func (m *Manager) SetAccountConcurrencyConfig(waitTimeout time.Duration, maxQueueDepth int) {
+	if m == nil {
+		return
+	}
+	if waitTimeout < 0 {
+		waitTimeout = 0
+	}
+	if maxQueueDepth < 0 {
+		maxQueueDepth = 0
+	}
+	m.accountConcurrencyWait.Store(waitTimeout.Nanoseconds())
+	m.accountConcurrencyQueueDepth.Store(int32(maxQueueDepth))
+}

--- a/sdk/cliproxy/service_config_reload.go
+++ b/sdk/cliproxy/service_config_reload.go
@@ -34,6 +34,7 @@ func (s *Service) applyRetryConfig(cfg *config.Config) {
 	}
 	maxInterval := time.Duration(cfg.MaxRetryInterval) * time.Second
 	s.coreManager.SetRetryConfig(cfg.RequestRetry, maxInterval)
+	s.coreManager.SetAccountConcurrencyConfig(cfg.AccountConcurrency.WaitTimeout(), cfg.AccountConcurrency.QueueDepth())
 }
 
 func (s *Service) applyConfigReload(newCfg *config.Config, refreshRegisteredModels bool) {


### PR DESCRIPTION
## 问题

账号达到 `concurrency_limit` 后，请求当场失败，不排队。

- 选号阶段会过滤掉饱和账号，但候选只剩一个（或全部饱和）时过滤不生效，必定选中一个满的号；
- `AcquireSlot` 满了立刻返回错误，没有等待;
- 单账号路由（pin 账号 / 会话粘性）没有别的号可换，超出上限的下一个请求直接失败；
- 该错误没有实现 `StatusCode()`，在 handler 里落进 default 分支，客户端收到的是 **500 `internal_server_error`** —— 账号其实只是忙，客户端却以为代理挂了，也不会做限流退避。

线上现象：

```
{"error":{"message":"account concurrency limit exceeded: account <id>/<file> active=3 max=3","type":"server_error","code":"internal_server_error"}}
```

## 改动

**队列原语**（`sdk/cliproxy/auth/account_concurrency_queue.go`，新增）

- 每账号一条 FIFO 等待队列；`ReleaseSlot` 把释放的槽位**直接交接**给排队最久的调用方，而不是释放后重新竞争 —— 否则持续涌入的新请求会不断插队，排队的请求会被饿死。
- 一个等待者可同时挂在多个账号队列上，谁先空出槽位就在谁那里恢复；拿到槽位后从其余队列注销。
- 账号上限被调小时不交接、改为 drain，避免在途数长期高于新上限。
- 等待有界且可取消：超时、`context` 取消（客户端断开）都会立即离队。授予与放弃的竞态由 `claimed` CAS 保证只有一方成功；放弃方若发现槽位已交接给自己，必须接收，否则会永久泄漏在途容量。

**执行链路**（`sdk/cliproxy/auth/conductor_execution_service.go`）

- 抽出 `nextReadyCandidate`，三条执行路径（非流式 / 流式 / count-tokens）共用：空闲账号立即使用，**只有全部候选饱和才排队**，failover 仍然优先于等待。
- 拿到排队槽位的账号会从待排队列表中移除，避免上游持续失败时反复排队造成死循环。

**配置**（`internal/config/account_concurrency.go`，新增）

```yaml
account-concurrency:
  wait-timeout-seconds: 30  # 省略即取默认 30；设 0 恢复原来的立即失败
  max-queue-depth: 0        # 每账号排队上限，0 不限；上游卡死时用来削峰
```

支持热重载（`server_config_reload.go` / `service_config_reload.go` 均已接线）。

**状态码**

排队超时返回的 `*AccountConcurrencyError` 实现 `StatusCode() 429`，并 `Unwrap` 到原 sentinel，`errors.Is(err, ErrAccountConcurrencyExceeded)` 保持可用。handler 通过裸类型断言取状态码，已补测试确认错误不会在返回途中被包装。

## 兼容性

- 默认行为变化：账号满时从「立即失败」变为「最多排队 30 秒」。需要旧行为的部署设 `account-concurrency.wait-timeout-seconds: 0`。
- 排队失败的响应码从 500 变为 429。
- 账号满时不再写 `MarkResult`，不影响账号健康状态与冷却（与改动前一致）。

## 测试

新增 23 个用例：

- **队列原语（10）**：排队直到释放、超时报 429、ctx 取消、FIFO 顺序、多账号等待任一、`timeout=0` 快速失败、队列深度上限、上限调小后不交接、无限额账号不排队、**授予/放弃竞态 300 轮不泄漏槽位与队列**。
- **执行链路（7）**：全饱和时排队并最终成功、超时报 429（含 HTTP 层取值方式）、客户端断开立即离队、有空闲号时不排队、流式关闭后队列恢复、count-tokens 排队、**上游失败后不重复排队**（该用例已验证：移除修复即失败）。
- **配置（4）**：默认值、显式 0 关闭、自定义值、负数收敛。
- **压力（2）**：120 个并发请求跑通 2 个槽位，**零拒绝**、峰值不超限、结束后在途与队列均归零；有界队列削峰。

### 执行的命令

- `./scripts/ci-pr.sh` → exit 0（结构检查、gofmt、secret scan、`go test ./...`、golangci-lint、build 全绿）
- `go test ./sdk/cliproxy/auth/ -race` → ok
- `go test ./sdk/cliproxy/auth/ -run "TestAcquireSlotWait|TestReleaseSlot" -race -count=2` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)