### PR TITLE
fix: restore Antigravity multi-turn calls and the model catalogue's probes

### DIFF
--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -528,6 +528,11 @@ func isTenantScopedManagementPath(path string) bool {
 		strings.HasPrefix(relative, "/identity-fingerprint"),
 		strings.HasPrefix(relative, "/model-definitions/"),
 		strings.HasPrefix(relative, "/image-generation"),
+		// Text-to-video and image-to-video probes from the model catalogue.
+		// The image-generation sibling above was allowed through but this one
+		// was missed, so video models could not be tested from a business
+		// tenant at all.
+		strings.HasPrefix(relative, "/video-generation"),
 		relative == "/vertex/import",
 		strings.HasSuffix(relative, "-auth-url"),
 		relative == "/oauth-callback",
@@ -553,6 +558,11 @@ func isTenantScopedManagementPath(path string) bool {
 		relative == "/codex-oauth-admission":
 		return true
 	case relative == "/models",
+		// The catalogue's "test this model" dialog. It resolves the channel
+		// from the tenant's own auth files, so it is tenant-scoped in the same
+		// way /models is — listing it separately is what an exact == match on
+		// "/models" costs.
+		relative == "/models/test",
 		relative == "/models/configured-availability",
 		relative == "/model-path-availability",
 		strings.HasPrefix(relative, "/model-configs"),

--- a/internal/api/handlers/management/tenant_scope_gate_test.go
+++ b/internal/api/handlers/management/tenant_scope_gate_test.go
@@ -70,6 +70,33 @@ func TestTenantScopedManagementPathIncludesProviderRuntimeRoutes(t *testing.T) {
 	}
 }
 
+// The model catalogue's probes run on management authority and scope
+// themselves to the caller's effective tenant, so a business tenant must be
+// able to reach all three. /models/test and /video-generation/test were left
+// out, which is why testing a chat, image or video model from the catalogue
+// answered "tenant business resources are not enabled for this tenant".
+func TestTenantScopedManagementPathIncludesModelProbes(t *testing.T) {
+	tenantOperator := identity.Principal{
+		PlatformAdmin:   false,
+		EffectiveTenant: identity.Tenant{ID: "tenant-potato"},
+		HomeTenant:      identity.Tenant{ID: "tenant-potato"},
+	}
+	for _, path := range []string{
+		"/v0/management/models/test",
+		"/v0/management/image-generation/test",
+		"/v0/management/image-generation/test/task-1",
+		"/v0/management/video-generation/test",
+		"/v0/management/video-generation/test/task-1",
+	} {
+		if !isTenantScopedManagementPath(path) {
+			t.Errorf("isTenantScopedManagementPath(%q) = false", path)
+		}
+		if deniesTenantResourceScope(tenantOperator, path) {
+			t.Errorf("business tenant must reach %s", path)
+		}
+	}
+}
+
 func TestDeniesTenantResourceScopeAllowsBusinessTenantEndUsers(t *testing.T) {
 	tenantOperator := identity.Principal{
 		PlatformAdmin:   false,

--- a/internal/runtime/executor/antigravity_request.go
+++ b/internal/runtime/executor/antigravity_request.go
@@ -64,6 +64,15 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	// Normalising here rather than in the translator covers every entrypoint
 	// format at once: this is the last point all of them pass through.
 	payloadStr = util.NormalizeGeminiContentRoles(payloadStr, "request.contents")
+
+	// Thinking replayed from an earlier turn is only accepted on the terms of
+	// the model family answering the call, and each entrypoint translator used
+	// to guess at those terms separately. Settle it here, where they all meet,
+	// so a thought block never reaches the upstream in a shape it rejects.
+	sanitized := sanitizeAntigravityThoughts([]byte(payloadStr), modelName)
+	sanitized = stripAntigravityUnsupportedThinkingConfig(sanitized, modelName)
+	payloadStr = string(sanitized)
+
 	paths := make([]string, 0)
 	util.Walk(gjson.Parse(payloadStr), "", "parametersJsonSchema", &paths)
 	for _, p := range paths {

--- a/internal/runtime/executor/antigravity_thinking.go
+++ b/internal/runtime/executor/antigravity_thinking.go
@@ -1,0 +1,144 @@
+package executor
+
+import (
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/cache"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// antigravityThoughtSentinel is the placeholder signature the Gemini family
+// accepts in place of a real one. The other families reject it — see
+// antigravityThinkingReplay below.
+const antigravityThoughtSentinel = "skip_thought_signature_validator"
+
+// antigravityThinkingReplay describes how much of a previous turn's thinking a
+// model family will accept when it is replayed in a follow-up request.
+type antigravityThinkingReplay int
+
+const (
+	// replaySentinelOK: an unsigned thought is fine as long as it carries the
+	// skip sentinel. Only the Gemini family behaves this way.
+	replaySentinelOK antigravityThinkingReplay = iota
+	// replaySignedOnly: only a genuine upstream signature is accepted. Anthropic
+	// answers an empty signature with "thinking.signature: Field required" and a
+	// fabricated one with "Invalid `signature` in `thinking` block".
+	replaySignedOnly
+	// replayNever: the family rejects a replayed thought whatever its signature.
+	// CloudCode renders GPT turns as an OpenAI `messages` array and has no shape
+	// for a thought part, so it fails the whole request with
+	// "Expected a(n) 'messages' array element to be an object."
+	replayNever
+)
+
+// antigravityThinkingReplayFor maps a model onto its family's replay rule.
+// It keys off the shared model group rather than a model list so newly
+// published models inherit the right behaviour without a code change.
+func antigravityThinkingReplayFor(modelName string) antigravityThinkingReplay {
+	switch cache.GetModelGroup(modelName) {
+	case "gemini":
+		return replaySentinelOK
+	case "gpt":
+		return replayNever
+	case "claude":
+		return replaySignedOnly
+	default:
+		// Unknown families get the conservative rule: replaying an unsigned
+		// thought is what breaks requests, dropping one never does.
+		return replaySignedOnly
+	}
+}
+
+// sanitizeAntigravityThoughts drops thought parts the upstream would reject and
+// tops up the sentinel for the family that wants one.
+//
+// Every entrypoint format (Gemini, Claude, OpenAI chat completions, OpenAI
+// responses) has its own translator, and each one used to decide this for
+// itself — the Claude translator dropped unsigned thoughts correctly while the
+// Responses translator emitted an empty signature. Doing it here instead covers
+// all four at once, because this is the last point they share.
+func sanitizeAntigravityThoughts(payload []byte, modelName string) []byte {
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return payload
+	}
+	policy := antigravityThinkingReplayFor(modelName)
+
+	type drop struct {
+		contentIdx int
+		partIdx    int
+	}
+	var partDrops []drop
+	var contentDrops []int
+
+	contentResults := contents.Array()
+	for contentIdx, content := range contentResults {
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			continue
+		}
+		partResults := parts.Array()
+		kept := 0
+		for partIdx, part := range partResults {
+			if !part.Get("thought").Bool() {
+				kept++
+				continue
+			}
+			signature := part.Get("thoughtSignature").String()
+			switch policy {
+			case replayNever:
+				partDrops = append(partDrops, drop{contentIdx, partIdx})
+			case replaySentinelOK:
+				if !cache.HasValidSignature(modelName, signature) {
+					payload, _ = sjson.SetBytes(payload, fmt.Sprintf("request.contents.%d.parts.%d.thoughtSignature", contentIdx, partIdx), antigravityThoughtSentinel)
+				}
+				kept++
+			default: // replaySignedOnly
+				if cache.HasValidSignature(modelName, signature) && signature != antigravityThoughtSentinel {
+					kept++
+					continue
+				}
+				partDrops = append(partDrops, drop{contentIdx, partIdx})
+			}
+		}
+		// A content left with no parts is itself invalid upstream ("required
+		// oneof field 'data' must have one initialized field"), so it goes too.
+		if kept == 0 && len(partResults) > 0 {
+			contentDrops = append(contentDrops, contentIdx)
+		}
+	}
+
+	// Delete back to front so the earlier indices stay addressable.
+	for i := len(partDrops) - 1; i >= 0; i-- {
+		d := partDrops[i]
+		payload, _ = sjson.DeleteBytes(payload, fmt.Sprintf("request.contents.%d.parts.%d", d.contentIdx, d.partIdx))
+	}
+	for i := len(contentDrops) - 1; i >= 0; i-- {
+		payload, _ = sjson.DeleteBytes(payload, fmt.Sprintf("request.contents.%d", contentDrops[i]))
+	}
+	return payload
+}
+
+// stripAntigravityUnsupportedThinkingConfig removes a thinkingConfig the model
+// cannot accept.
+//
+// The GPT family rejects both `includeThoughts` and `thinkingLevel` with a bare
+// 400 that names no field, which is easy to misread as a broken credential. Its
+// reasoning effort is already carried by the model id itself (gpt-oss-120b-low
+// / -medium / -high), so nothing is lost by dropping the block.
+func stripAntigravityUnsupportedThinkingConfig(payload []byte, modelName string) []byte {
+	if cache.GetModelGroup(modelName) != "gpt" {
+		return payload
+	}
+	if !gjson.GetBytes(payload, "request.generationConfig.thinkingConfig").Exists() {
+		return payload
+	}
+	payload, _ = sjson.DeleteBytes(payload, "request.generationConfig.thinkingConfig")
+	// An empty generationConfig is harmless but noisy; drop it when it was only
+	// ever holding the thinkingConfig.
+	if gen := gjson.GetBytes(payload, "request.generationConfig"); gen.IsObject() && len(gen.Map()) == 0 {
+		payload, _ = sjson.DeleteBytes(payload, "request.generationConfig")
+	}
+	return payload
+}

--- a/internal/runtime/executor/antigravity_thinking_test.go
+++ b/internal/runtime/executor/antigravity_thinking_test.go
@@ -1,0 +1,146 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// realSignature stands in for a genuine upstream signature: what matters to the
+// code under test is only that it clears cache.MinValidSignatureLen.
+var realSignature = strings.Repeat("s", 64)
+
+func thoughtPayload(signature string) []byte {
+	return []byte(`{"request":{"contents":[` +
+		`{"role":"user","parts":[{"text":"count to two"}]},` +
+		`{"role":"model","parts":[{"text":"thinking out loud","thought":true,"thoughtSignature":"` + signature + `"}]},` +
+		`{"role":"model","parts":[{"functionCall":{"name":"calc","args":{}}}]}` +
+		`]}}`)
+}
+
+func thoughtParts(t *testing.T, payload []byte) []gjson.Result {
+	t.Helper()
+	var out []gjson.Result
+	gjson.GetBytes(payload, "request.contents").ForEach(func(_, content gjson.Result) bool {
+		content.Get("parts").ForEach(func(_, part gjson.Result) bool {
+			if part.Get("thought").Bool() {
+				out = append(out, part)
+			}
+			return true
+		})
+		return true
+	})
+	return out
+}
+
+// The GPT family has no shape for a replayed thought: CloudCode renders those
+// turns as an OpenAI messages array and fails the whole request with
+// "Expected a(n) 'messages' array element to be an object." Verified against
+// the live upstream — the same payload with the thought removed answers 200.
+func TestSanitizeAntigravityThoughtsDropsThoughtsForGPT(t *testing.T) {
+	for _, signature := range []string{"", antigravityThoughtSentinel, realSignature} {
+		got := sanitizeAntigravityThoughts(thoughtPayload(signature), "gpt-oss-120b-medium")
+		if parts := thoughtParts(t, got); len(parts) != 0 {
+			t.Errorf("signature %q: thought parts survived: %v", signature, parts)
+		}
+		if n := gjson.GetBytes(got, "request.contents.#").Int(); n != 2 {
+			t.Errorf("signature %q: contents = %d, want 2 (the emptied one is dropped too)", signature, n)
+		}
+		if !gjson.GetBytes(got, "request.contents.1.parts.0.functionCall").Exists() {
+			t.Errorf("signature %q: the functionCall turn must survive", signature)
+		}
+	}
+}
+
+// Anthropic validates the signature for real: an empty one comes back as
+// "thinking.signature: Field required" and a fabricated one as
+// "Invalid `signature` in `thinking` block". Only a genuine signature may be
+// replayed; anything else has to go.
+func TestSanitizeAntigravityThoughtsDropsUnsignedThoughtsForClaude(t *testing.T) {
+	for _, signature := range []string{"", antigravityThoughtSentinel} {
+		got := sanitizeAntigravityThoughts(thoughtPayload(signature), "claude-opus-4-6-thinking")
+		if parts := thoughtParts(t, got); len(parts) != 0 {
+			t.Errorf("signature %q: unsigned thought survived: %v", signature, parts)
+		}
+	}
+
+	got := sanitizeAntigravityThoughts(thoughtPayload(realSignature), "claude-opus-4-6-thinking")
+	parts := thoughtParts(t, got)
+	if len(parts) != 1 {
+		t.Fatalf("signed thought parts = %d, want 1", len(parts))
+	}
+	if sig := parts[0].Get("thoughtSignature").String(); sig != realSignature {
+		t.Errorf("signature = %q, want the original to be preserved", sig)
+	}
+}
+
+// Gemini is the one family that accepts the sentinel, so an unsigned thought is
+// topped up rather than dropped and the turn keeps its context.
+func TestSanitizeAntigravityThoughtsFillsSentinelForGemini(t *testing.T) {
+	got := sanitizeAntigravityThoughts(thoughtPayload(""), "gemini-3-pro-high")
+	parts := thoughtParts(t, got)
+	if len(parts) != 1 {
+		t.Fatalf("thought parts = %d, want 1", len(parts))
+	}
+	if sig := parts[0].Get("thoughtSignature").String(); sig != antigravityThoughtSentinel {
+		t.Errorf("thoughtSignature = %q, want %q", sig, antigravityThoughtSentinel)
+	}
+	if n := gjson.GetBytes(got, "request.contents.#").Int(); n != 3 {
+		t.Errorf("contents = %d, want all 3 kept", n)
+	}
+}
+
+// A thought sharing a part list with real content must not take that content
+// with it: only the thought part itself is removed.
+func TestSanitizeAntigravityThoughtsKeepsSiblingParts(t *testing.T) {
+	payload := []byte(`{"request":{"contents":[` +
+		`{"role":"model","parts":[` +
+		`{"text":"thinking","thought":true,"thoughtSignature":""},` +
+		`{"text":"the answer is two"}` +
+		`]}]}}`)
+
+	got := sanitizeAntigravityThoughts(payload, "claude-opus-4-6-thinking")
+	if n := gjson.GetBytes(got, "request.contents.#").Int(); n != 1 {
+		t.Fatalf("contents = %d, want 1", n)
+	}
+	parts := gjson.GetBytes(got, "request.contents.0.parts").Array()
+	if len(parts) != 1 {
+		t.Fatalf("parts = %d, want 1", len(parts))
+	}
+	if text := parts[0].Get("text").String(); text != "the answer is two" {
+		t.Errorf("surviving part text = %q", text)
+	}
+}
+
+// Both `includeThoughts` and `thinkingLevel` draw a bare 400 from the GPT
+// family. Its reasoning effort already rides on the model id, so the block is
+// dropped rather than translated.
+func TestStripAntigravityUnsupportedThinkingConfig(t *testing.T) {
+	payload := []byte(`{"request":{"generationConfig":{"maxOutputTokens":64,"thinkingConfig":{"thinkingLevel":"low","includeThoughts":true}}}}`)
+
+	got := stripAntigravityUnsupportedThinkingConfig(payload, "gpt-oss-120b-medium")
+	if gjson.GetBytes(got, "request.generationConfig.thinkingConfig").Exists() {
+		t.Error("thinkingConfig must be removed for the GPT family")
+	}
+	if gjson.GetBytes(got, "request.generationConfig.maxOutputTokens").Int() != 64 {
+		t.Error("the rest of generationConfig must survive")
+	}
+
+	for _, model := range []string{"claude-opus-4-6-thinking", "gemini-3-pro-high"} {
+		got := stripAntigravityUnsupportedThinkingConfig(payload, model)
+		if !gjson.GetBytes(got, "request.generationConfig.thinkingConfig").Exists() {
+			t.Errorf("%s: thinkingConfig must be preserved", model)
+		}
+	}
+}
+
+// A generationConfig that held nothing but an unsupported thinkingConfig is
+// removed outright rather than left behind as an empty object.
+func TestStripAntigravityUnsupportedThinkingConfigDropsEmptyGenerationConfig(t *testing.T) {
+	payload := []byte(`{"request":{"generationConfig":{"thinkingConfig":{"includeThoughts":true}}}}`)
+	got := stripAntigravityUnsupportedThinkingConfig(payload, "gpt-oss-120b-medium")
+	if gjson.GetBytes(got, "request.generationConfig").Exists() {
+		t.Error("an emptied generationConfig must be dropped")
+	}
+}

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -97,22 +97,20 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 		}
 	}
 
-	// Gemini-specific handling for non-Claude models:
-	// - Add skip_thought_signature_validator to functionCall parts so upstream can bypass signature validation.
-	// - Also mark thinking parts with the same sentinel when present (we keep the parts; we only annotate them).
+	// Stamp the skip sentinel onto functionCall parts so the upstream waives
+	// signature validation for them. Claude is left alone: it validates the
+	// signature for real and rejects a made-up one.
+	//
+	// Thought parts deliberately are NOT stamped here. The sentinel only
+	// satisfies the Gemini family, and the executor settles that for every
+	// entrypoint in sanitizeAntigravityThoughts — stamping a GPT or Claude
+	// thought with it here just moved the failure one step downstream.
 	if !strings.Contains(modelName, "claude") {
 		const skipSentinel = "skip_thought_signature_validator"
 
 		gjson.GetBytes(rawJSON, "request.contents").ForEach(func(contentIdx, content gjson.Result) bool {
 			if content.Get("role").String() == "model" {
-				// First pass: collect indices of thinking parts to mark with skip sentinel
-				var thinkingIndicesToSkipSignature []int64
 				content.Get("parts").ForEach(func(partIdx, part gjson.Result) bool {
-					// Collect indices of thinking blocks to mark with skip sentinel
-					if part.Get("thought").Bool() {
-						thinkingIndicesToSkipSignature = append(thinkingIndicesToSkipSignature, partIdx.Int())
-					}
-					// Add skip sentinel to functionCall parts
 					if part.Get("functionCall").Exists() {
 						existingSig := part.Get("thoughtSignature").String()
 						if existingSig == "" || len(existingSig) < 50 {
@@ -121,12 +119,6 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 					}
 					return true
 				})
-
-				// Add skip_thought_signature_validator sentinel to thinking blocks in reverse order to preserve indices
-				for i := len(thinkingIndicesToSkipSignature) - 1; i >= 0; i-- {
-					idx := thinkingIndicesToSkipSignature[i]
-					rawJSON, _ = sjson.SetBytes(rawJSON, fmt.Sprintf("request.contents.%d.parts.%d.thoughtSignature", contentIdx.Int(), idx), skipSentinel)
-				}
 			}
 			return true
 		})

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_reasoning_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_reasoning_test.go
@@ -1,0 +1,88 @@
+package responses
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/cache"
+	"github.com/tidwall/gjson"
+)
+
+// reasoningReplayRequest is the shape a Responses client sends on the turn after
+// a tool call: the reasoning item it received back, then the call and its
+// output. `encrypted_content` is absent, which is the usual case — clients only
+// return it when the caller asked for it and stored it.
+func reasoningReplayRequest(model, encryptedContent string) []byte {
+	encrypted := ""
+	if encryptedContent != "" {
+		encrypted = `,"encrypted_content":"` + encryptedContent + `"`
+	}
+	return []byte(`{"model":"` + model + `","input":[` +
+		`{"type":"message","role":"user","content":[{"type":"input_text","text":"use calc on 1*8"}]},` +
+		`{"type":"reasoning","summary":[{"type":"summary_text","text":"Call calc."}],"content":[{"type":"reasoning_text","text":"Call calc."}]` + encrypted + `},` +
+		`{"type":"function_call","call_id":"call_1","name":"calc","arguments":"{\"expr\":\"1*8\"}"},` +
+		`{"type":"function_call_output","call_id":"call_1","output":"8"}` +
+		`],"stream":true}`)
+}
+
+func thoughtPartCount(payload []byte) int {
+	count := 0
+	gjson.GetBytes(payload, "contents").ForEach(func(_, content gjson.Result) bool {
+		content.Get("parts").ForEach(func(_, part gjson.Result) bool {
+			if part.Get("thought").Bool() {
+				count++
+			}
+			return true
+		})
+		return true
+	})
+	return count
+}
+
+// Writing an empty signature out is what broke these turns: the upstream
+// answered "thinking.signature: Field required" for Claude and
+// "Expected a(n) 'messages' array element to be an object." for GPT. With
+// nothing valid to send, the reasoning item is dropped instead.
+func TestConvertOpenAIResponsesRequestToGeminiDropsUnsignedReasoning(t *testing.T) {
+	for _, model := range []string{"claude-opus-4-6-thinking", "gpt-oss-120b-medium"} {
+		got := ConvertOpenAIResponsesRequestToGemini(model, reasoningReplayRequest(model, ""), true)
+		if n := thoughtPartCount(got); n != 0 {
+			t.Errorf("%s: thought parts = %d, want 0", model, n)
+		}
+		if strings.Contains(string(got), `"thoughtSignature":""`) {
+			t.Errorf("%s: an empty thoughtSignature must never be emitted: %s", model, got)
+		}
+		// Dropping the reasoning must not disturb the turns around it.
+		if !gjson.GetBytes(got, "contents.1.parts.0.functionCall").Exists() {
+			t.Errorf("%s: the function call turn must survive: %s", model, got)
+		}
+		if !gjson.GetBytes(got, "contents.2.parts.0.functionResponse").Exists() {
+			t.Errorf("%s: the function response turn must survive: %s", model, got)
+		}
+	}
+}
+
+// The Gemini family accepts the skip sentinel, which is what the signature
+// cache hands back for it, so its reasoning is still replayed.
+func TestConvertOpenAIResponsesRequestToGeminiKeepsGeminiReasoning(t *testing.T) {
+	got := ConvertOpenAIResponsesRequestToGemini("gemini-3-pro-high", reasoningReplayRequest("gemini-3-pro-high", ""), true)
+	if n := thoughtPartCount(got); n != 1 {
+		t.Fatalf("thought parts = %d, want 1: %s", n, got)
+	}
+	if sig := gjson.GetBytes(got, "contents.1.parts.0.thoughtSignature").String(); sig != "skip_thought_signature_validator" {
+		t.Errorf("thoughtSignature = %q, want the skip sentinel", sig)
+	}
+}
+
+// A client that does return `encrypted_content` gets it replayed verbatim —
+// that is the only signature Anthropic actually accepts.
+func TestConvertOpenAIResponsesRequestToGeminiKeepsSignedReasoning(t *testing.T) {
+	signature := strings.Repeat("s", cache.MinValidSignatureLen+8)
+	got := ConvertOpenAIResponsesRequestToGemini("claude-opus-4-6-thinking", reasoningReplayRequest("claude-opus-4-6-thinking", signature), true)
+	if n := thoughtPartCount(got); n != 1 {
+		t.Fatalf("thought parts = %d, want 1: %s", n, got)
+	}
+	if sig := gjson.GetBytes(got, "contents.1.parts.0.thoughtSignature").String(); sig != signature {
+		t.Errorf("thoughtSignature = %q, want the client signature preserved", sig)
+	}
+}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -3,6 +3,7 @@ package responses
 import (
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/translator/gemini/common"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -13,9 +14,8 @@ const geminiResponsesThoughtSignature = "skip_thought_signature_validator"
 func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := inputRawJSON
 
-	// Note: modelName and stream parameters are part of the fixed method signature
-	_ = modelName // Unused but required by interface
-	_ = stream    // Unused but required by interface
+	// Note: the stream parameter is part of the fixed method signature.
+	_ = stream // Unused but required by interface
 
 	// Base Gemini API template (do not include thinkingConfig by default)
 	out := `{"contents":[]}`
@@ -329,10 +329,29 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				out, _ = sjson.SetRaw(out, "contents.-1", functionContent)
 
 			case "reasoning":
+				// A reasoning item may only be replayed when it carries a
+				// signature the upstream will accept. Responses clients rarely
+				// send `encrypted_content` back, and writing the empty string
+				// out anyway is what made these turns fail: Anthropic answers
+				// it with "thinking.signature: Field required".
+				//
+				// Fall back to the signature cache, which hands the Gemini
+				// family its skip sentinel and everyone else an empty string,
+				// then drop the item when nothing valid turned up — the same
+				// rule the Claude translator already applies.
+				thoughtText := item.Get("summary.0.text").String()
+				signature := item.Get("encrypted_content").String()
+				if !cache.HasValidSignature(modelName, signature) {
+					signature = cache.GetCachedSignature(modelName, thoughtText)
+				}
+				if !cache.HasValidSignature(modelName, signature) {
+					continue
+				}
+
 				thoughtContent := `{"role":"model","parts":[]}`
 				thought := `{"text":"","thoughtSignature":"","thought":true}`
-				thought, _ = sjson.Set(thought, "text", item.Get("summary.0.text").String())
-				thought, _ = sjson.Set(thought, "thoughtSignature", item.Get("encrypted_content").String())
+				thought, _ = sjson.Set(thought, "text", thoughtText)
+				thought, _ = sjson.Set(thought, "thoughtSignature", signature)
 
 				thoughtContent, _ = sjson.SetRaw(thoughtContent, "parts.-1", thought)
 				out, _ = sjson.SetRaw(out, "contents.-1", thoughtContent)


### PR DESCRIPTION
Three reported failures, all reproduced against the live upstream before changing anything.

## 1 & 2 — Antigravity multi-turn calls (`claude-*`, `gpt-oss-*`)

A second turn carrying a reasoning block back — an agent client that calls a tool, then sends the result — failed outright:

| model | upstream 400 |
|---|---|
| `claude-opus-4-6-thinking`, `claude-sonnet-4-6` | `messages.1.content.0.thinking.signature: Field required` |
| `gpt-oss-120b-medium` | `Expected a(n) 'messages' array element to be an object.` |

Single-turn calls worked, which is why the failure looked intermittent: only conversations that reached a second turn broke, and an agent client reaches one immediately.

**Root cause.** The Responses translator wrote `thoughtSignature` straight from the request's `encrypted_content`. Clients rarely return that, so the field went upstream as `""`. The antigravity translator then stamped the skip sentinel onto every thought part whose model was not Claude — sweeping the GPT family in with Gemini.

Probing the live upstream shows the three families disagree completely:

| family | thought + sentinel | thought + real signature | thought removed |
|---|---|---|---|
| gemini | **200** | 200 | 200 |
| claude | 400 `Invalid \`signature\`` | **200** | 200 |
| gpt | 400 | 400 | **200** |

So the sentinel is a Gemini-only affordance, Anthropic validates signatures for real, and the GPT family cannot take a replayed thought at all — CloudCode renders those turns as an OpenAI `messages` array and has no shape for one.

Each of the four entrypoint translators decided this for itself and only the Claude one had it right (it already drops unsigned thinking blocks). This settles it once in the executor, where all four formats meet, keyed off the existing model group so new models inherit the right rule without a code change.

Also drops `thinkingConfig` for the GPT family, which answers both `includeThoughts` and `thinkingLevel` with a bare 400 naming no field. Its reasoning effort already rides on the model id (`-low`/`-medium`/`-high`), so nothing is lost.

## 3 — Model catalogue probes returned 403

Testing any model from the catalogue answered `tenant business resources are not enabled for this tenant` unless the session was a platform admin, so chat, text-to-image, image-to-image and video models could not be probed.

The tenant-scope gate allow-lists paths and two of the three probes fell through it: `/models` is matched exactly so `/models/test` never hit it, and `/video-generation` was missing next to its `/image-generation` sibling. Both handlers already scope to the caller's effective tenant (`TenantMetadataKey`, `ListForTenant(effectiveTenantID)`), so this widens the gate to what they were written to serve, not past it.

## Verification

End to end against the live upstream, same config and credentials, this branch vs `origin/dev`:

| case | origin/dev | this branch |
|---|---|---|
| `claude-opus-4-6-thinking` responses multi-turn | 400 | **200** |
| `claude-sonnet-4-6` responses multi-turn | 400 | **200** |
| `gpt-oss-120b-medium` responses multi-turn | 400 | **200** |
| other 9 cases (single-turn, `/v1/messages`, `/v1/chat/completions`) | 200 | 200 |

9/16 → 12/16. The remaining 4 are `gemini-3.1-pro-high`, which fails identically on `origin/dev` — the model is unavailable upstream for these credentials (`gemini-3.1-pro` itself answers 404). Unrelated to this change; worth a separate look.

`scripts/ci-pr.sh` passes; full `go test ./...` is green across 99 packages.

New regression tests cover each family's replay rule, the sibling-part and emptied-content cases, the `thinkingConfig` strip, and all three probe paths.