### PR TITLE
fix(codex): make image models routable, not just visible

### DIFF
--- a/internal/runtime/executor/codex_image_models.go
+++ b/internal/runtime/executor/codex_image_models.go
@@ -1,0 +1,85 @@
+package executor
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+// withCodexImageModels merges the Codex image models into a discovered model list.
+//
+// A Codex credential's routable models come entirely from the ChatGPT manifest,
+// which lists chat models only — image generation is served through a separate
+// tool/endpoint and never appears there. Registering an image model in the static
+// catalog therefore makes it visible in the panel while the request router still
+// has no credential that serves it, and the request fails with
+//
+//	auth_not_found: no auth available
+//
+// before any upstream call is made. gpt-image-2 escaped this because it predates
+// the manifest becoming the sole source; gpt-image-2.5-flare and -sunburst did not,
+// and were selectable in the console but unusable.
+//
+// This is the same merge xAI already does in withXAIMediaModels, for the same
+// reason. Doing it per provider is what let Codex miss it.
+//
+// Merging is safe because image generation is reachable with the same token the
+// chat surface uses; a credential that cannot serve one fails at request time with
+// a real upstream error rather than looking like a missing model.
+func withCodexImageModels(models []*sdkmodelcatalog.ModelInfo) []*sdkmodelcatalog.ModelInfo {
+	imageModels := codexImageModelInfos()
+	if len(imageModels) == 0 {
+		return models
+	}
+
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		seen[strings.ToLower(strings.TrimSpace(model.ID))] = struct{}{}
+	}
+
+	merged := make([]*sdkmodelcatalog.ModelInfo, 0, len(models)+len(imageModels))
+	merged = append(merged, models...)
+	for _, model := range imageModels {
+		// A live listing that already advertises the model wins, so upstream stays
+		// authoritative about anything it does report.
+		if _, exists := seen[strings.ToLower(strings.TrimSpace(model.ID))]; exists {
+			continue
+		}
+		merged = append(merged, model)
+	}
+	return merged
+}
+
+// codexImageModelInfos converts the static Codex image definitions into catalog
+// entries. Sourcing them from the registry keeps one definition of the model set,
+// so adding a model there makes it routable without a second edit here.
+func codexImageModelInfos() []*sdkmodelcatalog.ModelInfo {
+	definitions := registry.GetOpenAIModels()
+	models := make([]*sdkmodelcatalog.ModelInfo, 0, 4)
+	for _, definition := range definitions {
+		if definition == nil || !registry.IsImageGenerationModel(definition.ID) {
+			continue
+		}
+		// The provider serving the model has to be codex, or a Codex credential
+		// would advertise another pool's models and fail at request time.
+		if !strings.EqualFold(registry.ImageGenerationProvider(definition.ID), registry.ImageProviderCodex) {
+			continue
+		}
+		models = append(models, &sdkmodelcatalog.ModelInfo{
+			ID:                  definition.ID,
+			Object:              definition.Object,
+			Created:             definition.Created,
+			OwnedBy:             definition.OwnedBy,
+			Type:                definition.Type,
+			DisplayName:         definition.DisplayName,
+			Description:         definition.Description,
+			Version:             definition.Version,
+			SupportedParameters: append([]string(nil), definition.SupportedParameters...),
+		})
+	}
+	return models
+}

