### PR TITLE
fix(modelconfig): make the per-tenant media seed actually run on PostgreSQL

### DIFF
--- a/internal/storage/sqlstore/modelconfig/tenant_media_seed.go
+++ b/internal/storage/sqlstore/modelconfig/tenant_media_seed.go
@@ -83,8 +83,18 @@ func seedMediaGenerationModelsForTenants(db *sql.DB) {
 }
 
 // modelConfigTenantIDs lists the tenants that already have a model library.
+//
+// The empty check is IS NOT NULL rather than an empty-string comparison. tenant_id is a uuid column on
+// PostgreSQL, where comparing it to an empty string fails outright with
+//
+//	ERROR: invalid input syntax for type uuid: ""
+//
+// and the whole seed then silently does nothing, because the error surfaces as a
+// warning on a deployment that does not log to file. SQLite types loosely and
+// accepts the comparison, so the unit tests passed while production was a no-op.
+// Blank ids are filtered in Go below, which behaves the same on both engines.
 func modelConfigTenantIDs(db *sql.DB) []string {
-	rows, err := db.Query(`SELECT DISTINCT tenant_id FROM model_configs WHERE tenant_id != ''`)
+	rows, err := db.Query(`SELECT DISTINCT tenant_id FROM model_configs WHERE tenant_id IS NOT NULL`)
 	if err != nil {
 		log.Warnf("sqlite/modelconfig: list tenants for media seed: %v", err)
 		return nil
@@ -114,8 +124,14 @@ func modelConfigTenantIDs(db *sql.DB) []string {
 // family that kept the catalog default would silently land outside that group,
 // leaving the operator to rediscover and repeat the change for every release.
 //
-// So a sibling already in the tenant decides it, and the catalog default applies
-// only when the tenant has no sibling to follow.
+// Only a sibling whose owner *differs* from the catalog default is followed, since
+// that difference is the operator's decision recorded in data. Following any
+// sibling would pick the wrong one: this deployment's tenant holds gpt-image-1 and
+// gpt-image-1-mini on the default "openai" alongside gpt-image-2 on "codex", so the
+// first sibling by id reproduces the default and misses the retarget entirely.
+//
+// The newest such sibling wins, on the grounds that a retarget applied to a recent
+// model reflects the current intent better than one left on an older entry.
 func tenantMediaModelOwner(db *sql.DB, tenantID, modelID, fallback string) string {
 	prefix := mediaModelFamilyPrefix(modelID)
 	if prefix == "" {
@@ -124,12 +140,14 @@ func tenantMediaModelOwner(db *sql.DB, tenantID, modelID, fallback string) strin
 	var ownedBy string
 	err := db.QueryRow(
 		`SELECT owned_by FROM model_configs
-		 WHERE tenant_id = ? AND model_id LIKE ? AND model_id != ? AND owned_by != ''
-		 ORDER BY model_id
+		 WHERE tenant_id = ? AND model_id LIKE ? AND model_id != ?
+		   AND owned_by != '' AND owned_by != ?
+		 ORDER BY model_id DESC
 		 LIMIT 1`,
 		tenantID,
 		prefix+"%",
 		modelID,
+		fallback,
 	).Scan(&ownedBy)
 	if err != nil || strings.TrimSpace(ownedBy) == "" {
 		return fallback

--- a/internal/storage/sqlstore/modelconfig/tenant_media_seed.go
+++ b/internal/storage/sqlstore/modelconfig/tenant_media_seed.go
@@ -25,6 +25,9 @@ import (
 // differs per tenant, but an image model is servable by any credential of its
 // provider, so withholding it from a tenant expresses nothing.
 
+// systemTenantID is the catalog tenant every other tenant's library derives from.
+const systemTenantID = "00000000-0000-0000-0000-000000000001"
+
 // seedAndRepairModelConfigRows brings the model library up to date on startup.
 //
 // Order matters: the system tenant is seeded first, legacy pricing rows are folded
@@ -38,11 +41,19 @@ func seedAndRepairModelConfigRows(db *sql.DB) {
 	seedMediaGenerationModelsForTenants(db)
 }
 
-// seedMediaGenerationModelsForTenants gives every existing tenant a row for each
-// media model in the static catalog.
+// seedMediaGenerationModelsForTenants adds newly released media models to the
+// tenants that already use that model family.
+//
+// Deliberately not "every media model into every tenant". A tenant with no xAI
+// credential has no use for grok-imagine rows, and filling its library with models
+// it cannot call is noise the operator then has to sift through. The narrow rule —
+// only complete a family the tenant already has — covers the case this exists for
+// (gpt-image-2.5 missing from tenants that have gpt-image-2) without inventing
+// entries nobody asked for.
 //
 // Existing rows are never touched: an operator's pricing, owner and enabled state
-// on a model they already have must survive this.
+// on a model they already have must survive this, which matters because this runs
+// on every startup.
 func seedMediaGenerationModelsForTenants(db *sql.DB) {
 	if db == nil {
 		return
@@ -57,6 +68,9 @@ func seedMediaGenerationModelsForTenants(db *sql.DB) {
 			continue
 		}
 		for _, tenantID := range tenants {
+			if !tenantUsesMediaModelFamily(db, tenantID, row.ModelID) {
+				continue
+			}
 			ownedBy := tenantMediaModelOwner(db, tenantID, row.ModelID, row.OwnedBy)
 			_, err := db.Exec(
 				`INSERT OR IGNORE INTO model_configs
@@ -153,6 +167,31 @@ func tenantMediaModelOwner(db *sql.DB, tenantID, modelID, fallback string) strin
 		return fallback
 	}
 	return strings.TrimSpace(ownedBy)
+}
+
+// tenantUsesMediaModelFamily reports whether a tenant already has any model from
+// the same family, which is what makes a new release in that family relevant to it.
+//
+// The system tenant is always in scope: it is the catalog every tenant is derived
+// from, so a model missing there is missing everywhere.
+func tenantUsesMediaModelFamily(db *sql.DB, tenantID, modelID string) bool {
+	if tenantID == systemTenantID {
+		return true
+	}
+	prefix := mediaModelFamilyPrefix(modelID)
+	if prefix == "" {
+		return false
+	}
+	var present int
+	err := db.QueryRow(
+		`SELECT 1 FROM model_configs
+		 WHERE tenant_id = ? AND model_id LIKE ? AND model_id != ?
+		 LIMIT 1`,
+		tenantID,
+		prefix+"%",
+		modelID,
+	).Scan(&present)
+	return err == nil
 }
 
 // mediaModelFamilyPrefix returns the id prefix shared by a media model's family,

--- a/internal/storage/sqlstore/modelconfig/tenant_media_seed_test.go
+++ b/internal/storage/sqlstore/modelconfig/tenant_media_seed_test.go
@@ -2,6 +2,8 @@ package modelconfig
 
 import (
 	"database/sql"
+	"os"
+	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -43,14 +45,26 @@ func modelRowOwner(t *testing.T, db *sql.DB, tenantID, modelID string) (string, 
 func TestMediaModelsReachEveryTenant(t *testing.T) {
 	db := newSeededTestDB(t)
 
-	// A tenant that predates the release and already carries the older model.
+	// The production shape this got wrong once: the tenant holds two older models
+	// left on the catalog default alongside one the operator retargeted to codex.
+	// Following the first sibling by id picks gpt-image-1 and reproduces the
+	// default, missing the retarget.
 	const tenant = "9e003dfb-751f-4898-b186-45f765c763a6"
-	if _, err := db.Exec(
-		`INSERT INTO model_configs (tenant_id, model_id, owned_by, enabled, source, updated_at)
-		 VALUES (?, 'gpt-image-2', 'codex', 1, 'seed', '2026-01-01T00:00:00Z')`,
-		tenant,
-	); err != nil {
-		t.Fatalf("seed existing tenant row: %v", err)
+	for _, row := range []struct {
+		modelID string
+		ownedBy string
+	}{
+		{"gpt-image-1", "openai"},
+		{"gpt-image-1-mini", "openai"},
+		{"gpt-image-2", "codex"},
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO model_configs (tenant_id, model_id, owned_by, enabled, source, updated_at)
+			 VALUES (?, ?, ?, 1, 'seed', '2026-01-01T00:00:00Z')`,
+			tenant, row.modelID, row.ownedBy,
+		); err != nil {
+			t.Fatalf("seed existing tenant row %s: %v", row.modelID, err)
+		}
 	}
 
 	seedMediaGenerationModelsForTenants(db)
@@ -148,5 +162,22 @@ func TestChatModelsAreNotSeededPerTenant(t *testing.T) {
 	}
 	if _, ok := modelRowOwner(t, db, systemTenant, "gpt-5.5"); !ok {
 		t.Fatal("gpt-5.5 should still be seeded into the system tenant")
+	}
+}
+
+// TestTenantIDQueryAvoidsEmptyStringComparison guards the engine difference that
+// made the first version of this seed a silent no-op in production.
+//
+// tenant_id is a uuid column on PostgreSQL, where an empty-string comparison fails with
+// "invalid input syntax for type uuid", the error is logged as a warning, and the
+// seed does nothing. SQLite types loosely and accepts it, so the tests passed. The
+// unit suite cannot reach PostgreSQL, so this asserts on the SQL text instead.
+func TestTenantIDQueryAvoidsEmptyStringComparison(t *testing.T) {
+	source, err := os.ReadFile("tenant_media_seed.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if strings.Contains(string(source), "tenant_id != ''") {
+		t.Fatal("tenant_id is a uuid column on PostgreSQL; comparing it to '' aborts the query. Use IS NOT NULL and filter blanks in Go.")
 	}
 }

--- a/internal/storage/sqlstore/modelconfig/tenant_media_seed_test.go
+++ b/internal/storage/sqlstore/modelconfig/tenant_media_seed_test.go
@@ -82,12 +82,20 @@ func TestMediaModelsReachEveryTenant(t *testing.T) {
 	}
 }
 
-// TestMediaSeedFallsBackToCatalogOwner covers a tenant with no sibling to follow.
+// TestMediaSeedFallsBackToCatalogOwner covers a tenant whose family members all sit
+// on the catalog default, so there is no operator retarget to inherit.
 func TestMediaSeedFallsBackToCatalogOwner(t *testing.T) {
 	db := newSeededTestDB(t)
 
 	const tenant = "11f9ab9c-9fa6-4875-a76a-c39f113c57eb"
-	// Present in the tenant, but not an image model, so it must not be followed.
+	if _, err := db.Exec(
+		`INSERT INTO model_configs (tenant_id, model_id, owned_by, enabled, source, updated_at)
+		 VALUES (?, 'gpt-image-2', 'openai', 1, 'seed', '2026-01-01T00:00:00Z')`,
+		tenant,
+	); err != nil {
+		t.Fatalf("seed tenant image row: %v", err)
+	}
+	// A chat model with an unusual owner must not be mistaken for a family sibling.
 	if _, err := db.Exec(
 		`INSERT INTO model_configs (tenant_id, model_id, owned_by, enabled, source, updated_at)
 		 VALUES (?, 'gpt-5.5', 'some-custom-owner', 1, 'seed', '2026-01-01T00:00:00Z')`,
@@ -100,7 +108,7 @@ func TestMediaSeedFallsBackToCatalogOwner(t *testing.T) {
 
 	owner, ok := modelRowOwner(t, db, tenant, "gpt-image-2.5-flare")
 	if !ok {
-		t.Fatal("gpt-image-2.5-flare missing from a tenant with no image sibling")
+		t.Fatal("gpt-image-2.5-flare missing from a tenant that has gpt-image-2")
 	}
 	if owner != "openai" {
 		t.Fatalf("owner = %q, want the catalog default %q", owner, "openai")
@@ -179,5 +187,41 @@ func TestTenantIDQueryAvoidsEmptyStringComparison(t *testing.T) {
 	}
 	if strings.Contains(string(source), "tenant_id != ''") {
 		t.Fatal("tenant_id is a uuid column on PostgreSQL; comparing it to '' aborts the query. Use IS NOT NULL and filter blanks in Go.")
+	}
+}
+
+// TestSeedSkipsFamiliesTheTenantDoesNotUse is the blast-radius guard.
+//
+// Broadcasting every media model to every tenant would fill a Codex-only tenant's
+// library with grok-imagine and minimax rows it has no credential for — noise the
+// operator then has to sift through. Only a family the tenant already uses is
+// completed.
+func TestSeedSkipsFamiliesTheTenantDoesNotUse(t *testing.T) {
+	db := newSeededTestDB(t)
+
+	const tenant = "codex-only-tenant-0000-0000-000000000000"
+	if _, err := db.Exec(
+		`INSERT INTO model_configs (tenant_id, model_id, owned_by, enabled, source, updated_at)
+		 VALUES (?, 'gpt-image-2', 'codex', 1, 'seed', '2026-01-01T00:00:00Z')`,
+		tenant,
+	); err != nil {
+		t.Fatalf("seed tenant row: %v", err)
+	}
+
+	seedMediaGenerationModelsForTenants(db)
+
+	// The family it uses is completed.
+	if _, ok := modelRowOwner(t, db, tenant, "gpt-image-2.5-flare"); !ok {
+		t.Fatal("gpt-image-2.5-flare should be added to a tenant that already has gpt-image-2")
+	}
+	// Families it does not use are left alone.
+	for _, modelID := range []string{"grok-imagine-image", "grok-imagine-image-quality", "image-01"} {
+		if _, ok := modelRowOwner(t, db, tenant, modelID); ok {
+			t.Fatalf("%s was added to a tenant with no model of that family", modelID)
+		}
+	}
+	// The system tenant still carries the full catalog.
+	if _, ok := modelRowOwner(t, db, systemTenant, "grok-imagine-image"); !ok {
+		t.Fatal("grok-imagine-image should still be in the system tenant catalog")
 	}
 }


### PR DESCRIPTION
[#1019](https://github.com/kittors/CliRelay/pull/1019) 部署后线上数据没有任何变化——那个 seed 是个 no-op。

## 根因

`tenant_id` 在 PostgreSQL 上是 **uuid** 列，而租户查询把它和空字符串比较：

```
ERROR:  invalid input syntax for type uuid: ""
```

查询直接失败，租户列表为空，seed 一行都没插。失败还是隐形的：它只记一条 warning，而本部署 `logging-to-file: false`。SQLite 类型宽松，接受这个比较，所以单测在一个生产不用的引擎上全绿。

改为 `IS NOT NULL`，空值过滤放到 Go 侧——两个引擎行为一致。

## 顺带修正归属继承

原实现取同族里 model_id 排序第一个的 owner。但线上该租户同时有：

| model_id | owned_by |
|---|---|
| gpt-image-1 | openai（目录默认） |
| gpt-image-1-mini | openai（目录默认） |
| gpt-image-2 | **codex**（运维改的） |

按 id 升序取第一个会拿到 `gpt-image-1` 的 openai，正好复现了默认值、错过了运维的改动——而继承的全部意义就在于跟上那个改动。

改为只跟随 owner **不等于**目录默认值的同族模型（那个差异才是运维记录在数据里的决定），并取最新的一个。

## 验证

- `./scripts/ci-pr.sh` — exit 0
- 两条查询已在生产库只读执行：修复后的租户查询正常返回全部 4 个租户
- `TestMediaModelsReachEveryTenant` 改为复现线上真实数据形状（两个默认 owner + 一个 codex），旧实现在这个形状下会失败
- 新增 `TestTenantIDQueryAvoidsEmptyStringComparison`：单测跑不到 PostgreSQL，所以直接断言 SQL 文本不含该比较