### PR TITLE
fix(translator): handle nullable array type in Gemini tool schema conversion

### DIFF
--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -367,8 +367,16 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 					if properties := paramsResult.Get("properties"); properties.Exists() {
 						properties.ForEach(func(key, value gjson.Result) bool {
 							if propType := value.Get("type"); propType.Exists() {
-								upperType := strings.ToUpper(propType.String())
-								cleaned, _ = sjson.Set(cleaned, "properties."+key.String()+".type", upperType)
+								t := propType.String()
+								if propType.IsArray() {
+									for _, item := range propType.Array() {
+										if item.String() != "null" {
+											t = item.String()
+											break
+										}
+									}
+								}
+								cleaned, _ = sjson.Set(cleaned, "properties."+key.String()+".type", strings.ToUpper(t))
 							}
 							return true
 						})

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response_test.go
@@ -351,3 +351,39 @@ func TestConvertGeminiResponseToOpenAIResponses_ResponseOutputOrdering(t *testin
 		t.Fatalf("expected response.completed after message added: msgAdded=%d completed=%d", posMsgAdded, posCompleted)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToGemini_NullableTypeInToolSchema(t *testing.T) {
+	req := []byte(`{
+		"model": "ag/gemini-3.8-flash-low",
+		"tools": [{
+			"type": "function",
+			"name": "grep",
+			"description": "search",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"skip": {
+						"type": ["number", "null"],
+						"description": "pagination"
+					},
+					"query": {
+						"type": "string"
+					}
+				}
+			}
+		}]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToGemini("gemini-2.5-pro", req, false)
+	outStr := string(out)
+
+	skipType := gjson.Get(outStr, "tools.0.functionDeclarations.0.parametersJsonSchema.properties.skip.type").String()
+	if skipType != "NUMBER" {
+		t.Fatalf("expected NUMBER, got %q", skipType)
+	}
+
+	queryType := gjson.Get(outStr, "tools.0.functionDeclarations.0.parametersJsonSchema.properties.query.type").String()
+	if queryType != "STRING" {
+		t.Fatalf("expected STRING, got %q", queryType)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes an `INVALID_ARGUMENT (400)` error returned by Google Gemini / Antigravity APIs when clients using the OpenAI Responses protocol (such as [Oh My Pi](https://github.com/can1357/oh-my-pi)) send tools containing JSON Schema 2020-12 nullable types (e.g. `"type": ["number", "null"]`).

## Root Cause

In `internal/translator/gemini/openai/responses/gemini_openai-responses_request.go:370`:

```go
if propType := value.Get("type"); propType.Exists() {
    upperType := strings.ToUpper(propType.String())
    cleaned, _ = sjson.Set(cleaned, "properties."+key.String()+".type", upperType)
}
 ```                                                                                                                                                                               
                                                                                                                                                                                   
 When propType is an array (e.g., ["number", "null"]), propType.String() returns "[\"number\",\"null\"]". strings.ToUpper converts this into "[\"NUMBER\",\"NULL\"]", producing an invalid string value for the type field instead of a valid schema type enum:                                                                                                      
                                                                                                                                                                                   
 ```json                                                                                                                                                                           
"skip": {
  "type": "[\"NUMBER\",\"NULL\"]"
}
 ```                                                                                                                                                                               
                                                                                                                                                                                   
 Google's generateContent API rejects this with:                                                                                                                                   
                                                                                                                                                                                   
 ```                                                                                                                                                                               
400 Invalid value at 'request.tools[0].function_declarations[...].parameters.properties[...].value.type' (type.googleapis.com/google.cloud.aiplatform.master.Type), "[\"NUMBER\",\"NULL\"]"
 ```                                                                                                                                                                               
                                                                                                                                                                                   
 Changes                                                                                                                                                                           
                                                                                                                                                                                   
 1. internal/translator/gemini/openai/responses/gemini_openai-responses_request.go:                                                                                                
   - Check if propType.IsArray().                                                                                                                                                  
   - If it is an array, iterate through its members and select the primary non-"null" scalar type before uppercasing.                                                              
   - Preserves normal string behavior when propType is a plain string.                                                                                                             
 2. internal/translator/gemini/openai/responses/gemini_openai-responses_response_test.go:                                                                                          
   - Added unit test TestConvertOpenAIResponsesRequestToGemini_NullableTypeInToolSchema ensuring ["number", "null"] correctly maps to "NUMBER".                                    
                                                                                                                                                                                   
 Verification                                                                                                                                                                      
                                                                                                                                                                                   
 - Unit tests: go test -v ./internal/translator/gemini/openai/responses/... passes.                                                                                                
 - End-to-End: Built binary and hot-swapped into a live cli-proxy-api container. Replayed the exact failing request from Oh My Pi against /v1/responses with Gemini (gemini-3.8-flash-low); previously returned HTTP 400, now returns HTTP 200 OK.   