--- a/internal/runtime/executor/codex_image_models_test.go
+++ b/internal/runtime/executor/codex_image_models_test.go
@@ -1,0 +1,73 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
+)
+
+// TestCodexImageModelsAreRoutable is the guard for "visible in the panel, unusable
+// on call".
+//
+// A Codex credential's routable model set comes from the ChatGPT manifest, which
+// lists chat models only. Without this merge, selecting gpt-image-2.5-flare in the
+// console produced auth_not_found: no auth available — the router had no credential
+// advertising it — while every catalog surface happily offered it.
+func TestCodexImageModelsAreRoutable(t *testing.T) {
+	merged := withCodexImageModels(nil)
+
+	ids := make(map[string]struct{}, len(merged))
+	for _, model := range merged {
+		ids[strings.ToLower(model.ID)] = struct{}{}
+	}
+
+	for _, modelID := range []string{"gpt-image-2", "gpt-image-2.5-flare", "gpt-image-2.5-sunburst"} {
+		if _, ok := ids[modelID]; !ok {
+			t.Errorf("%s is not in a Codex credential's model set, so requests for it fail with auth_not_found", modelID)
+		}
+	}
+
+	// Another pool's image models must not ride along, or a Codex credential would
+	// advertise models it cannot serve.
+	for _, modelID := range []string{"grok-imagine-image", "image-01"} {
+		if _, ok := ids[modelID]; ok {
+			t.Errorf("%s belongs to another provider and must not be merged into Codex", modelID)
+		}
+	}
+}
+
+// TestCodexImageModelsPreserveLiveDefinitions keeps upstream authoritative about
+// anything the manifest does report.
+func TestCodexImageModelsPreserveLiveDefinitions(t *testing.T) {
+	live := []*sdkmodelcatalog.ModelInfo{
+		{ID: "gpt-5.5", DisplayName: "Live Chat"},
+		{ID: "gpt-image-2", DisplayName: "Live Image Definition"},
+	}
+
+	merged := withCodexImageModels(live)
+
+	var seenImage2 int
+	for _, model := range merged {
+		if strings.EqualFold(model.ID, "gpt-image-2") {
+			seenImage2++
+			if model.DisplayName != "Live Image Definition" {
+				t.Errorf("gpt-image-2 display name = %q, want the live definition to win", model.DisplayName)
+			}
+		}
+	}
+	if seenImage2 != 1 {
+		t.Errorf("gpt-image-2 appears %d times, want exactly one entry", seenImage2)
+	}
+
+	// The chat model the manifest reported must survive untouched.
+	found := false
+	for _, model := range merged {
+		if model.ID == "gpt-5.5" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("gpt-5.5 was dropped from the merged model set")
+	}
+}

--- a/internal/runtime/executor/codex_models.go
+++ b/internal/runtime/executor/codex_models.go
@@ -219,6 +219,10 @@ func FetchCodexModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.
 	token, baseURL := codexCreds(auth)
 	token = strings.TrimSpace(token)
 	if token == "" {
+		// No credential: return whatever the cache holds, unmerged. Merging image
+		// models here would manufacture a routable set out of nothing, which reads
+		// downstream as live upstream data and leaks the system registry's models
+		// into tenants that hold no Codex credential at all.
 		return fallbackCodexModels()
 	}
 
@@ -229,7 +233,7 @@ func FetchCodexModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
 	if err != nil {
-		return fallbackCodexModels()
+		return withCodexImageModels(fallbackCodexModels())
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -249,7 +253,7 @@ func FetchCodexModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.
 		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 			log.Debugf("codex executor: models request failed: %v", err)
 		}
-		return fallbackCodexModels()
+		return withCodexImageModels(fallbackCodexModels())
 	}
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
@@ -260,22 +264,22 @@ func FetchCodexModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		log.Debugf("codex executor: models request failed with status %d", resp.StatusCode)
-		return fallbackCodexModels()
+		return withCodexImageModels(fallbackCodexModels())
 	}
 
 	body, err := readUpstreamResponseBody("codex", resp.Body)
 	if err != nil {
 		log.Debugf("codex executor: models response read failed: %v", err)
-		return fallbackCodexModels()
+		return withCodexImageModels(fallbackCodexModels())
 	}
 
 	models, ok := parseCodexModels(body, time.Now().Unix())
 	if !ok {
 		log.Debug("codex executor: fetched empty or invalid model list; retaining cached model list")
-		return fallbackCodexModels()
+		return withCodexImageModels(fallbackCodexModels())
 	}
 	storeCodexModels(models)
-	return models
+	return withCodexImageModels(models)
 }
 
 func codexAccountID(auth *cliproxyauth.Auth) string {

--- a/internal/runtime/executor/codex_models_test.go
+++ b/internal/runtime/executor/codex_models_test.go
@@ -113,8 +113,13 @@ func TestFetchCodexModelsAPIKeyCatalog(t *testing.T) {
 			"base_url": srv.URL,
 		},
 	}, nil)
-	if len(models) != 1 || models[0].ID != "codex-live-1" {
-		t.Fatalf("models=%v", models)
+	// Image models are merged into every Codex credential's set (see
+	// withCodexImageModels), so assert on membership rather than length.
+	if !codexModelSetContains(models, "codex-live-1") {
+		t.Fatalf("live model missing: %v", codexModelIDs(models))
+	}
+	if !codexModelSetContains(models, "gpt-image-2") {
+		t.Fatalf("image models must be routable for this credential: %v", codexModelIDs(models))
 	}
 }
 
