### PR TITLE
feat(codex): register the GPT Image 2.5 pair and open the images endpoint to the family

### DIFF
--- a/internal/registry/image_generation_models.go
+++ b/internal/registry/image_generation_models.go
@@ -28,6 +28,20 @@ var imageGenerationModels = map[string]imageGenerationModelDefaults{
 		PricePerCall: 0.04,
 		Description:  "Image generation model billed per invocation",
 	},
+	// OpenAI prices the 2.5 pair per token rather than per image ($5/M text in,
+	// $8/M image in, $30/M image out) and states its token rates match GPT Image 2.
+	// Per-call is the only mode this struct expresses, so they inherit the 2 rate:
+	// on the subscription channel the request is billed against the plan anyway, and
+	// on any channel that later serves 2.5 natively the upstream response carries a
+	// real usage block for reporting to use.
+	"gpt-image-2.5-flare": {
+		PricePerCall: 0.04,
+		Description:  "GPT Image 2.5 Flare, billed per invocation",
+	},
+	"gpt-image-2.5-sunburst": {
+		PricePerCall: 0.04,
+		Description:  "GPT Image 2.5 Sunburst, billed per invocation",
+	},
 	// Grok Imagine. These two ids are what api.x.ai actually serves; earlier
 	// revisions also listed grok-imagine-image-pro and grok-2-image-1212, taken
 	// from a third-party model list and never present in the live catalog, so

--- a/internal/registry/image_generation_models_test.go
+++ b/internal/registry/image_generation_models_test.go
@@ -1,6 +1,9 @@
 package registry
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestIsImageGenerationModel(t *testing.T) {
 	imageModels := []string{
@@ -231,6 +234,50 @@ func TestMiniMaxDoesNotAdvertiseUndocumentedTextToImageModels(t *testing.T) {
 			if model.ID == id {
 				t.Errorf("unsupported static model: %s", id)
 			}
+		}
+	}
+}
+
+// TestGPTImage25ModelsAreRegistered covers the 2.5 pair reaching every surface a
+// selectable image model has to appear on: the codex catalog, the classifier, the
+// provider mapping, edit support, and the console listing.
+func TestGPTImage25ModelsAreRegistered(t *testing.T) {
+	wanted := []string{"gpt-image-2.5-flare", "gpt-image-2.5-sunburst"}
+
+	registered := make(map[string]*ModelInfo)
+	for _, model := range GetOpenAIModels() {
+		registered[model.ID] = model
+	}
+	listed := make(map[string]ImageGenerationModel)
+	for _, model := range ListImageGenerationModels() {
+		listed[model.ID] = model
+	}
+
+	for _, modelID := range wanted {
+		info, ok := registered[modelID]
+		if !ok {
+			t.Errorf("%s is missing from the codex static catalog", modelID)
+			continue
+		}
+		// The panel shows this text; it must keep saying the subscription channel
+		// still renders 2.0, because upstream ignores the model field there.
+		if !strings.Contains(info.Description, "GPT Image 2.0") {
+			t.Errorf("%s description should disclose the 2.0 downgrade, got %q", modelID, info.Description)
+		}
+		if !IsImageGenerationModel(modelID) {
+			t.Errorf("IsImageGenerationModel(%q) = false, want true", modelID)
+		}
+		if got := ImageGenerationProvider(modelID); got != ImageProviderCodex {
+			t.Errorf("ImageGenerationProvider(%q) = %q, want %q", modelID, got, ImageProviderCodex)
+		}
+		if !SupportsImageEditing(modelID) {
+			t.Errorf("SupportsImageEditing(%q) = false, want true", modelID)
+		}
+		if _, _, ok := ImageGenerationModelDefaults(modelID); !ok {
+			t.Errorf("%s has no billing defaults, so it would be billed per token", modelID)
+		}
+		if _, ok := listed[modelID]; !ok {
+			t.Errorf("%s is absent from ListImageGenerationModels", modelID)
 		}
 	}
 }

--- a/internal/registry/model_definitions_image_data.go
+++ b/internal/registry/model_definitions_image_data.go
@@ -9,7 +9,17 @@ package registry
 // interpret them means adding a model is one file, not two.
 
 // getOpenAIImageModelDefinitions returns OpenAI image-generation models.
