### PR TITLE
fix(antigravity): replay thinking only on terms each model family accepts (executor half of #1023)

### DIFF
--- a/internal/api/handlers/management/identity_auth.go
+++ b/internal/api/handlers/management/identity_auth.go
@@ -534,6 +534,11 @@ func isTenantScopedManagementPath(path string) bool {
 		strings.HasPrefix(relative, "/identity-fingerprint"),
 		strings.HasPrefix(relative, "/model-definitions/"),
 		strings.HasPrefix(relative, "/image-generation"),
+		// Text-to-video and image-to-video probes from the model catalogue.
+		// The image-generation sibling above was allowed through but this one
+		// was missed, so video models could not be tested from a business
+		// tenant at all.
+		strings.HasPrefix(relative, "/video-generation"),
 		relative == "/vertex/import",
 		strings.HasSuffix(relative, "-auth-url"),
 		relative == "/oauth-callback",
@@ -559,6 +564,11 @@ func isTenantScopedManagementPath(path string) bool {
 		relative == "/codex-oauth-admission":
 		return true
 	case relative == "/models",
+		// The catalogue's "test this model" dialog. It resolves the channel
+		// from the tenant's own auth files, so it is tenant-scoped in the same
+		// way /models is — listing it separately is what an exact == match on
+		// "/models" costs.
+		relative == "/models/test",
 		relative == "/models/configured-availability",
 		relative == "/model-path-availability",
 		strings.HasPrefix(relative, "/model-configs"),

--- a/internal/api/handlers/management/tenant_scope_gate_test.go
+++ b/internal/api/handlers/management/tenant_scope_gate_test.go
@@ -70,6 +70,33 @@ func TestTenantScopedManagementPathIncludesProviderRuntimeRoutes(t *testing.T) {
 	}
 }
 
+// The model catalogue's probes run on management authority and scope
+// themselves to the caller's effective tenant, so a business tenant must be
+// able to reach all three. /models/test and /video-generation/test were left
+// out, which is why testing a chat, image or video model from the catalogue
+// answered "tenant business resources are not enabled for this tenant".
+func TestTenantScopedManagementPathIncludesModelProbes(t *testing.T) {
+	tenantOperator := identity.Principal{
+		PlatformAdmin:   false,
+		EffectiveTenant: identity.Tenant{ID: "tenant-potato"},
+		HomeTenant:      identity.Tenant{ID: "tenant-potato"},
+	}
+	for _, path := range []string{
+		"/v0/management/models/test",
+		"/v0/management/image-generation/test",
+		"/v0/management/image-generation/test/task-1",
+		"/v0/management/video-generation/test",
+		"/v0/management/video-generation/test/task-1",
+	} {
+		if !isTenantScopedManagementPath(path) {
+			t.Errorf("isTenantScopedManagementPath(%q) = false", path)
+		}
+		if deniesTenantResourceScope(tenantOperator, path) {
+			t.Errorf("business tenant must reach %s", path)
+		}
+	}
+}
+
 func TestDeniesTenantResourceScopeAllowsBusinessTenantEndUsers(t *testing.T) {
 	tenantOperator := identity.Principal{
 		PlatformAdmin:   false,

--- a/internal/runtime/executor/antigravity_request.go
+++ b/internal/runtime/executor/antigravity_request.go
@@ -64,6 +64,15 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 	// Normalising here rather than in the translator covers every entrypoint
 	// format at once: this is the last point all of them pass through.
 	payloadStr = util.NormalizeGeminiContentRoles(payloadStr, "request.contents")
+
+	// Thinking replayed from an earlier turn is only accepted on the terms of
+	// the model family answering the call, and each entrypoint translator used
+	// to guess at those terms separately. Settle it here, where they all meet,
+	// so a thought block never reaches the upstream in a shape it rejects.
+	sanitized := sanitizeAntigravityThoughts([]byte(payloadStr), modelName)
+	sanitized = stripAntigravityUnsupportedThinkingConfig(sanitized, modelName)
+	payloadStr = string(sanitized)
+
 	paths := make([]string, 0)
 	util.Walk(gjson.Parse(payloadStr), "", "parametersJsonSchema", &paths)
 	for _, p := range paths {

--- a/internal/runtime/executor/antigravity_thinking.go
+++ b/internal/runtime/executor/antigravity_thinking.go
@@ -1,0 +1,144 @@
+package executor
+
+import (
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/cache"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// antigravityThoughtSentinel is the placeholder signature the Gemini family
+// accepts in place of a real one. The other families reject it — see
+// antigravityThinkingReplay below.
+const antigravityThoughtSentinel = "skip_thought_signature_validator"
+
+// antigravityThinkingReplay describes how much of a previous turn's thinking a
+// model family will accept when it is replayed in a follow-up request.
+type antigravityThinkingReplay int
+
+const (
+	// replaySentinelOK: an unsigned thought is fine as long as it carries the
+	// skip sentinel. Only the Gemini family behaves this way.
+	replaySentinelOK antigravityThinkingReplay = iota
+	// replaySignedOnly: only a genuine upstream signature is accepted. Anthropic
+	// answers an empty signature with "thinking.signature: Field required" and a
+	// fabricated one with "Invalid `signature` in `thinking` block".
+	replaySignedOnly
+	// replayNever: the family rejects a replayed thought whatever its signature.
+	// CloudCode renders GPT turns as an OpenAI `messages` array and has no shape
+	// for a thought part, so it fails the whole request with
+	// "Expected a(n) 'messages' array element to be an object."
+	replayNever
+)
+
+// antigravityThinkingReplayFor maps a model onto its family's replay rule.
+// It keys off the shared model group rather than a model list so newly
+// published models inherit the right behaviour without a code change.
+func antigravityThinkingReplayFor(modelName string) antigravityThinkingReplay {
+	switch cache.GetModelGroup(modelName) {
+	case "gemini":
+		return replaySentinelOK
+	case "gpt":
+		return replayNever
+	case "claude":
+		return replaySignedOnly
+	default:
+		// Unknown families get the conservative rule: replaying an unsigned
+		// thought is what breaks requests, dropping one never does.
+		return replaySignedOnly
+	}
+}
+
+// sanitizeAntigravityThoughts drops thought parts the upstream would reject and
+// tops up the sentinel for the family that wants one.
+//
+// Every entrypoint format (Gemini, Claude, OpenAI chat completions, OpenAI
+// responses) has its own translator, and each one used to decide this for
+// itself — the Claude translator dropped unsigned thoughts correctly while the
+// Responses translator emitted an empty signature. Doing it here instead covers
+// all four at once, because this is the last point they share.
+func sanitizeAntigravityThoughts(payload []byte, modelName string) []byte {
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return payload
+	}
+	policy := antigravityThinkingReplayFor(modelName)
+
+	type drop struct {
+		contentIdx int
+		partIdx    int
+	}
+	var partDrops []drop
+	var contentDrops []int
+
+	contentResults := contents.Array()
+	for contentIdx, content := range contentResults {
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			continue
+		}
+		partResults := parts.Array()
+		kept := 0
+		for partIdx, part := range partResults {
+			if !part.Get("thought").Bool() {
+				kept++
+				continue
+			}
+			signature := part.Get("thoughtSignature").String()
+			switch policy {
+			case replayNever:
+				partDrops = append(partDrops, drop{contentIdx, partIdx})
+			case replaySentinelOK:
+				if !cache.HasValidSignature(modelName, signature) {
+					payload, _ = sjson.SetBytes(payload, fmt.Sprintf("request.contents.%d.parts.%d.thoughtSignature", contentIdx, partIdx), antigravityThoughtSentinel)
+				}
+				kept++
+			default: // replaySignedOnly
+				if cache.HasValidSignature(modelName, signature) && signature != antigravityThoughtSentinel {
+					kept++
+					continue
+				}
+				partDrops = append(partDrops, drop{contentIdx, partIdx})
+			}
+		}
+		// A content left with no parts is itself invalid upstream ("required
+		// oneof field 'data' must have one initialized field"), so it goes too.
+		if kept == 0 && len(partResults) > 0 {
+			contentDrops = append(contentDrops, contentIdx)
+		}
+	}
+
+	// Delete back to front so the earlier indices stay addressable.
+	for i := len(partDrops) - 1; i >= 0; i-- {
+		d := partDrops[i]
+		payload, _ = sjson.DeleteBytes(payload, fmt.Sprintf("request.contents.%d.parts.%d", d.contentIdx, d.partIdx))
+	}
+	for i := len(contentDrops) - 1; i >= 0; i-- {
+		payload, _ = sjson.DeleteBytes(payload, fmt.Sprintf("request.contents.%d", contentDrops[i]))
+	}
+	return payload
+}
+
+// stripAntigravityUnsupportedThinkingConfig removes a thinkingConfig the model
+// cannot accept.
+//
+// The GPT family rejects both `includeThoughts` and `thinkingLevel` with a bare
+// 400 that names no field, which is easy to misread as a broken credential. Its
+// reasoning effort is already carried by the model id itself (gpt-oss-120b-low
+// / -medium / -high), so nothing is lost by dropping the block.
+func stripAntigravityUnsupportedThinkingConfig(payload []byte, modelName string) []byte {
+	if cache.GetModelGroup(modelName) != "gpt" {
+		return payload
+	}
+	if !gjson.GetBytes(payload, "request.generationConfig.thinkingConfig").Exists() {
+		return payload
+	}
+	payload, _ = sjson.DeleteBytes(payload, "request.generationConfig.thinkingConfig")
+	// An empty generationConfig is harmless but noisy; drop it when it was only
+	// ever holding the thinkingConfig.
+	if gen := gjson.GetBytes(payload, "request.generationConfig"); gen.IsObject() && len(gen.Map()) == 0 {
+		payload, _ = sjson.DeleteBytes(payload, "request.generationConfig")
+	}
+	return payload
+}

--- a/internal/runtime/executor/antigravity_thinking_test.go
+++ b/internal/runtime/executor/antigravity_thinking_test.go
@@ -1,0 +1,146 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// realSignature stands in for a genuine upstream signature: what matters to the
+// code under test is only that it clears cache.MinValidSignatureLen.
+var realSignature = strings.Repeat("s", 64)
+
+func thoughtPayload(signature string) []byte {
+	return []byte(`{"request":{"contents":[` +
+		`{"role":"user","parts":[{"text":"count to two"}]},` +
+		`{"role":"model","parts":[{"text":"thinking out loud","thought":true,"thoughtSignature":"` + signature + `"}]},` +
+		`{"role":"model","parts":[{"functionCall":{"name":"calc","args":{}}}]}` +
+		`]}}`)
+}
+
+func thoughtParts(t *testing.T, payload []byte) []gjson.Result {
+	t.Helper()
+	var out []gjson.Result
+	gjson.GetBytes(payload, "request.contents").ForEach(func(_, content gjson.Result) bool {
+		content.Get("parts").ForEach(func(_, part gjson.Result) bool {
+			if part.Get("thought").Bool() {
+				out = append(out, part)
+			}
+			return true
+		})
+		return true
+	})
+	return out
+}
+
+// The GPT family has no shape for a replayed thought: CloudCode renders those
+// turns as an OpenAI messages array and fails the whole request with
+// "Expected a(n) 'messages' array element to be an object." Verified against
+// the live upstream — the same payload with the thought removed answers 200.
+func TestSanitizeAntigravityThoughtsDropsThoughtsForGPT(t *testing.T) {
+	for _, signature := range []string{"", antigravityThoughtSentinel, realSignature} {
+		got := sanitizeAntigravityThoughts(thoughtPayload(signature), "gpt-oss-120b-medium")
+		if parts := thoughtParts(t, got); len(parts) != 0 {
+			t.Errorf("signature %q: thought parts survived: %v", signature, parts)
+		}
+		if n := gjson.GetBytes(got, "request.contents.#").Int(); n != 2 {
+			t.Errorf("signature %q: contents = %d, want 2 (the emptied one is dropped too)", signature, n)
+		}
+		if !gjson.GetBytes(got, "request.contents.1.parts.0.functionCall").Exists() {
+			t.Errorf("signature %q: the functionCall turn must survive", signature)
+		}
+	}
+}
+
+// Anthropic validates the signature for real: an empty one comes back as
+// "thinking.signature: Field required" and a fabricated one as
+// "Invalid `signature` in `thinking` block". Only a genuine signature may be
+// replayed; anything else has to go.
+func TestSanitizeAntigravityThoughtsDropsUnsignedThoughtsForClaude(t *testing.T) {
+	for _, signature := range []string{"", antigravityThoughtSentinel} {
+		got := sanitizeAntigravityThoughts(thoughtPayload(signature), "claude-opus-4-6-thinking")
+		if parts := thoughtParts(t, got); len(parts) != 0 {
+			t.Errorf("signature %q: unsigned thought survived: %v", signature, parts)
+		}
+	}
+
+	got := sanitizeAntigravityThoughts(thoughtPayload(realSignature), "claude-opus-4-6-thinking")
+	parts := thoughtParts(t, got)
+	if len(parts) != 1 {
+		t.Fatalf("signed thought parts = %d, want 1", len(parts))
+	}
+	if sig := parts[0].Get("thoughtSignature").String(); sig != realSignature {
+		t.Errorf("signature = %q, want the original to be preserved", sig)
+	}
+}
+
+// Gemini is the one family that accepts the sentinel, so an unsigned thought is
+// topped up rather than dropped and the turn keeps its context.
+func TestSanitizeAntigravityThoughtsFillsSentinelForGemini(t *testing.T) {
+	got := sanitizeAntigravityThoughts(thoughtPayload(""), "gemini-3-pro-high")
+	parts := thoughtParts(t, got)
+	if len(parts) != 1 {
+		t.Fatalf("thought parts = %d, want 1", len(parts))
+	}
+	if sig := parts[0].Get("thoughtSignature").String(); sig != antigravityThoughtSentinel {
+		t.Errorf("thoughtSignature = %q, want %q", sig, antigravityThoughtSentinel)
+	}
+	if n := gjson.GetBytes(got, "request.contents.#").Int(); n != 3 {
+		t.Errorf("contents = %d, want all 3 kept", n)
+	}
+}
+
+// A thought sharing a part list with real content must not take that content
+// with it: only the thought part itself is removed.
+func TestSanitizeAntigravityThoughtsKeepsSiblingParts(t *testing.T) {
+	payload := []byte(`{"request":{"contents":[` +
+		`{"role":"model","parts":[` +
+		`{"text":"thinking","thought":true,"thoughtSignature":""},` +
+		`{"text":"the answer is two"}` +
+		`]}]}}`)
+
+	got := sanitizeAntigravityThoughts(payload, "claude-opus-4-6-thinking")
+	if n := gjson.GetBytes(got, "request.contents.#").Int(); n != 1 {
+		t.Fatalf("contents = %d, want 1", n)
+	}
+	parts := gjson.GetBytes(got, "request.contents.0.parts").Array()
+	if len(parts) != 1 {
+		t.Fatalf("parts = %d, want 1", len(parts))
+	}
+	if text := parts[0].Get("text").String(); text != "the answer is two" {
+		t.Errorf("surviving part text = %q", text)
+	}
+}
+
+// Both `includeThoughts` and `thinkingLevel` draw a bare 400 from the GPT
+// family. Its reasoning effort already rides on the model id, so the block is
+// dropped rather than translated.
+func TestStripAntigravityUnsupportedThinkingConfig(t *testing.T) {
+	payload := []byte(`{"request":{"generationConfig":{"maxOutputTokens":64,"thinkingConfig":{"thinkingLevel":"low","includeThoughts":true}}}}`)
+
+	got := stripAntigravityUnsupportedThinkingConfig(payload, "gpt-oss-120b-medium")
+	if gjson.GetBytes(got, "request.generationConfig.thinkingConfig").Exists() {
+		t.Error("thinkingConfig must be removed for the GPT family")
+	}
+	if gjson.GetBytes(got, "request.generationConfig.maxOutputTokens").Int() != 64 {
+		t.Error("the rest of generationConfig must survive")
+	}
+
+	for _, model := range []string{"claude-opus-4-6-thinking", "gemini-3-pro-high"} {
+		got := stripAntigravityUnsupportedThinkingConfig(payload, model)
+		if !gjson.GetBytes(got, "request.generationConfig.thinkingConfig").Exists() {
+			t.Errorf("%s: thinkingConfig must be preserved", model)
+		}
+	}
+}
+
+// A generationConfig that held nothing but an unsupported thinkingConfig is
+// removed outright rather than left behind as an empty object.
+func TestStripAntigravityUnsupportedThinkingConfigDropsEmptyGenerationConfig(t *testing.T) {
+	payload := []byte(`{"request":{"generationConfig":{"thinkingConfig":{"includeThoughts":true}}}}`)
+	got := stripAntigravityUnsupportedThinkingConfig(payload, "gpt-oss-120b-medium")
+	if gjson.GetBytes(got, "request.generationConfig").Exists() {
+		t.Error("an emptied generationConfig must be dropped")
+	}
+}


### PR DESCRIPTION
This is #1023 minus its `internal/translator` changes, so it can land under the translator path guard that blocked the original. Same behaviour, verified below.

## The failure

A second turn carrying a reasoning block back — an agent client that calls a tool, then sends the result — failed outright:

| model | upstream 400 |
|---|---|
| `claude-opus-4-6-thinking`, `claude-sonnet-4-6` | `messages.1.content.0.thinking.signature: Field required` |
| `gpt-oss-120b-medium` | `Expected a(n) 'messages' array element to be an object.` |

Single-turn calls worked, which is why it looked intermittent: only conversations reaching a second turn broke, and an agent client reaches one immediately.

## Root cause

Probing the live upstream shows the three families disagree completely:

| family | thought + sentinel | thought + real signature | thought removed |
|---|---|---|---|
| gemini | **200** | 200 | 200 |
| claude | 400 ``Invalid `signature` `` | **200** | 200 |
| gpt | 400 | 400 | **200** |

The sentinel is a Gemini-only affordance, Anthropic validates signatures for real, and the GPT family cannot take a replayed thought at all — CloudCode renders those turns as an OpenAI `messages` array and has no shape for one.

Each of the four entrypoint translators decided this for itself and only the Claude one had it right. This settles it once in the executor, where all four formats meet, keyed off the existing model group so new models inherit the right rule without a code change.

Also drops `thinkingConfig` for the GPT family, which answers both `includeThoughts` and `thinkingLevel` with a bare 400 naming no field. Its reasoning effort already rides on the model id (`-low`/`-medium`/`-high`), so nothing is lost.

## Why the executor half stands alone

The executor is the deciding layer, not a second opinion: it drops a Claude thought whose signature is empty **or** is the sentinel (`HasValidSignature("")` is false, and the sentinel is excluded explicitly), and drops a GPT thought unconditionally. A translator writing either one upstream of it therefore cannot reach the API. That is what makes the split safe rather than merely convenient.

The two translator changes in #1023 remain worth making on their own terms and are tracked separately — see the linked issue. One is dead-code removal now that the executor decides; the other lets the Responses entrypoint recover a **real** signature from the signature cache, which would let Claude *keep* a replayed thought instead of dropping it. That is a quality difference on a working request, not a success/failure one, and it is not exercised by the cases below.

## Verification

Three binaries against the live upstream on an isolated instance, same config and credentials:

| case | origin/dev | full #1023 | this branch |
|---|---|---|---|
| multi-turn `claude-opus-4-6-thinking` | 400 | 200 | **200** |
| multi-turn `claude-sonnet-4-6` | 400 | 200 | **200** |
| multi-turn `gpt-oss-120b-medium` | 400 | 200 | **200** |
| multi-turn `gemini-3-flash` | 200 | 200 | 200 |
| single-turn, all four models | 200 | 200 | 200 |

**5/8 on dev, 8/8 both with and without the translator changes** — the split loses nothing measurable here.

`go test ./internal/runtime/executor/... ./internal/api/handlers/management/...` is green. The regression tests from #1023 covering each family's replay rule, the sibling-part and emptied-content cases and the `thinkingConfig` strip all come along; only the translator-directory test file stays behind.

## Also included

`fix(management): let business tenants run the model catalogue's probes` — the second, unrelated fix from #1023, which never touched `internal/translator` either. Testing any model from the catalogue answered `tenant business resources are not enabled for this tenant` unless the session was a platform admin.

Supersedes the mergeable part of #1023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)