### PR TITLE
fix(modelconfig): seed image and video models into every tenant, not just the system one

### DIFF
--- a/internal/storage/sqlstore/modelconfig/store.go
+++ b/internal/storage/sqlstore/modelconfig/store.go
@@ -158,10 +158,7 @@ func InitTables(db *sql.DB) {
 	ensureModelConfigSchema(db)
 	ensureOpenRouterModelSyncStateSchema(db)
 	migrateModelConfigTenantSchema(db)
-	seedDefaultModelConfigRows(db)
-	mergeLegacyPricingIntoModelConfigs(db)
-	repairDefaultPerCallModelConfigRows(db)
-	repairMediaGenerationModelConfigRows(db)
+	seedAndRepairModelConfigRows(db)
 }
 
 func NormalizeModelOwnerValue(value string) string {

--- a/internal/storage/sqlstore/modelconfig/tenant_media_seed.go
+++ b/internal/storage/sqlstore/modelconfig/tenant_media_seed.go
@@ -1,0 +1,150 @@
+package modelconfig
+
+import (
+	"database/sql"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Per-tenant seeding for image and video models.
+//
+// seedDefaultModelConfigRows only ever writes the system tenant. Every other
+// tenant's library was populated indirectly: pricing import created rows with
+// source 'legacy-pricing', and repairMediaGenerationModelConfigRows later restamped
+// them as 'seed'. That works for a model old enough to appear in a pricing feed and
+// fails completely for a newly released one — nothing creates the row, so the model
+// is invisible in the tenant's library, its catalog, its plaza and its channel-group
+// editor, no matter that the runtime can serve it.
+//
+// gpt-image-2 reached every tenant only because it had been through that pricing
+// path. gpt-image-2.5-flare and -sunburst had not, and landed nowhere but the
+// system tenant.
+//
+// Only media models are seeded this way. Chat model availability legitimately
+// differs per tenant, but an image model is servable by any credential of its
+// provider, so withholding it from a tenant expresses nothing.
+
+// seedAndRepairModelConfigRows brings the model library up to date on startup.
+//
+// Order matters: the system tenant is seeded first, legacy pricing rows are folded
+// in and restamped, and only then are media models broadcast to the remaining
+// tenants — so a row a repair step would have fixed is not first inserted fresh.
+func seedAndRepairModelConfigRows(db *sql.DB) {
+	seedDefaultModelConfigRows(db)
+	mergeLegacyPricingIntoModelConfigs(db)
+	repairDefaultPerCallModelConfigRows(db)
+	repairMediaGenerationModelConfigRows(db)
+	seedMediaGenerationModelsForTenants(db)
+}
+
+// seedMediaGenerationModelsForTenants gives every existing tenant a row for each
+// media model in the static catalog.
+//
+// Existing rows are never touched: an operator's pricing, owner and enabled state
+// on a model they already have must survive this.
+func seedMediaGenerationModelsForTenants(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	tenants := modelConfigTenantIDs(db)
+	if len(tenants) == 0 {
+		return
+	}
+	now := nowRFC3339()
+	for _, row := range defaultModelConfigRows() {
+		if !isMediaGenerationModel(row.ModelID) {
+			continue
+		}
+		for _, tenantID := range tenants {
+			ownedBy := tenantMediaModelOwner(db, tenantID, row.ModelID, row.OwnedBy)
+			_, err := db.Exec(
+				`INSERT OR IGNORE INTO model_configs
+				 (tenant_id, model_id, owned_by, display_name, description, enabled, input_modalities, output_modalities, pricing_mode, input_price_per_million, output_price_per_million, cached_price_per_million, price_per_call, source, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, ?, ?, ?)`,
+				tenantID,
+				row.ModelID,
+				ownedBy,
+				row.DisplayName,
+				row.Description,
+				boolToInt(row.Enabled),
+				encodeModelModalities(row.InputModalities),
+				encodeModelModalities(row.OutputModalities),
+				NormalizePricingMode(row.PricingMode),
+				row.PricePerCall,
+				row.Source,
+				now,
+			)
+			if err != nil {
+				log.Warnf("sqlite/modelconfig: seed media model %s for tenant %s: %v", row.ModelID, tenantID, err)
+			}
+		}
+	}
+}
+
+// modelConfigTenantIDs lists the tenants that already have a model library.
+func modelConfigTenantIDs(db *sql.DB) []string {
+	rows, err := db.Query(`SELECT DISTINCT tenant_id FROM model_configs WHERE tenant_id != ''`)
+	if err != nil {
+		log.Warnf("sqlite/modelconfig: list tenants for media seed: %v", err)
+		return nil
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	tenants := make([]string, 0, 8)
+	for rows.Next() {
+		var tenantID string
+		if err := rows.Scan(&tenantID); err != nil {
+			continue
+		}
+		if trimmed := strings.TrimSpace(tenantID); trimmed != "" {
+			tenants = append(tenants, trimmed)
+		}
+	}
+	return tenants
+}
+
+// tenantMediaModelOwner picks the owner a new media model should carry in a tenant.
+//
+// Owner drives the console's owner-group mapping, and operators retarget it per
+// tenant: on this deployment two tenants moved gpt-image-2 from "openai" to "codex"
+// so it would show under their Codex credential group. A new model in the same
+// family that kept the catalog default would silently land outside that group,
+// leaving the operator to rediscover and repeat the change for every release.
+//
+// So a sibling already in the tenant decides it, and the catalog default applies
+// only when the tenant has no sibling to follow.
+func tenantMediaModelOwner(db *sql.DB, tenantID, modelID, fallback string) string {
+	prefix := mediaModelFamilyPrefix(modelID)
+	if prefix == "" {
+		return fallback
+	}
+	var ownedBy string
+	err := db.QueryRow(
+		`SELECT owned_by FROM model_configs
+		 WHERE tenant_id = ? AND model_id LIKE ? AND model_id != ? AND owned_by != ''
+		 ORDER BY model_id
+		 LIMIT 1`,
+		tenantID,
+		prefix+"%",
+		modelID,
+	).Scan(&ownedBy)
+	if err != nil || strings.TrimSpace(ownedBy) == "" {
+		return fallback
+	}
+	return strings.TrimSpace(ownedBy)
+}
+
+// mediaModelFamilyPrefix returns the id prefix shared by a media model's family,
+// used to find a sibling whose owner a new release should follow.
+func mediaModelFamilyPrefix(modelID string) string {
+	normalized := strings.ToLower(strings.TrimSpace(modelID))
+	for _, prefix := range []string{"gpt-image-", "grok-imagine-image", "grok-imagine-video", "sora-", "image-"} {
+		if strings.HasPrefix(normalized, prefix) {
+			return prefix
+		}
+	}
+	return ""
+}

--- a/internal/storage/sqlstore/modelconfig/tenant_media_seed_test.go
+++ b/internal/storage/sqlstore/modelconfig/tenant_media_seed_test.go
@@ -1,0 +1,152 @@
+package modelconfig
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+const systemTenant = "00000000-0000-0000-0000-000000000001"
+
+func newSeededTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	InitTables(db)
+	return db
+}
+
+func modelRowOwner(t *testing.T, db *sql.DB, tenantID, modelID string) (string, bool) {
+	t.Helper()
+	var ownedBy string
+	err := db.QueryRow(
+		`SELECT owned_by FROM model_configs WHERE tenant_id = ? AND model_id = ?`,
+		tenantID, modelID,
+	).Scan(&ownedBy)
+	if err == sql.ErrNoRows {
+		return "", false
+	}
+	if err != nil {
+		t.Fatalf("query %s/%s: %v", tenantID, modelID, err)
+	}
+	return ownedBy, true
+}
+
+// TestMediaModelsReachEveryTenant reproduces the gap that made gpt-image-2.5
+// invisible: seeding only ever wrote the system tenant, and every other tenant got
+// its image models as a side effect of pricing import. A model too new to appear in
+// a pricing feed therefore reached no tenant but the system one.
+func TestMediaModelsReachEveryTenant(t *testing.T) {
+	db := newSeededTestDB(t)
+
+	// A tenant that predates the release and already carries the older model.
+	const tenant = "9e003dfb-751f-4898-b186-45f765c763a6"
+	if _, err := db.Exec(
+		`INSERT INTO model_configs (tenant_id, model_id, owned_by, enabled, source, updated_at)
+		 VALUES (?, 'gpt-image-2', 'codex', 1, 'seed', '2026-01-01T00:00:00Z')`,
+		tenant,
+	); err != nil {
+		t.Fatalf("seed existing tenant row: %v", err)
+	}
+
+	seedMediaGenerationModelsForTenants(db)
+
+	for _, modelID := range []string{"gpt-image-2.5-flare", "gpt-image-2.5-sunburst"} {
+		owner, ok := modelRowOwner(t, db, tenant, modelID)
+		if !ok {
+			t.Fatalf("%s is missing from tenant %s, so it cannot appear in that tenant's library", modelID, tenant)
+		}
+		// The tenant moved gpt-image-2 to the codex owner group. A sibling that kept
+		// the catalog default would land outside that group and stay invisible there.
+		if owner != "codex" {
+			t.Fatalf("%s owner = %q, want it to follow the sibling's %q", modelID, owner, "codex")
+		}
+	}
+}
+
+// TestMediaSeedFallsBackToCatalogOwner covers a tenant with no sibling to follow.
+func TestMediaSeedFallsBackToCatalogOwner(t *testing.T) {
+	db := newSeededTestDB(t)
+
+	const tenant = "11f9ab9c-9fa6-4875-a76a-c39f113c57eb"
+	// Present in the tenant, but not an image model, so it must not be followed.
+	if _, err := db.Exec(
+		`INSERT INTO model_configs (tenant_id, model_id, owned_by, enabled, source, updated_at)
+		 VALUES (?, 'gpt-5.5', 'some-custom-owner', 1, 'seed', '2026-01-01T00:00:00Z')`,
+		tenant,
+	); err != nil {
+		t.Fatalf("seed tenant chat row: %v", err)
+	}
+
+	seedMediaGenerationModelsForTenants(db)
+
+	owner, ok := modelRowOwner(t, db, tenant, "gpt-image-2.5-flare")
+	if !ok {
+		t.Fatal("gpt-image-2.5-flare missing from a tenant with no image sibling")
+	}
+	if owner != "openai" {
+		t.Fatalf("owner = %q, want the catalog default %q", owner, "openai")
+	}
+}
+
+// TestMediaSeedPreservesOperatorEdits is the guard against this running on every
+// startup and undoing console changes.
+func TestMediaSeedPreservesOperatorEdits(t *testing.T) {
+	db := newSeededTestDB(t)
+
+	const tenant = "14b1ee9a-6177-4f5f-b5d4-4fba60ad24fa"
+	if _, err := db.Exec(
+		`INSERT INTO model_configs (tenant_id, model_id, owned_by, enabled, pricing_mode, price_per_call, source, updated_at)
+		 VALUES (?, 'gpt-image-2.5-flare', 'operator-owner', 0, 'call', 9.99, 'user', '2026-01-01T00:00:00Z')`,
+		tenant,
+	); err != nil {
+		t.Fatalf("seed operator row: %v", err)
+	}
+
+	seedMediaGenerationModelsForTenants(db)
+
+	var (
+		ownedBy string
+		enabled int
+		price   float64
+		source  string
+	)
+	if err := db.QueryRow(
+		`SELECT owned_by, enabled, price_per_call, source FROM model_configs
+		 WHERE tenant_id = ? AND model_id = 'gpt-image-2.5-flare'`,
+		tenant,
+	).Scan(&ownedBy, &enabled, &price, &source); err != nil {
+		t.Fatalf("query operator row: %v", err)
+	}
+	if ownedBy != "operator-owner" || enabled != 0 || price != 9.99 || source != "user" {
+		t.Fatalf("operator row was overwritten: owner=%q enabled=%d price=%v source=%q", ownedBy, enabled, price, source)
+	}
+}
+
+// TestChatModelsAreNotSeededPerTenant keeps the change narrow: chat availability
+// legitimately differs per tenant, so only media models are broadcast.
+func TestChatModelsAreNotSeededPerTenant(t *testing.T) {
+	db := newSeededTestDB(t)
+
+	const tenant = "tenant-without-chat-models"
+	if _, err := db.Exec(
+		`INSERT INTO model_configs (tenant_id, model_id, owned_by, enabled, source, updated_at)
+		 VALUES (?, 'gpt-image-2', 'codex', 1, 'seed', '2026-01-01T00:00:00Z')`,
+		tenant,
+	); err != nil {
+		t.Fatalf("seed tenant row: %v", err)
+	}
+
+	seedMediaGenerationModelsForTenants(db)
+
+	if _, ok := modelRowOwner(t, db, tenant, "gpt-5.5"); ok {
+		t.Fatal("gpt-5.5 was seeded into a tenant, but chat models must stay per-tenant")
+	}
+	if _, ok := modelRowOwner(t, db, systemTenant, "gpt-5.5"); !ok {
+		t.Fatal("gpt-5.5 should still be seeded into the system tenant")
+	}
+}


### PR DESCRIPTION
承接 [kittors/CliRelay#1018](https://github.com/kittors/CliRelay/pull/1018)。注册进目录还不够——2.5 在管理端仍然看不见。

## 现象

#1018 合并部署后，线上模型库里 2.5 只有系统租户一份：

```
gpt-image-2.5-flare|openai|1|seed      ← 仅 00000000-...-0001
gpt-image-2.5-sunburst|openai|1|seed   ← 仅 00000000-...-0001
```

而 gpt-image-2 在全部 4 个租户里都有。用户的租户（`9e003dfb`）里没有 2.5 的行，所以模型库、模型目录、模型广场、渠道分组编辑器全都看不到它。

## 根因

`seedDefaultModelConfigRows` **只写系统租户**（代码注释里原话："the seed itself only ever wrote the system tenant"）。其余租户的图像模型行是间接来的：定价导入先以 `source='legacy-pricing'` 建行，之后 `repairMediaGenerationModelConfigRows` 把它们改写成 `source='seed'` 并打上按次计费。

这条路径对「老到已经进了定价源」的模型有效，对新发布的模型完全无效——没有任何环节会去创建那一行。gpt-image-2 走过这条路，2.5 没有。

## 改动

媒体类模型现在会写入每一个已有模型库的租户。范围刻意收窄：chat 模型的可用性本来就该按租户区分，但图像模型只要该 provider 的凭据能跑就能出图，对某个租户藏起来不表达任何东西。

两个细节：

- **不动已有行**（`INSERT OR IGNORE`）。运维设置的价格、归属、启用状态都保留——这一点很重要，因为它每次启动都会跑。
- **新模型跟随同租户内同族模型的归属**。归属决定管理端的归属分组映射，而运维会按租户改它：本部署有两个租户把 gpt-image-2 从 `openai` 改成了 `codex`，好让它出现在自己的 Codex 凭据分组下。新模型若保留目录默认值就会落在分组外，等于每出一个新模型运维都要重做一次这个修改。

seed/repair 序列从 `InitTables` 抽成一次调用，顺带让 `store.go` 回到结构棘轮之下（934 → 931 行）。

## 测试

- `./scripts/ci-pr.sh` — exit 0
- `TestMediaModelsReachEveryTenant` — 复现原问题：一个已有 gpt-image-2（owner 改为 codex）的租户，seed 后必须拿到 2.5 两条，且 owner 跟随为 codex
- `TestMediaSeedFallsBackToCatalogOwner` — 无同族可跟随时用目录默认值，且不会去跟随 chat 模型的 owner
- `TestMediaSeedPreservesOperatorEdits` — 运维改过的行（owner/enabled/价格/source）不被覆盖
- `TestChatModelsAreNotSeededPerTenant` — chat 模型不广播到租户，但系统租户仍然有