+//
+// The 2.5 pair is registered ahead of the subscription channel actually serving it.
+// chatgpt.com/backend-api/codex/images/generations ignores the model field outright
+// — sending gpt-image-2.5-flare, gpt-image-2, or a model id that does not exist at
+// all each return 200 with C2PA content credentials reading "gpt-image version
+// 2.0". Registering them makes the ids selectable and routable now, and they start
+// producing 2.5 output on their own the day upstream honours the field. Until then
+// the descriptions say so outright, because a silently downgraded model is worse to
+// debug than one that fails.
 func getOpenAIImageModelDefinitions() []*ModelInfo {
+	imageParameters := []string{"prompt", "size", "n", "response_format", "quality"}
 	return []*ModelInfo{
 		{
 			ID:                  "gpt-image-2",
@@ -20,6 +30,26 @@ func getOpenAIImageModelDefinitions() []*ModelInfo {
 			DisplayName:         "GPT Image 2",
 			Description:         "Text-to-image generation model.",
 			SupportedParameters: []string{"prompt", "size", "n", "response_format"},
+		},
+		{
+			ID:                  "gpt-image-2.5-flare",
+			Object:              "model",
+			OwnedBy:             "openai",
+			Type:                "openai",
+			Version:             "gpt-image-2.5-flare-2026-09-08",
+			DisplayName:         "GPT Image 2.5 Flare",
+			Description:         "Text-to-image generation, faster and higher quality than GPT Image 2. Note: the Codex subscription channel currently ignores the image model field and still renders GPT Image 2.0.",
+			SupportedParameters: imageParameters,
+		},
+		{
+			ID:                  "gpt-image-2.5-sunburst",
+			Object:              "model",
+			OwnedBy:             "openai",
+			Type:                "openai",
+			Version:             "gpt-image-2.5-sunburst-2026-09-08",
+			DisplayName:         "GPT Image 2.5 Sunburst",
+			Description:         "Text-to-image generation tuned for edit precision. Note: the Codex subscription channel currently ignores the image model field and still renders GPT Image 2.0.",
+			SupportedParameters: imageParameters,
 		},
 	}
 }

--- a/internal/runtime/executor/codex_image_model_family_test.go
+++ b/internal/runtime/executor/codex_image_model_family_test.go
@@ -1,0 +1,100 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// TestParseCodexImageRequestAcceptsImageFamily is the gate that used to reject
+// anything but one model id. A new gpt-image release was turned away here, before
+// upstream ever saw the request, which is not this layer's call to make.
+func TestParseCodexImageRequestAcceptsImageFamily(t *testing.T) {
+	accepted := []string{
+		"gpt-image-2",
+		"gpt-image-2.5-flare",
+		"gpt-image-2.5-sunburst",
+		// Not in the catalog: the prefix classifier still routes it, so a future
+		// release is servable without a code change.
+		"gpt-image-3",
+		"GPT-Image-2.5-Flare",
+	}
+	for _, model := range accepted {
+		parsed, err := parseCodexImageRequest([]byte(`{"model":"` + model + `","prompt":"draw a fox"}`))
+		if err != nil {
+			t.Fatalf("parseCodexImageRequest(%q) error = %v, want it accepted", model, err)
+		}
+		if parsed.Model != model {
+			t.Fatalf("parsed model = %q, want %q preserved verbatim", parsed.Model, model)
+		}
+	}
+
+	rejected := []string{
+		"gpt-5.5",                // chat model, wrong endpoint
+		"grok-imagine-image",     // image model, but served by the xAI pool
+		"definitely-not-a-model", // nonsense
+		"gpt-image",              // family root, not a model id upstream serves
+	}
+	for _, model := range rejected {
+		if _, err := parseCodexImageRequest([]byte(`{"model":"` + model + `","prompt":"x"}`)); err == nil {
+			t.Fatalf("parseCodexImageRequest(%q) = nil error, want rejection", model)
+		}
+	}
+
+	// An omitted model still defaults, so existing clients are unaffected.
+	parsed, err := parseCodexImageRequest([]byte(`{"prompt":"draw a fox"}`))
+	if err != nil {
+		t.Fatalf("parseCodexImageRequest() error = %v", err)
+	}
+	if parsed.Model != codexImageModel {
+		t.Fatalf("default model = %q, want %q", parsed.Model, codexImageModel)
+	}
+}
+
+// TestCodexImageRequestAcceptsExtendedQuality covers the levels 2.5 added. Refusing
+// them locally would fail a request the proxy has no basis to refuse.
+func TestCodexImageRequestAcceptsExtendedQuality(t *testing.T) {
+	for _, quality := range []string{"low", "medium", "high", "xhigh", "max", "auto", "AUTO"} {
+		parsed, err := parseCodexImageRequest([]byte(`{"model":"gpt-image-2.5-flare","prompt":"x","quality":"` + quality + `"}`))
+		if err != nil {
+			t.Fatalf("quality %q rejected: %v", quality, err)
+		}
+		if parsed.Quality != strings.ToLower(quality) {
+			t.Fatalf("parsed quality = %q, want %q", parsed.Quality, strings.ToLower(quality))
+		}
+	}
+	if _, err := parseCodexImageRequest([]byte(`{"model":"gpt-image-2","prompt":"x","quality":"ultra"}`)); err == nil {
+		t.Fatal("quality \"ultra\" accepted, want rejection")
+	}
+}
+
+// TestBuildCodexImageResponsesRequestForwardsSelectedModel proves the caller's
+// choice reaches the tool payload instead of being overwritten by the default.
+// Without this the 2.5 ids would be selectable but never actually sent.
+func TestBuildCodexImageResponsesRequestForwardsSelectedModel(t *testing.T) {
+	for _, model := range []string{"gpt-image-2", "gpt-image-2.5-flare", "gpt-image-2.5-sunburst"} {
+		parsed := &codexImageRequest{Model: model, Prompt: "draw a fox", N: 1}
+		body, err := buildCodexImageResponsesRequest(parsed, codexImageToolModel(parsed), "gpt-5.5")
+		if err != nil {
+			t.Fatalf("buildCodexImageResponsesRequest(%q) error = %v", model, err)
+		}
+		if got := gjson.GetBytes(body, "tools.0.model").String(); got != model {
+			t.Fatalf("tools.0.model = %q, want the selected model %q", got, model)
+		}
+		if got := gjson.GetBytes(body, "model").String(); got != "gpt-5.5" {
+			t.Fatalf("carrier model = %q, want it untouched by the image model", got)
+		}
+	}
+
+	// A request with no model still sends the default rather than an empty string,
+	// which upstream rejects as an invalid model.
+	parsed := &codexImageRequest{Prompt: "draw a fox", N: 1}
+	body, err := buildCodexImageResponsesRequest(parsed, codexImageToolModel(parsed), "gpt-5.5")
+	if err != nil {
+		t.Fatalf("buildCodexImageResponsesRequest() error = %v", err)
+	}
+	if got := gjson.GetBytes(body, "tools.0.model").String(); got != codexImageModel {
+		t.Fatalf("tools.0.model = %q, want the default %q", got, codexImageModel)
+	}
+}

--- a/internal/runtime/executor/codex_image_request.go
+++ b/internal/runtime/executor/codex_image_request.go
@@ -7,9 +7,28 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+// isCodexImageFamilyModel reports whether a model on the /v1/images endpoints is an
+// image model this credential pool serves.
+//
+// Classification comes from the registry rather than a list kept here, so adding a
+// model to the static catalog is enough to make it routable. Pinning a single id at
+// this gate meant every new gpt-image release was rejected by the proxy before
+// upstream ever saw it, which is not a judgement this layer should be making.
+func isCodexImageFamilyModel(model string) bool {
+	trimmed := strings.TrimSpace(model)
+	if trimmed == "" {
+		return false
+	}
+	if !registry.IsImageGenerationModel(trimmed) {
+		return false
+	}
+	return strings.EqualFold(registry.ImageGenerationProvider(trimmed), registry.ImageProviderCodex)
+}
 
 func parseCodexImageRequest(body []byte) (*codexImageRequest, error) {
 	if len(body) == 0 {
@@ -22,7 +41,11 @@ func parseCodexImageRequest(body []byte) (*codexImageRequest, error) {
 	if model == "" {
 		model = codexImageModel
 	}
-	if model != codexImageModel {
+	// Admit the whole Codex image family rather than one id. Pinning a single
+	// constant here meant every new gpt-image release was rejected by this proxy
+	// before upstream ever saw it, which is not a judgement this layer should be
+	// making: whether an account can serve a given image model is upstream's answer.
+	if !isCodexImageFamilyModel(model) {
 		return nil, fmt.Errorf("model %q is not supported by this endpoint", model)
 	}
 	prompt := strings.TrimSpace(gjson.GetBytes(body, "prompt").String())
@@ -58,7 +81,7 @@ func parseCodexImageRequest(body []byte) (*codexImageRequest, error) {
 	}
 	parsed.Quality = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "quality").String()))
 	if parsed.Quality != "" && !isSupportedCodexImageQuality(parsed.Quality) {
-		return nil, fmt.Errorf("quality must be one of low, medium, high")
+		return nil, fmt.Errorf("quality must be one of low, medium, high, xhigh, max, auto")
 	}
 	parsed.Background = strings.TrimSpace(gjson.GetBytes(body, "background").String())
 	parsed.OutputFormat = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "output_format").String()))
