### PR TITLE
fix(antigravity): cap Claude's maxOutputTokens at what the upstream accepts

### DIFF
--- a/internal/runtime/executor/antigravity_output_tokens.go
+++ b/internal/runtime/executor/antigravity_output_tokens.go
@@ -1,0 +1,59 @@
+package executor
+
+import (
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/cache"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// antigravityClaudeMaxOutputTokens is the ceiling CloudCode puts on
+// generationConfig.maxOutputTokens for the Claude family. Probed against the
+// live upstream on 2026-09-12: 64000 answers 200 and 64001 answers a bare 400
+// INVALID_ARGUMENT naming no field. The Gemini family takes 65536 at the same
+// spot, which is why only Claude requests failed.
+const antigravityClaudeMaxOutputTokens = 64000
+
+// clampAntigravityOutputTokens caps maxOutputTokens at what the model family
+// accepts, and keeps thinkingBudget under the cap it lands on.
+//
+// Clients pick their own ceiling and agent clients ask for the largest one they
+// know of — 65536 is common — so the value went upstream unchanged and failed
+// every Claude request before a single token was generated. The failure names
+// no field, so it reads as "the model is broken" rather than as one number
+// being one too high.
+//
+// Capping here rather than in a translator covers all four entrypoint formats
+// at once: this is the last point they share. Only requests that were already
+// doomed change shape; anything at or below the cap is passed through untouched.
+func clampAntigravityOutputTokens(payload string, modelName string) string {
+	if cache.GetModelGroup(modelName) != "claude" {
+		return payload
+	}
+
+	const maxOutputTokensPath = "request.generationConfig.maxOutputTokens"
+	current := gjson.Get(payload, maxOutputTokensPath)
+	if !current.Exists() || current.Int() <= antigravityClaudeMaxOutputTokens {
+		return payload
+	}
+
+	updated, err := sjson.Set(payload, maxOutputTokensPath, antigravityClaudeMaxOutputTokens)
+	if err != nil {
+		return payload
+	}
+
+	// The upstream also requires max_tokens > thinking.budget_tokens, and
+	// answers a violation with `max_tokens` must be greater than
+	// `thinking.budget_tokens`. A budget that cleared the client's own ceiling
+	// can exceed the one we just imposed, so lower it to stay inside the cap
+	// rather than trade one 400 for another.
+	const thinkingBudgetPath = "request.generationConfig.thinkingConfig.thinkingBudget"
+	budget := gjson.Get(updated, thinkingBudgetPath)
+	if !budget.Exists() || budget.Int() < antigravityClaudeMaxOutputTokens {
+		return updated
+	}
+	withBudget, err := sjson.Set(updated, thinkingBudgetPath, antigravityClaudeMaxOutputTokens-1)
+	if err != nil {
+		return updated
+	}
+	return withBudget
+}

--- a/internal/runtime/executor/antigravity_output_tokens_test.go
+++ b/internal/runtime/executor/antigravity_output_tokens_test.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestClampAntigravityOutputTokens_CapsClaudeAboveCeiling(t *testing.T) {
+	// The exact payload shape that failed: an agent client asking for 65536.
+	payload := `{"request":{"generationConfig":{"maxOutputTokens":65536,"thinkingConfig":{"includeThoughts":true,"thinkingBudget":24576}}}}`
+
+	got := clampAntigravityOutputTokens(payload, "claude-opus-4-6-thinking")
+
+	if v := gjson.Get(got, "request.generationConfig.maxOutputTokens").Int(); v != antigravityClaudeMaxOutputTokens {
+		t.Fatalf("maxOutputTokens = %d, want %d", v, antigravityClaudeMaxOutputTokens)
+	}
+	// A budget already under the cap is the client's choice; leave it alone.
+	if v := gjson.Get(got, "request.generationConfig.thinkingConfig.thinkingBudget").Int(); v != 24576 {
+		t.Fatalf("thinkingBudget = %d, want it untouched at 24576", v)
+	}
+	if v := gjson.Get(got, "request.generationConfig.thinkingConfig.includeThoughts").Bool(); !v {
+		t.Fatal("includeThoughts was dropped")
+	}
+}
+
+func TestClampAntigravityOutputTokens_LeavesClaudeAtOrBelowCeiling(t *testing.T) {
+	for _, value := range []int64{1, 8192, antigravityClaudeMaxOutputTokens} {
+		payload := `{"request":{"generationConfig":{"maxOutputTokens":` + itoa(value) + `}}}`
+
+		got := clampAntigravityOutputTokens(payload, "claude-sonnet-4-6")
+
+		if got != payload {
+			t.Fatalf("maxOutputTokens %d was rewritten: %s", value, got)
+		}
+	}
+}
+
+func TestClampAntigravityOutputTokens_KeepsThinkingBudgetUnderTheCap(t *testing.T) {
+	// A budget that cleared the client's own ceiling can exceed ours. Trading
+	// the bare 400 for "`max_tokens` must be greater than `thinking.budget_tokens`"
+	// would be no fix at all.
+	payload := `{"request":{"generationConfig":{"maxOutputTokens":70000,"thinkingConfig":{"thinkingBudget":65000}}}}`
+
+	got := clampAntigravityOutputTokens(payload, "claude-opus-4-6-thinking")
+
+	maxTokens := gjson.Get(got, "request.generationConfig.maxOutputTokens").Int()
+	budget := gjson.Get(got, "request.generationConfig.thinkingConfig.thinkingBudget").Int()
+	if maxTokens != antigravityClaudeMaxOutputTokens {
+		t.Fatalf("maxOutputTokens = %d, want %d", maxTokens, antigravityClaudeMaxOutputTokens)
+	}
+	if budget >= maxTokens {
+		t.Fatalf("thinkingBudget %d must stay below maxOutputTokens %d", budget, maxTokens)
+	}
+}
+
+func TestClampAntigravityOutputTokens_LeavesOtherFamiliesAlone(t *testing.T) {
+	// Gemini answers 200 at 65536, and the GPT family has its maxOutputTokens
+	// removed upstream of this call. Neither should be rewritten here.
+	payload := `{"request":{"generationConfig":{"maxOutputTokens":65536}}}`
+
+	for _, model := range []string{"gemini-3-flash", "gpt-oss-120b-medium", "some-new-model"} {
+		if got := clampAntigravityOutputTokens(payload, model); got != payload {
+			t.Fatalf("model %s was rewritten: %s", model, got)
+		}
+	}
+}
+
+func TestClampAntigravityOutputTokens_IgnoresPayloadWithoutTheField(t *testing.T) {
+	payload := `{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`
+
+	if got := clampAntigravityOutputTokens(payload, "claude-opus-4-6-thinking"); got != payload {
+		t.Fatalf("payload without maxOutputTokens was rewritten: %s", got)
+	}
+}

--- a/internal/runtime/executor/antigravity_request.go
+++ b/internal/runtime/executor/antigravity_request.go
@@ -94,6 +94,7 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	} else {
 		payloadStr, _ = sjson.Delete(payloadStr, "request.generationConfig.maxOutputTokens")
 	}