@@ -125,10 +130,53 @@ func TestFetchCodexModelsFallsBackToCache(t *testing.T) {
 	if ok := storeCodexModels([]*sdkmodelcatalog.ModelInfo{{ID: "cached-codex", OwnedBy: "openai", Type: "codex"}}); !ok {
 		t.Fatal("cache seed failed")
 	}
+	// This auth carries no token, so nothing here is routable — the cache is
+	// returned unmerged. Merging image models onto a credential-less lookup would
+	// manufacture a servable set out of nothing.
 	models := FetchCodexModels(context.Background(), &cliproxyauth.Auth{Provider: "codex"}, nil)
 	if len(models) != 1 || models[0].ID != "cached-codex" {
-		t.Fatalf("fallback models=%v", models)
+		t.Fatalf("fallback models=%v", codexModelIDs(models))
 	}
+}
+
+// TestFetchCodexModelsMergesImageModelsForCredentialedFallback covers the other
+// fallback shape: a real credential whose manifest fetch failed still has to be
+// able to serve an image request, or the router reports auth_not_found.
+func TestFetchCodexModelsMergesImageModelsForCredentialedFallback(t *testing.T) {
+	resetCodexModelsCacheForTest()
+	t.Cleanup(resetCodexModelsCacheForTest)
+
+	if ok := storeCodexModels([]*sdkmodelcatalog.ModelInfo{{ID: "cached-codex", OwnedBy: "openai", Type: "codex"}}); !ok {
+		t.Fatal("cache seed failed")
+	}
+	models := FetchCodexModels(context.Background(), &cliproxyauth.Auth{
+		Provider:   "codex",
+		Attributes: map[string]string{"api_key": "sk-test", "base_url": "http://127.0.0.1:1"},
+	}, nil)
+	for _, modelID := range []string{"cached-codex", "gpt-image-2", "gpt-image-2.5-flare"} {
+		if !codexModelSetContains(models, modelID) {
+			t.Fatalf("%s missing from a credentialed fallback set: %v", modelID, codexModelIDs(models))
+		}
+	}
+}
+
+func codexModelIDs(models []*sdkmodelcatalog.ModelInfo) []string {
+	ids := make([]string, 0, len(models))
+	for _, model := range models {
+		if model != nil {
+			ids = append(ids, model.ID)
+		}
+	}
+	return ids
+}
+
+func codexModelSetContains(models []*sdkmodelcatalog.ModelInfo, modelID string) bool {
+	for _, model := range models {
+		if model != nil && model.ID == modelID {
+			return true
+		}
+	}
+	return false
 }
 
 func TestResolveCodexModelsClientVersionFloorsStaleDefault(t *testing.T) {


### PR DESCRIPTION
在管理端选中 `gpt-image-2.5-flare` 生成，返回：

```
auth_not_found: no auth available
```

上游一次都没被调用。

## 根因

注册进静态目录只能让模型在各个目录界面**可见**；但 Codex 凭据的**可路由**模型集完全来自 ChatGPT manifest，而 manifest 只列 chat 模型——图像生成走的是另一套工具/端点，从不出现在那里。于是路由层找不到任何声明该模型的凭据，直接拒绝分发。

`gpt-image-2` 躲过了这个问题，因为它早于 manifest 成为唯一来源。2.5 这两个没有，于是「哪儿都能选，哪儿都不能用」。

xAI 早就在 `withXAIMediaModels` 里解决了同样的问题，注释里的理由一字不差。按 provider 各写一份，正是 Codex 漏掉的原因。现在 Codex 用同样方式合并，覆盖 `FetchCodexModels` 的每一条返回路径。

## 一个例外，很关键

**无凭据路径返回缓存，不合并。** 在那里合并等于凭空造出一个可路由集合，下游会把它当成真实的 upstream 数据，还会把系统 registry 的模型泄漏到根本没有 Codex 凭据的租户里。

这不是推测——我第一版就是这么写的，被三个既有测试当场抓住：

- `TestListModelEntriesLiveForTenantCodexDoesNotReplaceRegistry`（source 标签变成 upstream）
- `TestListModelEntriesLiveWithoutRefreshUsesRegistryWhenNoDiscoveryCache`
- `TestConfiguredAvailabilityDoesNotLeakSystemRegistryModelsToOtherTenant`（租户隔离被破）

## 测试

- `./scripts/ci-pr.sh` — exit 0
- 新增 `TestCodexImageModelsAreRoutable`：三个 codex 图像模型都在凭据的模型集里，且别的 provider 的图像模型不会混进来
- 新增 `TestCodexImageModelsPreserveLiveDefinitions`：manifest 报告过的定义优先，不产生重复条目
- 新增 `TestFetchCodexModelsMergesImageModelsForCredentialedFallback`：有凭据但拉取失败时仍可路由
- 调整 `TestFetchCodexModelsFallsBackToCache`：明确断言无凭据时**不**合并