@@ -183,9 +206,13 @@ func isValidCodexImageSize(size string) bool {
 	return codexImageSizePattern.MatchString(strings.ToLower(strings.TrimSpace(size)))
 }
 
+// isSupportedCodexImageQuality accepts the quality levels the GPT Image family
+// documents. xhigh, max and auto arrived with 2.5; rejecting them locally would
+// fail a request this proxy has no reason to refuse, since the endpoint decides
+// what it honours. (Today it honours none of them and echoes back "low".)
 func isSupportedCodexImageQuality(quality string) bool {
 	switch strings.ToLower(strings.TrimSpace(quality)) {
-	case "low", "medium", "high":
+	case "low", "medium", "high", "xhigh", "max", "auto":
 		return true
 	default:
 		return false

--- a/internal/runtime/executor/codex_image_responses.go
+++ b/internal/runtime/executor/codex_image_responses.go
@@ -32,7 +32,11 @@ func (e *CodexExecutor) executeCodexImageViaResponses(
 	if baseURL == "" {
 		baseURL = "https://chatgpt.com/backend-api/codex"
 	}
-	body, err := buildCodexImageResponsesRequest(parsed, codexImageModel, e.resolveCodexImageBaseModel())
+	// The caller's image model is forwarded rather than the compiled-in default, so
+	// selecting gpt-image-2.5-* actually reaches upstream. Upstream currently ignores
+	// this field on the subscription channel, which is why the catalog descriptions
+	// say so; sending it anyway is what makes the ids work the moment that changes.
+	body, err := buildCodexImageResponsesRequest(parsed, codexImageToolModel(parsed), e.resolveCodexImageBaseModel())
 	if err != nil {
 		return nil, nil, statusErr{code: http.StatusBadRequest, msg: err.Error()}
 	}
@@ -94,6 +98,18 @@ func (e *CodexExecutor) executeCodexImageViaResponses(
 		return nil, nil, lastErr
 	}
 	return nil, nil, statusErr{code: http.StatusBadGateway, msg: "responses image request failed"}
+}
+
+// codexImageToolModel resolves the image model to attach to the image_generation
+// tool, falling back to the compiled-in default when a caller omitted it.
+func codexImageToolModel(parsed *codexImageRequest) string {
+	if parsed == nil {
+		return codexImageModel
+	}
+	if model := strings.TrimSpace(parsed.Model); model != "" {
+		return model
+	}
+	return codexImageModel
 }
 
 func buildCodexImageResponsesRequest(parsed *codexImageRequest, toolModel string, baseModel string) ([]byte, error) {


### PR DESCRIPTION
接入 gpt-image-2.5-flare / gpt-image-2.5-sunburst（2026-09-08 发布）。前端配套 PR：[kittors/codeProxy#1001](https://github.com/kittors/codeProxy/pull/1001)。

## 光注册是不够的，有两处会把它挡掉

**1. `/v1/images/{generations,edits}` 的准入是单常量比对**

```go
if model != codexImageModel {   // codexImageModel = "gpt-image-2"
    return nil, fmt.Errorf("model %q is not supported by this endpoint", model)
}
```

任何新的 gpt-image 版本在到达上游之前就被代理层拒了 —— 这不该是这一层做的判断。现在改成由 registry 分类器 + provider 映射决定，`gpt-image-3` 将来无需改代码即可路由。

**2. image_generation 工具永远用编译期常量构造**

即使选了 2.5，出站时也被替换回 `gpt-image-2`。现在转发调用方选择的模型。

## 其余改动

- 静态目录注册两个模型 → 自动进入 DB seed（模型库）、catalog、模型广场、账号「模型」tab、图像生成页选择器
- 计价：沿用 gpt-image-2 的按次费率（官方说明 2.5 的 token 费率与 2 一致；本结构只表达按次）
- quality 放宽到 `low/medium/high/xhigh/max/auto`

## 已知限制（已写进模型描述）

Codex 订阅通道当前**完全忽略** image model 字段。实测传 `gpt-image-2.5-flare`、`gpt-image-2`、乃至一个根本不存在的模型名，都返回 200，且图片的 C2PA 内容凭证均为 `gpt-image version 2.0`。

这两个 id 是前置注册：上游哪天开始认这个字段，它们无需再改任何代码就会输出真正的 2.5。两个模型的 Description 都显式写明了这一点，避免运维对着「2.5 怎么看起来像 2」排查。

## 验证

`./scripts/ci-pr.sh` — exit 0。

新增测试：
- `TestGPTImage25ModelsAreRegistered` — 目录、分类器、provider 映射、编辑支持、计价、控制台列表，以及描述必须披露 2.0 降级
- `TestParseCodexImageRequestAcceptsImageFamily` — 接受整个 codex 图像家族（含未注册的 `gpt-image-3`），拒绝 chat 模型与 xAI 图像模型，省略 model 时仍走默认
- `TestCodexImageRequestAcceptsExtendedQuality` — 六档质量
- `TestBuildCodexImageResponsesRequestForwardsSelectedModel` — 所选模型真的进入 `tools.0.model`，且不污染承载模型