+	payloadStr = clampAntigravityOutputTokens(payloadStr, modelName)
 
 	payloadBytes := e.obfuscateSensitiveWords([]byte(payloadStr))
 	payloadStr = string(payloadBytes)


### PR DESCRIPTION
Reported as "Antigravity cannot use Claude models". Reproduced against the live upstream before changing anything.

## Symptom

Every Antigravity request for a Claude model carrying `max_tokens` above 64000 failed outright:

```json
{"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT"}}
```

Agent clients ask for the largest ceiling they know of — 65536 is common — so for them the model simply did not work, on the first turn, every time. The upstream names no field, so it reads as "this model is unavailable" rather than as one number being one too high.

This is **not** the multi-turn thinking failure from #1023. The request that prompted this was a first turn: `thoughtSignature` and `thought:true` both appear zero times in the captured body.

## Root cause

Probing the live upstream places the ceiling exactly at 64000:

| maxOutputTokens | `claude-opus-4-6-thinking` / `claude-sonnet-4-6` | `gemini-3-flash` |
|---|---|---|
| 8192 / 32768 / 64000 | 200 | 200 |
| 64001 / 65000 / 65536 | **400** | 200 |

`buildRequest` deletes `generationConfig.maxOutputTokens` for every family **except** Claude, so the client's value reached the upstream unchanged for precisely the family that has a limit. The Gemini family answers 200 at 65536, which is why only Claude broke.

Capping it in the executor rather than a translator covers all four entrypoint formats at once — this is the last point they share. It matters here: `/v1/responses`, `/v1/messages` and `/v1/chat/completions` were all affected, not just the one the report came through. Requests at or below the ceiling are passed through untouched.

The upstream also requires `max_tokens > thinking.budget_tokens`, answering a violation with `` `max_tokens` must be greater than `thinking.budget_tokens` ``. A budget that cleared the client's own ceiling can exceed the one we now impose, so `thinkingBudget` is lowered alongside it — otherwise the fix would trade one 400 for another.

## Verification

End to end against the live upstream on an isolated instance, same config and credentials, this branch vs `origin/dev`:

| case | origin/dev | this branch |
|---|---|---|
| `responses claude-opus-4-6-thinking max=65536` | 400 | **200** |
| `responses claude-sonnet-4-6 max=65536` | 400 | **200** |
| `messages claude-opus-4-6-thinking max=65536` | 400 | **200** |
| `messages claude-sonnet-4-6 max=65536` | 400 | **200** |
| `chat claude-sonnet-4-6 max=65536` | 400 | **200** |
| other 9 cases (gemini, gpt, smaller and absent max) | 200 | 200 |

9/14 → 14/14, with nothing regressing from 200. The 93KB request that prompted this, replayed unchanged through the built binary, returns 200 and a complete 114KB stream.

`go test ./...` is green and `scripts/check-backend-structure.py` passes. New tests cover the cap, the untouched pass-through at and below it, the `thinkingBudget` interaction, the other families, and a payload without the field.

Touches only `internal/runtime/executor`, so the translator path guard does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)