### PR TITLE
feat(models,codex): shape the catalog probe per modality and let accounts pick an image model

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -87,6 +87,7 @@ func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Man
 	}
 	h.imageGeneration = h.newImageGenerationService()
 	h.videoGeneration = h.newVideoGenerationService()
+	h.modelTest = h.newModelTestService()
 	return h
 }
 

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -51,6 +51,7 @@ type Handler struct {
 	systemStatsCache     systemStatsCacheEntry
 	imageGeneration      *imagegeneration.Service
 	videoGeneration      *imagegeneration.Service
+	modelTest            *imagegeneration.Service
 	identityService      *identity.Service
 	aiAccountStatus      *aiaccountstatus.Service
 	statusScheduler      *aiaccountstatus.Scheduler

--- a/internal/api/handlers/management/model_test_modality.go
+++ b/internal/api/handlers/management/model_test_modality.go
@@ -1,0 +1,369 @@
+package management
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/tidwall/sjson"
+)
+
+// Modality routing for the model catalog probe.
+//
+// The probe used to build one shape for every model: a non-streaming chat
+// completion carrying the operator's prompt. For a text model that answers the
+// question an operator is asking ("can this be reached"). For gpt-image-2.5-flare
+// it does not — the request either comes back as prose, because the upstream
+// treated an image model as a chat model, or fails for a reason that says nothing
+// about the model's actual health. Either way the catalog reported on a code path
+// no real image client uses.
+//
+// Modality is derived from the model registry rather than trusted from the
+// caller. The registry is already the source /v1/images/* and /v1/videos/* use to
+// decide which models they serve, so deriving from it is what keeps "testable in
+// the catalog" and "servable in production" from drifting apart.
+
+type modelTestMode string
+
+const (
+	modeText           modelTestMode = "text"
+	modeVision         modelTestMode = "vision"
+	modeImage          modelTestMode = "image"
+	modeImageEdit      modelTestMode = "image_edit"
+	modeVideo          modelTestMode = "video"
+	modeVideoFromImage modelTestMode = "video_from_image"
+)
+
+// Default prompts per modality.
+//
+// These are kept in English on purpose: they are sent to the model, not shown as
+// UI copy, and every provider here is measurably better at following an English
+// prompt. Each one is written so a wrong result is obvious at a glance — a
+// specific subject and setting beats "draw something nice", which any model can
+// satisfy with anything.
+const (
+	defaultTextTestPrompt      = "How is the weather in Los Angeles today?"
+	defaultVisionTestPrompt    = "Describe this image in one sentence, and name any text you can read in it."
+	defaultImageTestPrompt     = "A red ceramic teapot on a white marble table, soft window light, photorealistic"
+	defaultImageEditTestPrompt = "Replace the background with a snowy mountain range. Keep the main subject unchanged."
+	defaultVideoTestPrompt     = "A paper boat drifting across a rain puddle, close-up, gentle ripples, natural daylight"
+	defaultVideoImagePrompt    = "Slowly push the camera in while the scene comes to life with subtle motion."
+)
+
+// modelTestModeInfo describes one runnable probe shape for a model.
+type modelTestModeInfo struct {
+	Mode          modelTestMode `json:"mode"`
+	DefaultPrompt string        `json:"default_prompt"`
+	// RequiresImage marks the modes whose whole point is a reference image, so the
+	// panel can require an upload instead of letting the operator submit a request
+	// the upstream will reject.
+	RequiresImage bool `json:"requires_image"`
+}
+
+// modelTestOptions is everything the panel needs to render a correct form for one
+// model. It is served by the API rather than inferred in the browser because the
+// browser only has the model id and its OpenRouter modality tags, which say
+// nothing about whether this deployment can run an edit or an image-to-video call
+// for that model.
+type modelTestOptions struct {
+	Model              string              `json:"model"`
+	Modes              []modelTestModeInfo `json:"modes"`
+	Sizes              []string            `json:"sizes,omitempty"`
+	Qualities          []string            `json:"qualities,omitempty"`
+	MaxImages          int                 `json:"max_images,omitempty"`
+	MaxDurationSeconds int                 `json:"max_duration_seconds,omitempty"`
+}
+
+// imageTestQualities mirrors the levels the image console offers. Kept as a plain
+// list because the upstream validates the value and an unknown one is a 400, so
+// the panel should only ever offer levels that exist.
+var imageTestQualities = []string{"low", "medium", "high"}
+
+// modelTestModes reports the probe shapes a model supports, most representative
+// first. The first entry is what the panel selects by default, so an image model
+// opens on "generate an image" rather than on a chat box.
+func modelTestModes(model string) []modelTestModeInfo {
+	switch {
+	case registry.IsVideoGenerationModel(model):
+		modes := []modelTestModeInfo{{Mode: modeVideo, DefaultPrompt: defaultVideoTestPrompt}}
+		if registry.SupportsImageToVideo(model) {
+			modes = append(modes, modelTestModeInfo{
+				Mode:          modeVideoFromImage,
+				DefaultPrompt: defaultVideoImagePrompt,
+				RequiresImage: true,
+			})
+		}
+		return modes
+	case registry.IsImageGenerationModel(model):
+		modes := []modelTestModeInfo{{Mode: modeImage, DefaultPrompt: defaultImageTestPrompt}}
+		if registry.SupportsImageEditing(model) {
+			modes = append(modes, modelTestModeInfo{
+				Mode:          modeImageEdit,
+				DefaultPrompt: defaultImageEditTestPrompt,
+				RequiresImage: true,
+			})
+		}
+		return modes
+	default:
+		// Vision is offered for every chat model rather than gated on a capability
+		// flag: the catalog's modality metadata is missing or wrong for a good part
+		// of the library, and a model that cannot see returns a clear upstream
+		// error, which is a better answer than hiding the button that would have
+		// proved it.
+		return []modelTestModeInfo{
+			{Mode: modeText, DefaultPrompt: defaultTextTestPrompt},
+			{Mode: modeVision, DefaultPrompt: defaultVisionTestPrompt, RequiresImage: true},
+		}
+	}
+}
+
+// buildModelTestOptions assembles the form description for one model.
+func buildModelTestOptions(model, tenantID string) modelTestOptions {
+	options := modelTestOptions{Model: model, Modes: modelTestModes(model)}
+	for _, mode := range options.Modes {
+		switch mode.Mode {
+		case modeImage, modeImageEdit:
+			options.Sizes = imageGenerationSizePresetsForTenant(tenantID)
+			options.Qualities = imageTestQualities
+			options.MaxImages = imageMaxUploads
+		case modeVideo, modeVideoFromImage:
+			options.MaxImages = 1
+			if _, _, ok := registry.VideoGenerationModelDefaults(model); ok {
+				for _, item := range registry.ListVideoGenerationModels() {
+					if strings.EqualFold(item.ID, model) {
+						options.MaxDurationSeconds = item.MaxDurationSeconds
+						break
+					}
+				}
+			}
+		}
+	}
+	return options
+}
+
+// resolveModelTestMode picks the probe shape to run. An empty request mode takes
+// the model's default; an explicit one is validated against the same list the
+// panel was given, so a stale tab cannot ask for an edit on a model that has none.
+func resolveModelTestMode(model, requested string) (modelTestMode, error) {
+	modes := modelTestModes(model)
+	requested = strings.TrimSpace(strings.ToLower(requested))
+	if requested == "" {
+		return modes[0].Mode, nil
+	}
+	for _, mode := range modes {
+		if string(mode.Mode) == requested {
+			return mode.Mode, nil
+		}
+	}
+	names := make([]string, 0, len(modes))
+	for _, mode := range modes {
+		names = append(names, string(mode.Mode))
+	}
+	return "", fmt.Errorf("model %q does not support test mode %q (supported: %s)",
+		model, requested, strings.Join(names, ", "))
+}
+
+// modeRequiresImage reports whether a mode is meaningless without a reference
+// image.
+func modeRequiresImage(mode modelTestMode) bool {
+	return mode == modeImageEdit || mode == modeVision || mode == modeVideoFromImage
+}
+
+// upstreamAlt maps a mode to the executor alt that selects the upstream endpoint.
+// Text modes have none: they go through the normal chat completion path.
+func upstreamAlt(mode modelTestMode) string {
+	switch mode {
+	case modeImage:
+		return imageGenerationAlt
+	case modeImageEdit:
+		return imageEditsAlt
+	case modeVideo, modeVideoFromImage:
+		return videoGenerationAlt
+	default:
+		return ""
+	}
+}
+
+// buildUpstreamPayload turns a validated probe request into the body its upstream
+// endpoint expects. Each branch produces exactly the shape a real client of that
+// endpoint would send, which is the point: a probe that tests a bespoke shape
+// proves nothing about the path production traffic takes.
+func buildUpstreamPayload(req modelTestRequest, mode modelTestMode) ([]byte, error) {
+	switch mode {
+	case modeImage, modeImageEdit:
+		return buildImageTestPayload(req, mode)
+	case modeVideo, modeVideoFromImage:
+		return buildVideoTestPayload(req, mode)
+	case modeVision:
+		return buildVisionTestPayload(req)
+	default:
+		return buildChatTestPayload(req)
+	}
+}
+
+func buildChatTestPayload(req modelTestRequest) ([]byte, error) {
+	payload := []byte(`{"stream":false,"messages":[]}`)
+	var err error
+	if payload, err = sjson.SetBytes(payload, "model", req.Model); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	if payload, err = sjson.SetBytes(payload, "messages.0.role", "user"); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	if payload, err = sjson.SetBytes(payload, "messages.0.content", req.Prompt); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	return payload, nil
+}
+
+// buildVisionTestPayload sends the prompt alongside the reference images using
+// the multi-part content form, which is what a vision client sends.
+func buildVisionTestPayload(req modelTestRequest) ([]byte, error) {
+	payload := []byte(`{"stream":false,"messages":[{"role":"user","content":[]}]}`)
+	var err error
+	if payload, err = sjson.SetBytes(payload, "model", req.Model); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	if payload, err = sjson.SetBytes(payload, "messages.0.content.0", map[string]any{
+		"type": "text",
+		"text": req.Prompt,
+	}); err != nil {
+		return nil, fmt.Errorf("build model test payload: %w", err)
+	}
+	for index, image := range req.Images {
+		part := map[string]any{
+			"type":      "image_url",
+			"image_url": map[string]any{"url": image},
+		}
+		if payload, err = sjson.SetBytes(payload, fmt.Sprintf("messages.0.content.%d", index+1), part); err != nil {
+			return nil, fmt.Errorf("build model test payload: %w", err)
+		}
+	}
+	return payload, nil
+}
+
+func buildImageTestPayload(req modelTestRequest, mode modelTestMode) ([]byte, error) {
+	payload := []byte(`{}`)
+	var err error
+	if payload, err = sjson.SetBytes(payload, "model", req.Model); err != nil {
+		return nil, fmt.Errorf("build image test payload: %w", err)
+	}
+	if payload, err = sjson.SetBytes(payload, "prompt", req.Prompt); err != nil {
+		return nil, fmt.Errorf("build image test payload: %w", err)
+	}
+	count := req.N
+	if count <= 0 {
+		count = 1
+	}
+	if payload, err = sjson.SetBytes(payload, "n", count); err != nil {
+		return nil, fmt.Errorf("build image test payload: %w", err)
+	}
+	for path, value := range map[string]string{"size": req.Size, "quality": req.Quality} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			if payload, err = sjson.SetBytes(payload, path, trimmed); err != nil {
+				return nil, fmt.Errorf("build image test payload: %w", err)
+			}
+		}
+	}
+	if mode == modeImageEdit {
+		// The edits endpoint reads its reference frames from "image". Data URIs are
+		// accepted here because the panel uploads through JSON rather than the
+		// multipart form a raw HTTP client would use.
+		if payload, err = sjson.SetBytes(payload, "image", req.Images); err != nil {
+			return nil, fmt.Errorf("build image test payload: %w", err)
+		}
+	}
+	return payload, nil
+}
+
+func buildVideoTestPayload(req modelTestRequest, mode modelTestMode) ([]byte, error) {
+	payload := []byte(`{}`)
+	var err error
+	if payload, err = sjson.SetBytes(payload, "model", req.Model); err != nil {
+		return nil, fmt.Errorf("build video test payload: %w", err)
+	}
+	if payload, err = sjson.SetBytes(payload, "prompt", req.Prompt); err != nil {
+		return nil, fmt.Errorf("build video test payload: %w", err)
+	}
+	if req.Duration > 0 {
+		if payload, err = sjson.SetBytes(payload, "duration", req.Duration); err != nil {
+			return nil, fmt.Errorf("build video test payload: %w", err)
+		}
+	}
+	for path, value := range map[string]string{
+		"aspect_ratio": req.AspectRatio,
+		"resolution":   req.Resolution,
+	} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			if payload, err = sjson.SetBytes(payload, path, trimmed); err != nil {
+				return nil, fmt.Errorf("build video test payload: %w", err)
+			}
+		}
+	}
+	if mode == modeVideoFromImage && len(req.Images) > 0 {
+		// xAI's media host animates a single source frame, so only the first upload
+		// is sent rather than silently dropping the rest inside the executor.
+		if payload, err = sjson.SetBytes(payload, "image", req.Images[0]); err != nil {
+			return nil, fmt.Errorf("build video test payload: %w", err)
+		}
+	}
+	return payload, nil
+}
+
+// maxModelTestImageBytes bounds one decoded reference image. The limit exists so a
+// mistaken upload fails in the panel with a clear message instead of after a
+// minute of uploading to the upstream.
+const maxModelTestImageBytes = 8 * 1024 * 1024
+
+// validateModelTestImages checks the reference images a mode needs. Both data
+// URIs and https URLs are accepted: the panel sends data URIs from a file picker,
+// while an operator reproducing a report usually has a URL.
+func validateModelTestImages(images []string, mode modelTestMode, maxImages int) ([]string, error) {
+	cleaned := make([]string, 0, len(images))
+	for _, image := range images {
+		image = strings.TrimSpace(image)
+		if image == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(image, "data:"):
+			decoded, err := dataURIBytes(image)
+			if err != nil {
+				return nil, err
+			}
+			if len(decoded) > maxModelTestImageBytes {
+				return nil, fmt.Errorf("reference image exceeds %d MB", maxModelTestImageBytes/(1024*1024))
+			}
+		case strings.HasPrefix(image, "https://"):
+		default:
+			return nil, fmt.Errorf("reference image must be a data URI or an https URL")
+		}
+		cleaned = append(cleaned, image)
+	}
+	if modeRequiresImage(mode) && len(cleaned) == 0 {
+		return nil, fmt.Errorf("test mode %q requires at least one reference image", mode)
+	}
+	if maxImages > 0 && len(cleaned) > maxImages {
+		return nil, fmt.Errorf("at most %d reference images are accepted", maxImages)
+	}
+	return cleaned, nil
+}
+
+// dataURIBytes decodes the base64 payload of a data URI so its real size can be
+// checked before it is forwarded.
+func dataURIBytes(uri string) ([]byte, error) {
+	comma := strings.IndexByte(uri, ',')
+	if comma < 0 {
+		return nil, fmt.Errorf("malformed data URI")
+	}
+	header := uri[:comma]
+	if !strings.Contains(header, ";base64") {
+		return nil, fmt.Errorf("data URI must be base64 encoded")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(uri[comma+1:])
+	if err != nil {
+		return nil, fmt.Errorf("malformed data URI")
+	}
+	return decoded, nil
+}

--- a/internal/api/handlers/management/model_test_modality_test.go
+++ b/internal/api/handlers/management/model_test_modality_test.go
@@ -1,0 +1,230 @@
+package management
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// The bug this whole file exists for: the catalog probe sent a chat completion
+// for every model, so testing an image model asked the upstream to have a
+// conversation with it and reported whatever prose came back as success.
+func TestImageModelDoesNotProbeAsChat(t *testing.T) {
+	modes := modelTestModes("gpt-image-2.5-flare")
+	if len(modes) == 0 {
+		t.Fatal("an image model must offer at least one probe mode")
+	}
+	if modes[0].Mode != modeImage {
+		t.Fatalf("default mode = %q, want %q so the panel opens on image generation",
+			modes[0].Mode, modeImage)
+	}
+	for _, mode := range modes {
+		if mode.Mode == modeText {
+			t.Fatal("an image model must not offer a text-completion probe")
+		}
+		if strings.TrimSpace(mode.DefaultPrompt) == "" {
+			t.Fatalf("mode %q has no default prompt", mode.Mode)
+		}
+	}
+	if got := modes[0].DefaultPrompt; got == defaultTextTestPrompt {
+		t.Fatal("image generation must not default to the chat weather prompt")
+	}
+}
+
+func TestVideoModelOffersBothDirections(t *testing.T) {
+	modes := modelTestModes("grok-imagine-video-1.5")
+	if modes[0].Mode != modeVideo {
+		t.Fatalf("default mode = %q, want %q", modes[0].Mode, modeVideo)
+	}
+	found := false
+	for _, mode := range modes {
+		if mode.Mode == modeVideoFromImage {
+			found = true
+			if !mode.RequiresImage {
+				t.Fatal("image-to-video must be marked as needing a reference frame")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("a model that animates a source image must offer image-to-video")
+	}
+}
+
+func TestChatModelOffersTextAndVision(t *testing.T) {
+	modes := modelTestModes("gpt-5.5")
+	if modes[0].Mode != modeText {
+		t.Fatalf("default mode = %q, want %q", modes[0].Mode, modeText)
+	}
+	if modes[0].DefaultPrompt != defaultTextTestPrompt {
+		t.Fatalf("text default prompt = %q, want the existing probe prompt", modes[0].DefaultPrompt)
+	}
+}
+
+// A stale browser tab must not be able to run an edit against a model that has
+// none; the error names what the model does support so the operator can act.
+func TestResolveModelTestModeRejectsUnsupportedMode(t *testing.T) {
+	if _, err := resolveModelTestMode("gpt-image-2.5-flare", "video"); err == nil {
+		t.Fatal("an image model must reject a video probe")
+	}
+	mode, err := resolveModelTestMode("gpt-image-2.5-flare", "")
+	if err != nil {
+		t.Fatalf("default mode: %v", err)
+	}
+	if mode != modeImage {
+		t.Fatalf("mode = %q, want %q", mode, modeImage)
+	}
+}
+
+func TestBuildImagePayloadTargetsTheImagesEndpoint(t *testing.T) {
+	payload, err := buildUpstreamPayload(modelTestRequest{
+		Model:   "gpt-image-2.5-flare",
+		Prompt:  "a red teapot",
+		Size:    "1024x1024",
+		Quality: "high",
+	}, modeImage)
+	if err != nil {
+		t.Fatalf("buildUpstreamPayload: %v", err)
+	}
+	if gjson.GetBytes(payload, "messages").Exists() {
+		t.Fatal("an image request must not carry chat messages")
+	}
+	for path, want := range map[string]string{
+		"model":   "gpt-image-2.5-flare",
+		"prompt":  "a red teapot",
+		"size":    "1024x1024",
+		"quality": "high",
+	} {
+		if got := gjson.GetBytes(payload, path).String(); got != want {
+			t.Fatalf("%s = %q, want %q", path, got, want)
+		}
+	}
+	if got := gjson.GetBytes(payload, "n").Int(); got != 1 {
+		t.Fatalf("n = %d, want 1 by default", got)
+	}
+	if got := upstreamAlt(modeImage); got != imageGenerationAlt {
+		t.Fatalf("alt = %q, want %q", got, imageGenerationAlt)
+	}
+	if got := upstreamAlt(modeImageEdit); got != imageEditsAlt {
+		t.Fatalf("edit alt = %q, want %q", got, imageEditsAlt)
+	}
+}
+
+func TestBuildVisionPayloadAttachesTheImage(t *testing.T) {
+	payload, err := buildUpstreamPayload(modelTestRequest{
+		Model:  "gpt-5.5",
+		Prompt: "what is this",
+		Images: []string{"https://example.com/a.png"},
+	}, modeVision)
+	if err != nil {
+		t.Fatalf("buildUpstreamPayload: %v", err)
+	}
+	if got := gjson.GetBytes(payload, "messages.0.content.0.text").String(); got != "what is this" {
+		t.Fatalf("prompt part = %q", got)
+	}
+	if got := gjson.GetBytes(payload, "messages.0.content.1.image_url.url").String(); got != "https://example.com/a.png" {
+		t.Fatalf("image part = %q", got)
+	}
+}
+
+func TestBuildVideoFromImagePayloadCarriesOneFrame(t *testing.T) {
+	payload, err := buildUpstreamPayload(modelTestRequest{
+		Model:    "grok-imagine-video-1.5",
+		Prompt:   "pan across",
+		Duration: 6,
+		Images:   []string{"https://example.com/a.png", "https://example.com/b.png"},
+	}, modeVideoFromImage)
+	if err != nil {
+		t.Fatalf("buildUpstreamPayload: %v", err)
+	}
+	if got := gjson.GetBytes(payload, "image").String(); got != "https://example.com/a.png" {
+		t.Fatalf("image = %q, want the first frame only", got)
+	}
+	if got := gjson.GetBytes(payload, "duration").Int(); got != 6 {
+		t.Fatalf("duration = %d, want 6", got)
+	}
+}
+
+func TestValidateModelTestImagesEnforcesTheModeContract(t *testing.T) {
+	if _, err := validateModelTestImages(nil, modeImageEdit, 5); err == nil {
+		t.Fatal("an edit without a reference image must be rejected")
+	}
+	if _, err := validateModelTestImages([]string{"http://example.com/a.png"}, modeImageEdit, 5); err == nil {
+		t.Fatal("plaintext http references must be rejected")
+	}
+	cleaned, err := validateModelTestImages([]string{" ", "https://example.com/a.png"}, modeImage, 5)
+	if err != nil {
+		t.Fatalf("validateModelTestImages: %v", err)
+	}
+	if len(cleaned) != 1 {
+		t.Fatalf("cleaned = %v, want blanks dropped", cleaned)
+	}
+	if _, err = validateModelTestImages([]string{
+		"https://example.com/a.png", "https://example.com/b.png",
+	}, modeImage, 1); err == nil {
+		t.Fatal("more references than the model accepts must be rejected")
+	}
+}
+
+// The panel must not have to guess a model's form from its id.
+func TestModelTestOptionsDescribeTheForm(t *testing.T) {
+	options := buildModelTestOptions("gpt-image-2.5-flare", "")
+	if len(options.Sizes) == 0 {
+		t.Fatal("an image model must report selectable sizes")
+	}
+	if len(options.Qualities) == 0 {
+		t.Fatal("an image model must report quality levels")
+	}
+	video := buildModelTestOptions("grok-imagine-video-1.5", "")
+	if video.MaxDurationSeconds <= 0 {
+		t.Fatal("a video model must report its maximum clip length")
+	}
+}
+
+// An image model reaching the probe must be routed to the image pool, not
+// rejected by the chat catalog lookup that used to guard every request.
+func TestPostModelTestAcceptsMediaModels(t *testing.T) {
+	h := &Handler{}
+	rec := postModelTest(t, h, map[string]any{
+		"model":  "gpt-image-2.5-flare",
+		"prompt": "a red teapot",
+	})
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("status = 404: an image model must not be rejected as unserved (%s)", rec.Body.String())
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 for a handler with no auth manager", rec.Code)
+	}
+}
+
+// Provenance comparison is the field that catches an upstream serving a
+// different release than the one requested, so its edge cases matter more than
+// most: a rule that flags everything, or nothing, is equally useless.
+func TestProvenanceMatchesRequest(t *testing.T) {
+	cases := []struct {
+		requested string
+		generator string
+		version   string
+		want      bool
+		why       string
+	}{
+		{"gpt-image-2.5-flare", "gpt-image", "2.0", false,
+			"the reported bug: a 2.5 request answered by a 2.0 manifest"},
+		{"gpt-image-2.5-flare", "gpt-image", "2.5", true, "2.5 served by 2.5"},
+		{"gpt-image-2.5-sunburst", "gpt-image", "2.5", true, "the other 2.5 release"},
+		{"gpt-image-2", "gpt-image", "2.0", true, "a model id writes 2 where a manifest writes 2.0"},
+		{"gpt-image-2", "gpt-image", "3.0", false, "a major version jump is a real mismatch"},
+		{"grok-imagine-image", "gpt-image", "2.0", true,
+			"a different generator family cannot be compared, so nothing is asserted"},
+		{"gpt-image-flare", "gpt-image", "2.0", true, "an id with no version segment asserts nothing"},
+		{"gpt-image-2.5-flare", "gpt-image", "", true, "an unsigned image asserts nothing"},
+	}
+	for _, testCase := range cases {
+		got := provenanceMatchesRequest(testCase.requested, testCase.generator, testCase.version)
+		if got != testCase.want {
+			t.Errorf("provenanceMatchesRequest(%q, %q, %q) = %v, want %v — %s",
+				testCase.requested, testCase.generator, testCase.version, got, testCase.want, testCase.why)
+		}
+	}
+}

--- a/internal/api/handlers/management/model_test_result.go
+++ b/internal/api/handlers/management/model_test_result.go
@@ -1,0 +1,383 @@
+package management
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util/c2pa"
+	"github.com/tidwall/gjson"
+)
+
+// Probe reporting: what was sent, what came back, and what the artifact says
+// about itself.
+//
+// A green checkmark is not a useful answer for a media model. The Codex image
+// endpoint ignores the model field of the request, so gpt-image-2.5-flare,
+// gpt-image-2, and a model id that does not exist all return 200 with a picture.
+// An operator who only sees "ok" has learned nothing about which model served
+// them. So the probe reports three things instead of one: the exact request that
+// went upstream, the artifact itself, and the provenance metadata embedded in it
+// — which is the only place the real generator version appears.
+
+// modelTestResult is the modality-shaped payload the panel renders.
+type modelTestResult struct {
+	Kind   string                 `json:"kind"`
+	Text   string                 `json:"text,omitempty"`
+	Images []modelTestImageResult `json:"images,omitempty"`
+	Video  *modelTestVideoResult  `json:"video,omitempty"`
+}
+
+type modelTestImageResult struct {
+	B64JSON       string        `json:"b64_json,omitempty"`
+	URL           string        `json:"url,omitempty"`
+	RevisedPrompt string        `json:"revised_prompt,omitempty"`
+	Format        string        `json:"format,omitempty"`
+	Width         int           `json:"width,omitempty"`
+	Height        int           `json:"height,omitempty"`
+	Bytes         int           `json:"bytes,omitempty"`
+	C2PA          *c2pa.Summary `json:"c2pa,omitempty"`
+}
+
+type modelTestVideoResult struct {
+	URL       string  `json:"url,omitempty"`
+	Duration  float64 `json:"duration,omitempty"`
+	RequestID string  `json:"request_id,omitempty"`
+	Status    string  `json:"status,omitempty"`
+}
+
+// modelTestMetadata is the evidence panel: everything that helps an operator
+// judge whether the run did what it claims.
+type modelTestMetadataReport struct {
+	Mode string `json:"mode"`
+	// RequestedModel is what the operator selected; ReportedModel is what the
+	// upstream response says it used. They differ more often than one would hope,
+	// which is exactly why both are shown.
+	RequestedModel string `json:"requested_model"`
+	ReportedModel  string `json:"reported_model,omitempty"`
+	Channel        string `json:"channel,omitempty"`
+	Upstream       string `json:"upstream_endpoint,omitempty"`
+	// ProvenanceModel is the generator the artifact's own C2PA manifest names. For
+	// OpenAI images this is the field that reveals a 2.5 request served by 2.0.
+	ProvenanceModel   string         `json:"provenance_model,omitempty"`
+	ProvenanceVersion string         `json:"provenance_version,omitempty"`
+	ProvenanceMatches *bool          `json:"provenance_matches,omitempty"`
+	Usage             map[string]any `json:"usage,omitempty"`
+	ResponseFields    []string       `json:"response_fields,omitempty"`
+	FinishReason      string         `json:"finish_reason,omitempty"`
+}
+
+// buildModelTestResult converts one upstream response into the modality-shaped
+// result plus its metadata report.
+func buildModelTestResult(mode modelTestMode, model, channel string, payload []byte) (modelTestResult, modelTestMetadataReport) {
+	meta := modelTestMetadataReport{
+		Mode:           string(mode),
+		RequestedModel: model,
+		Channel:        channel,
+		Upstream:       upstreamEndpointLabel(mode),
+		ReportedModel:  strings.TrimSpace(gjson.GetBytes(payload, "model").String()),
+		ResponseFields: topLevelFields(payload),
+		FinishReason:   strings.TrimSpace(gjson.GetBytes(payload, "choices.0.finish_reason").String()),
+	}
+	if usage := gjson.GetBytes(payload, "usage"); usage.Exists() && usage.IsObject() {
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(usage.Raw), &decoded); err == nil {
+			meta.Usage = decoded
+		}
+	}
+
+	switch mode {
+	case modeImage, modeImageEdit:
+		result := buildImageResult(payload)
+		applyProvenance(&meta, model, result.Images)
+		return result, meta
+	case modeVideo, modeVideoFromImage:
+		return buildVideoResult(payload), meta
+	default:
+		return modelTestResult{Kind: "text", Text: modelTestContent(payload)}, meta
+	}
+}
+
+func upstreamEndpointLabel(mode modelTestMode) string {
+	if alt := upstreamAlt(mode); alt != "" {
+		return "/v1/" + alt
+	}
+	return "/v1/chat/completions"
+}
+
+func topLevelFields(payload []byte) []string {
+	parsed := gjson.ParseBytes(payload)
+	if !parsed.IsObject() {
+		return nil
+	}
+	fields := make([]string, 0, 8)
+	parsed.ForEach(func(key, _ gjson.Result) bool {
+		fields = append(fields, key.String())
+		return true
+	})
+	return fields
+}
+
+func buildImageResult(payload []byte) modelTestResult {
+	result := modelTestResult{Kind: "image"}
+	for _, item := range gjson.GetBytes(payload, "data").Array() {
+		image := modelTestImageResult{
+			B64JSON:       item.Get("b64_json").String(),
+			URL:           item.Get("url").String(),
+			RevisedPrompt: strings.TrimSpace(item.Get("revised_prompt").String()),
+		}
+		if image.B64JSON != "" {
+			if decoded, err := base64.StdEncoding.DecodeString(image.B64JSON); err == nil {
+				image.Bytes = len(decoded)
+				image.Format, image.Width, image.Height = describeImage(decoded)
+				if summary := c2pa.Extract(decoded); summary.Present {
+					image.C2PA = &summary
+				}
+			}
+		}
+		result.Images = append(result.Images, image)
+	}
+	return result
+}
+
+func buildVideoResult(payload []byte) modelTestResult {
+	video := modelTestVideoResult{
+		URL:       strings.TrimSpace(gjson.GetBytes(payload, "video.url").String()),
+		Duration:  gjson.GetBytes(payload, "video.duration").Float(),
+		RequestID: strings.TrimSpace(gjson.GetBytes(payload, "request_id").String()),
+		Status:    strings.TrimSpace(gjson.GetBytes(payload, "status").String()),
+	}
+	if video.URL == "" {
+		// Some providers return the clip at the top level rather than nested.
+		video.URL = strings.TrimSpace(gjson.GetBytes(payload, "url").String())
+	}
+	return modelTestResult{Kind: "video", Video: &video}
+}
+
+// applyProvenance lifts the C2PA generator onto the metadata report and compares
+// it with what was requested.
+//
+// The comparison is a prefix match on the generator family rather than string
+// equality: the manifest says "gpt-image" where the request said
+// "gpt-image-2.5-flare", so equality would flag every image as a mismatch and
+// teach operators to ignore the field. What it can still catch is the case that
+// matters — a manifest whose version does not line up with the requested one.
+func applyProvenance(meta *modelTestMetadataReport, requested string, images []modelTestImageResult) {
+	for _, image := range images {
+		if image.C2PA == nil {
+			continue
+		}
+		meta.ProvenanceModel = image.C2PA.Generator
+		meta.ProvenanceVersion = image.C2PA.GeneratorVersion
+		break
+	}
+	if meta.ProvenanceModel == "" && meta.ProvenanceVersion == "" {
+		return
+	}
+	matches := provenanceMatchesRequest(requested, meta.ProvenanceModel, meta.ProvenanceVersion)
+	meta.ProvenanceMatches = &matches
+}
+
+// provenanceMatchesRequest compares the version segment of the requested model
+// id with the version the manifest claims.
+//
+// The version is extracted from the id rather than substring-matched against it.
+// A substring test reports "gpt-image-2.5-flare" as a match for manifest version
+// "2.0", because dropping the trailing ".0" leaves "2", which the id contains —
+// and that is exactly the case this field exists to catch.
+//
+// Anything it cannot compare confidently reports a match: an unknown generator
+// family or an id with no version segment would otherwise raise a warning on
+// every run and teach operators to ignore it.
+func provenanceMatchesRequest(requested, generator, version string) bool {
+	requested = strings.ToLower(strings.TrimSpace(requested))
+	generator = strings.ToLower(strings.TrimSpace(generator))
+	version = strings.TrimSpace(version)
+	if requested == "" || version == "" || generator == "" {
+		return true
+	}
+	if !strings.HasPrefix(requested, generator) {
+		return true
+	}
+	rest := strings.TrimLeft(strings.TrimPrefix(requested, generator), "-_. ")
+	requestedVersion := leadingVersion(rest)
+	if requestedVersion == "" {
+		return true
+	}
+	return normalizeVersion(requestedVersion) == normalizeVersion(version)
+}
+
+// leadingVersion reads the digits-and-dots run at the head of a string, which is
+// how every model id in the catalog spells its version ("2", "2.5", "1.5").
+func leadingVersion(value string) string {
+	end := 0
+	for end < len(value) && (value[end] == '.' || (value[end] >= '0' && value[end] <= '9')) {
+		end++
+	}
+	return strings.Trim(value[:end], ".")
+}
+
+// normalizeVersion makes "2" and "2.0" compare equal, since a model id writes the
+// major-only form where a manifest writes the padded one.
+func normalizeVersion(value string) string {
+	value = strings.TrimSpace(value)
+	for strings.HasSuffix(value, ".0") {
+		value = strings.TrimSuffix(value, ".0")
+	}
+	return value
+}
+
+// describeImage reads the format and pixel dimensions straight from the encoded
+// bytes. Decoding the whole image to learn its size would allocate the full
+// bitmap for a diagnostic line of text.
+func describeImage(data []byte) (format string, width, height int) {
+	if len(data) >= 24 && string(data[1:4]) == "PNG" {
+		// IHDR is always the first chunk: 8-byte signature, 4-byte length,
+		// 4-byte type, then width and height as big-endian uint32.
+		return "png", int(binary.BigEndian.Uint32(data[16:20])), int(binary.BigEndian.Uint32(data[20:24]))
+	}
+	if len(data) >= 4 && data[0] == 0xFF && data[1] == 0xD8 {
+		w, h := jpegDimensions(data)
+		return "jpeg", w, h
+	}
+	if len(data) >= 12 && string(data[0:4]) == "RIFF" && string(data[8:12]) == "WEBP" {
+		return "webp", 0, 0
+	}
+	return "", 0, 0
+}
+
+// jpegDimensions walks the JPEG marker segments to the start-of-frame header.
+func jpegDimensions(data []byte) (int, int) {
+	for offset := 2; offset+9 < len(data); {
+		if data[offset] != 0xFF {
+			offset++
+			continue
+		}
+		marker := data[offset+1]
+		if marker == 0xD8 || marker == 0x01 || (marker >= 0xD0 && marker <= 0xD7) {
+			offset += 2
+			continue
+		}
+		length := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
+		// SOF0..SOF3 and SOF5..SOF15 carry the frame dimensions; the excluded
+		// markers in that range are DHT (0xC4), JPG (0xC8) and DAC (0xCC).
+		if marker >= 0xC0 && marker <= 0xCF && marker != 0xC4 && marker != 0xC8 && marker != 0xCC {
+			return int(binary.BigEndian.Uint16(data[offset+7 : offset+9])),
+				int(binary.BigEndian.Uint16(data[offset+5 : offset+7]))
+		}
+		if length <= 0 {
+			return 0, 0
+		}
+		offset += 2 + length
+	}
+	return 0, 0
+}
+
+// maxRedactedStringLength bounds any single string kept in the request snapshot.
+const maxRedactedStringLength = 200
+
+// redactModelTestRequest produces the request snapshot the panel shows.
+//
+// The snapshot is the exact body sent upstream with two classes of value
+// replaced: embedded media, which would be megabytes of base64 and is described
+// by size instead, and anything that reads like a credential. Nothing in this
+// body should carry a secret — the executor attaches the credential itself,
+// downstream of here — but the snapshot is rendered verbatim in an operator's
+// browser and may be pasted into a bug report, so it is filtered rather than
+// trusted to be clean.
+func redactModelTestRequest(payload []byte) map[string]any {
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return map[string]any{"raw": truncateForDisplay(string(payload))}
+	}
+	redacted, _ := redactValue(decoded).(map[string]any)
+	return redacted
+}
+
+func redactValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			if isSensitiveKey(key) {
+				out[key] = "[redacted]"
+				continue
+			}
+			out[key] = redactValue(item)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, redactValue(item))
+		}
+		return out
+	case string:
+		return redactString(typed)
+	default:
+		return value
+	}
+}
+
+func redactString(value string) string {
+	if strings.HasPrefix(value, "data:") {
+		return describeDataURI(value)
+	}
+	return truncateForDisplay(value)
+}
+
+// describeDataURI replaces an inline upload with its media type and size, so the
+// snapshot shows that an image was attached without carrying the image.
+func describeDataURI(uri string) string {
+	mediaType := "binary"
+	if comma := strings.IndexByte(uri, ','); comma > 5 {
+		header := uri[5:comma]
+		if semicolon := strings.IndexByte(header, ';'); semicolon > 0 {
+			header = header[:semicolon]
+		}
+		if header != "" {
+			mediaType = header
+		}
+	}
+	size := 0
+	if decoded, err := dataURIBytes(uri); err == nil {
+		size = len(decoded)
+	}
+	return fmt.Sprintf("[inline %s, %s]", mediaType, humanBytes(size))
+}
+
+func humanBytes(size int) string {
+	switch {
+	case size >= 1024*1024:
+		return fmt.Sprintf("%.1f MB", float64(size)/(1024*1024))
+	case size >= 1024:
+		return fmt.Sprintf("%.1f KB", float64(size)/1024)
+	default:
+		return fmt.Sprintf("%d B", size)
+	}
+}
+
+func truncateForDisplay(value string) string {
+	if len(value) <= maxRedactedStringLength {
+		return value
+	}
+	return value[:maxRedactedStringLength] + fmt.Sprintf("… (%s total)", humanBytes(len(value)))
+}
+
+// sensitiveKeyFragments are substrings that mark a field as unsafe to echo back.
+var sensitiveKeyFragments = []string{
+	"authorization", "api_key", "apikey", "api-key", "secret",
+	"token", "password", "cookie", "credential", "session",
+}
+
+func isSensitiveKey(key string) bool {
+	lowered := strings.ToLower(key)
+	for _, fragment := range sensitiveKeyFragments {
+		if strings.Contains(lowered, fragment) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/handlers/management/model_test_run.go
+++ b/internal/api/handlers/management/model_test_run.go
@@ -313,14 +313,27 @@ func modelTestErrorMessage(detail map[string]any) string {
 	return "model test failed"
 }
 
+// newModelTestService builds the task service for media probes.
+//
+// It deliberately does not require an auth manager, matching the image and video
+// services: without one the task store still has to exist so polling an unknown
+// id answers "not found" rather than "service unavailable". A run that genuinely
+// has nowhere to execute is rejected by PostModelTest instead.
+func (h *Handler) newModelTestService() *imagegeneration.Service {
+	if h == nil {
+		return nil
+	}
+	return imagegeneration.NewService(h.executeModelTestTask, modelTestSystemAPIKey)
+}
+
 func (h *Handler) ensureModelTestService() *imagegeneration.Service {
-	if h == nil || h.authManager == nil {
+	if h == nil {
 		return nil
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.modelTest == nil {
-		h.modelTest = imagegeneration.NewService(h.executeModelTestTask, modelTestSystemAPIKey)
+		h.modelTest = h.newModelTestService()
 	}
 	return h.modelTest
 }

--- a/internal/api/handlers/management/model_test_run.go
+++ b/internal/api/handlers/management/model_test_run.go
@@ -2,12 +2,15 @@ package management
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	imagegeneration "github.com/router-for-me/CLIProxyAPI/v6/internal/management/imagegeneration"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdkmodelcatalog "github.com/router-for-me/CLIProxyAPI/v6/sdk/modelcatalog"
@@ -24,43 +27,92 @@ import (
 // particular business identity may use the model. An operator checking a healthy
 // kimi account got "no auth available" because the key it happened to pick was
 // bound to an end user restricted to one channel group, and no amount of channel
-// or model configuration on the account side could change that.
+// or model configuration on the account side could change that. So the probe runs
+// here instead: management authority, tenant scope, no API key in the loop.
 //
-// Image and video generation already test through the auth manager for exactly
-// this reason. This does the same for chat models: management authority, tenant
-// scope, no API key in the loop.
+// It also used to send that same chat completion for every model in the catalog,
+// including the ones that generate images and video. See model_test_modality.go
+// for why that is wrong and how the shape is chosen now.
 
 const modelTestPromptLimit = 4000
 
-// modelTestTimeout bounds one probe. Long enough for a cold upstream, short
-// enough that an operator is not left watching a spinner.
+// modelTestTimeout bounds one synchronous probe. Long enough for a cold upstream,
+// short enough that an operator is not left watching a spinner. Media modes do
+// not use it — they run as tasks, because a video takes minutes and an image can
+// outlive an intermediate proxy's idle timeout.
 const modelTestTimeout = 120 * time.Second
+
+const modelTestSystemAPIKey = "POST /models/test"
 
 type modelTestRequest struct {
 	Model   string `json:"model"`
 	Prompt  string `json:"prompt"`
 	Channel string `json:"channel"`
+	// Mode selects the probe shape. Empty means "the model's default", which is
+	// what the panel sends when the operator did not switch tabs.
+	Mode string `json:"mode"`
+	// Images are reference frames for the edit / vision / image-to-video modes,
+	// as data URIs or https URLs.
+	Images []string `json:"images"`
+	// Image options.
+	Size    string `json:"size"`
+	Quality string `json:"quality"`
+	N       int    `json:"n"`
+	// Video options.
+	Duration    int    `json:"duration"`
+	AspectRatio string `json:"aspect_ratio"`
+	Resolution  string `json:"resolution"`
 }
 
-// PostModelTest runs one non-streaming completion against a model using
-// management authority, and reports what came back.
+// modelTestEnvelope carries a probe through the task service.
+//
+// The service hands its ExecuteFunc one payload, but a media probe needs the
+// upstream body *and* the channel the operator picked. Putting the channel in the
+// upstream body would forward it to the provider as an unknown field, so the two
+// travel wrapped together and are unwrapped on the worker side. Nothing in this
+// envelope reaches a provider.
+type modelTestEnvelope struct {
+	Mode     modelTestMode   `json:"mode"`
+	Model    string          `json:"model"`
+	Channel  string          `json:"channel"`
+	Upstream json.RawMessage `json:"upstream"`
+}
+
+// GetModelTestOptions describes the probe form for one model: which modes it
+// supports, their default prompts, and the option values this deployment accepts.
+func (h *Handler) GetModelTestOptions(c *gin.Context) {
+	model := strings.TrimSpace(c.Query("model"))
+	if model == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "model is required"})
+		return
+	}
+	c.JSON(http.StatusOK, buildModelTestOptions(model, effectiveTenantID(c)))
+}
+
+// PostModelTest runs one probe against a model using management authority and
+// reports what came back.
+//
+// Text modes answer inline. Image and video modes start a task and return its id:
+// a clip takes minutes upstream, and even a single image regularly runs past the
+// idle timeout of whatever sits between the browser and this process, so holding
+// the request open would report a gateway timeout as a model failure.
 func (h *Handler) PostModelTest(c *gin.Context) {
 	var body modelTestRequest
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
-	model := strings.TrimSpace(body.Model)
-	if model == "" {
+	body.Model = strings.TrimSpace(body.Model)
+	body.Prompt = strings.TrimSpace(body.Prompt)
+	if body.Model == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "model is required"})
 		return
 	}
-	prompt := strings.TrimSpace(body.Prompt)
-	if prompt == "" {
+	if body.Prompt == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "prompt is required"})
 		return
 	}
-	if len(prompt) > modelTestPromptLimit {
+	if len(body.Prompt) > modelTestPromptLimit {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "prompt is too long"})
 		return
 	}
@@ -69,45 +121,320 @@ func (h *Handler) PostModelTest(c *gin.Context) {
 		return
 	}
 
-	providers := sdkmodelcatalog.GetProviderName(model)
-	if len(providers) == 0 {
-		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("no provider serves model %q", model)})
+	mode, err := resolveModelTestMode(body.Model, body.Mode)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	options := buildModelTestOptions(body.Model, effectiveTenantID(c))
+	if body.Images, err = validateModelTestImages(body.Images, mode, options.MaxImages); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err = validateModelTestProviders(body.Model, mode); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
 	}
 
-	payload, err := buildModelTestPayload(model, prompt)
+	upstream, err := buildUpstreamPayload(body, mode)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
+	if upstreamAlt(mode) == "" {
+		h.runSynchronousModelTest(c, body, mode, upstream)
+		return
+	}
+	h.startModelTestTask(c, body, mode, upstream)
+}
+
+// validateModelTestProviders fails fast when nothing can serve the model, so the
+// operator gets "no provider serves this" rather than a generic routing error
+// several layers down.
+func validateModelTestProviders(model string, mode modelTestMode) error {
+	switch mode {
+	case modeImage, modeImageEdit:
+		if registry.ImageGenerationProvider(model) == "" {
+			return fmt.Errorf("model %q is not a supported image generation model", model)
+		}
+	case modeVideo, modeVideoFromImage:
+		if registry.VideoGenerationProvider(model) == "" {
+			return fmt.Errorf("model %q is not a supported video generation model", model)
+		}
+	default:
+		if len(modelTestProviders(model)) == 0 {
+			return fmt.Errorf("no provider serves model %q", model)
+		}
+	}
+	return nil
+}
+
+// modelTestProviders lists the credential pools that serve a chat model.
+func modelTestProviders(model string) []string {
+	return sdkmodelcatalog.GetProviderName(model)
+}
+
+func (h *Handler) runSynchronousModelTest(c *gin.Context, body modelTestRequest, mode modelTestMode, upstream []byte) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), modelTestTimeout)
 	defer cancel()
 
 	startedAt := time.Now()
-	resp, execErr := h.authManager.Execute(ctx, providers, coreexecutor.Request{
-		Model:   model,
-		Payload: payload,
+	resp, execErr := h.authManager.Execute(ctx, modelTestProviders(body.Model), coreexecutor.Request{
+		Model:   body.Model,
+		Payload: upstream,
 		Format:  sdktranslator.FromString("openai"),
 	}, coreexecutor.Options{
-		OriginalRequest: payload,
+		OriginalRequest: upstream,
 		SourceFormat:    sdktranslator.FromString("openai"),
 		Metadata:        modelTestMetadata(effectiveTenantID(c), body.Channel),
 	})
 	elapsed := time.Since(startedAt).Milliseconds()
 
+	snapshot := redactModelTestRequest(upstream)
 	if execErr != nil {
 		// The upstream reason is the whole point of the probe, so it is reported
 		// as a result rather than swallowed into a 5xx.
-		c.JSON(http.StatusOK, gin.H{"ok": false, "error": execErr.Error(), "duration_ms": elapsed})
+		c.JSON(http.StatusOK, gin.H{
+			"ok":          false,
+			"mode":        string(mode),
+			"error":       execErr.Error(),
+			"duration_ms": elapsed,
+			"request":     snapshot,
+		})
 		return
 	}
 
+	result, metadata := buildModelTestResult(mode, body.Model, body.Channel, resp.Payload)
 	c.JSON(http.StatusOK, gin.H{
-		"ok":          true,
-		"content":     modelTestContent(resp.Payload),
+		"ok":   true,
+		"mode": string(mode),
+		// content stays in the response for callers that only ever rendered text.
+		"content":     result.Text,
+		"result":      result,
+		"metadata":    metadata,
+		"request":     snapshot,
 		"duration_ms": elapsed,
 	})
+}
+
+func (h *Handler) startModelTestTask(c *gin.Context, body modelTestRequest, mode modelTestMode, upstream []byte) {
+	service := h.ensureModelTestService()
+	if service == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "model test service unavailable"})
+		return
+	}
+	envelope, err := json.Marshal(modelTestEnvelope{
+		Mode:     mode,
+		Model:    body.Model,
+		Channel:  strings.TrimSpace(body.Channel),
+		Upstream: upstream,
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "encode model test request"})
+		return
+	}
+
+	task := service.Start(effectiveTenantID(c), envelope, upstreamAlt(mode))
+	response := modelTestTaskSnapshot(task)
+	response["ok"] = true
+	response["mode"] = string(mode)
+	response["request"] = redactModelTestRequest(upstream)
+	c.JSON(http.StatusAccepted, response)
+}
+
+// GetModelTestTask reports the current state of a media probe.
+func (h *Handler) GetModelTestTask(c *gin.Context) {
+	taskID := strings.TrimSpace(c.Param("task_id"))
+	if taskID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "task_id is required"})
+		return
+	}
+	service := h.ensureModelTestService()
+	if service == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "model test service unavailable"})
+		return
+	}
+	task, ok := service.Get(effectiveTenantID(c), taskID)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "model test task not found"})
+		return
+	}
+	c.JSON(http.StatusOK, modelTestTaskSnapshot(task))
+}
+
+func modelTestTaskSnapshot(task imagegeneration.Snapshot) gin.H {
+	if task.ID == "" {
+		return gin.H{}
+	}
+	body := gin.H{
+		"task_id":     task.ID,
+		"status":      task.Status,
+		"phase":       task.Phase,
+		"elapsed_ms":  task.ElapsedMs,
+		"duration_ms": task.ElapsedMs,
+	}
+	if task.Result != nil {
+		// The worker already assembled result/metadata/request, so the stored
+		// payload is spread into the response rather than nested a level deeper.
+		if fields, ok := task.Result.(map[string]any); ok {
+			for key, value := range fields {
+				body[key] = value
+			}
+		} else {
+			body["result"] = task.Result
+		}
+	}
+	if task.Error != nil {
+		body["ok"] = false
+		body["error"] = modelTestErrorMessage(task.Error)
+		body["error_detail"] = task.Error
+	} else if task.Status == "succeeded" {
+		body["ok"] = true
+	}
+	return body
+}
+
+// modelTestErrorMessage lifts the human-readable reason out of the task's nested
+// error envelope, so the panel has one string to show without reaching through
+// three levels of map.
+func modelTestErrorMessage(detail map[string]any) string {
+	body, _ := detail["body"].(map[string]any)
+	if body == nil {
+		return "model test failed"
+	}
+	errorBody, _ := body["error"].(map[string]any)
+	if errorBody == nil {
+		return "model test failed"
+	}
+	if message, ok := errorBody["message"].(string); ok && strings.TrimSpace(message) != "" {
+		return message
+	}
+	return "model test failed"
+}
+
+func (h *Handler) ensureModelTestService() *imagegeneration.Service {
+	if h == nil || h.authManager == nil {
+		return nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.modelTest == nil {
+		h.modelTest = imagegeneration.NewService(h.executeModelTestTask, modelTestSystemAPIKey)
+	}
+	return h.modelTest
+}
+
+// executeModelTestTask runs one media probe and returns the finished report.
+//
+// Unlike the image and video consoles, this passes the operator's channel through
+// to the router. The catalog's channel selector always implied the probe would
+// land on that account; without this it only narrowed which credential pool was
+// consulted, so a green result could come from a different account than the one
+// being investigated.
+func (h *Handler) executeModelTestTask(ctx context.Context, tenantID string, payload []byte, alt string) ([]byte, error) {
+	var envelope modelTestEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, fmt.Errorf("decode model test request")
+	}
+
+	startedAt := time.Now()
+	response, err := h.executeModelTestUpstream(ctx, tenantID, envelope, alt)
+	if err != nil {
+		return nil, err
+	}
+	elapsed := time.Since(startedAt).Milliseconds()
+
+	result, metadata := buildModelTestResult(envelope.Mode, envelope.Model, envelope.Channel, response)
+	return json.Marshal(map[string]any{
+		"result":      result,
+		"metadata":    metadata,
+		"request":     redactModelTestRequest(envelope.Upstream),
+		"content":     result.Text,
+		"duration_ms": elapsed,
+	})
+}
+
+func (h *Handler) executeModelTestUpstream(ctx context.Context, tenantID string, envelope modelTestEnvelope, alt string) ([]byte, error) {
+	if envelope.Mode == modeVideo || envelope.Mode == modeVideoFromImage {
+		return h.executeModelTestVideo(ctx, tenantID, envelope)
+	}
+	provider := registry.ImageGenerationProvider(envelope.Model)
+	if provider == "" {
+		return nil, fmt.Errorf("model %q is not a supported image generation model", envelope.Model)
+	}
+	return h.executeModelTestCall(ctx, tenantID, provider, envelope, envelope.Upstream, alt)
+}
+
+// executeModelTestVideo submits the clip and waits for it, mirroring the video
+// console: the upstream contract is submit-then-poll, and an operator wants one
+// thing to watch rather than a request id to chase.
+func (h *Handler) executeModelTestVideo(ctx context.Context, tenantID string, envelope modelTestEnvelope) ([]byte, error) {
+	provider := registry.VideoGenerationProvider(envelope.Model)
+	if provider == "" {
+		return nil, fmt.Errorf("model %q is not a supported video generation model", envelope.Model)
+	}
+	submission, err := h.executeModelTestCall(ctx, tenantID, provider, envelope, envelope.Upstream, videoGenerationAlt)
+	if err != nil {
+		return nil, err
+	}
+	requestID := strings.TrimSpace(gjson.GetBytes(submission, "request_id").String())
+	if requestID == "" {
+		return submission, nil
+	}
+
+	statusPayload, err := sjson.SetBytes([]byte(`{}`), "request_id", requestID)
+	if err != nil {
+		return nil, fmt.Errorf("encode video status request")
+	}
+
+	deadline := time.Now().Add(videoPollBudget)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(videoPollInterval):
+		}
+
+		status, pollErr := h.executeModelTestCall(ctx, tenantID, provider, envelope, statusPayload, videoStatusAlt)
+		if pollErr != nil {
+			return nil, pollErr
+		}
+		switch strings.ToLower(strings.TrimSpace(gjson.GetBytes(status, "status").String())) {
+		case "done":
+			return status, nil
+		case "failed":
+			return nil, fmt.Errorf("video generation failed upstream")
+		case "expired":
+			return nil, fmt.Errorf("video generation request expired upstream")
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("video generation did not finish within %s", videoPollBudget)
+		}
+	}
+}
+
+func (h *Handler) executeModelTestCall(
+	ctx context.Context,
+	tenantID, provider string,
+	envelope modelTestEnvelope,
+	payload []byte,
+	alt string,
+) ([]byte, error) {
+	resp, err := h.authManager.Execute(ctx, []string{provider}, coreexecutor.Request{
+		Model:   envelope.Model,
+		Payload: payload,
+		Format:  sdktranslator.FromString("openai"),
+	}, coreexecutor.Options{
+		Alt:             alt,
+		OriginalRequest: payload,
+		SourceFormat:    sdktranslator.FromString("openai"),
+		Metadata:        modelTestMetadata(tenantID, envelope.Channel),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Payload, nil
 }
 
 // modelTestMetadata scopes the probe to the tenant and, when the operator picked
@@ -123,21 +450,6 @@ func modelTestMetadata(tenantID, channel string) map[string]any {
 		meta["allowed-channels"] = channel
 	}
 	return meta
-}
-
-func buildModelTestPayload(model, prompt string) ([]byte, error) {
-	payload := []byte(`{"stream":false,"messages":[]}`)
-	var err error
-	if payload, err = sjson.SetBytes(payload, "model", model); err != nil {
-		return nil, fmt.Errorf("build model test payload: %w", err)
-	}
-	if payload, err = sjson.SetBytes(payload, "messages.0.role", "user"); err != nil {
-		return nil, fmt.Errorf("build model test payload: %w", err)
-	}
-	if payload, err = sjson.SetBytes(payload, "messages.0.content", prompt); err != nil {
-		return nil, fmt.Errorf("build model test payload: %w", err)
-	}
-	return payload, nil
 }
 
 // modelTestContent pulls the assistant text out of an OpenAI-shaped response,

--- a/internal/api/handlers/management/model_test_run_test.go
+++ b/internal/api/handlers/management/model_test_run_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestBuildModelTestPayloadShapesOneUserTurn(t *testing.T) {
-	payload, err := buildModelTestPayload("kimi-k3", "How is the weather?")
+	payload, err := buildChatTestPayload(modelTestRequest{Model: "kimi-k3", Prompt: "How is the weather?"})
 	if err != nil {
-		t.Fatalf("buildModelTestPayload: %v", err)
+		t.Fatalf("buildChatTestPayload: %v", err)
 	}
 	if got := gjson.GetBytes(payload, "model").String(); got != "kimi-k3" {
 		t.Fatalf("model = %q, want kimi-k3", got)

--- a/internal/api/handlers/management/model_test_task_test.go
+++ b/internal/api/handlers/management/model_test_task_test.go
@@ -1,0 +1,309 @@
+package management
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	"golang.org/x/net/context"
+)
+
+// End-to-end for the reported bug: selecting an image model in the catalog and
+// pressing Test must reach the images endpoint and come back with a picture, not
+// run a chat completion and report the prose as a pass.
+
+// signedPNG builds a one-chunk PNG whose caBX manifest names a generator, so the
+// probe's provenance reporting is exercised on a real container rather than on a
+// mocked summary.
+func signedPNG(generator, version string) []byte {
+	manifest := []byte{0x00, 0x00, 0x00, 0x40}
+	manifest = append(manifest, "jumb"...)
+	manifest = append(manifest, make([]byte, 16)...)
+	manifest = append(manifest, "c2pa"...)
+	appendText := func(value string) {
+		manifest = append(manifest, byte(0x60|len(value)))
+		manifest = append(manifest, value...)
+	}
+	for _, token := range []string{"claim_generator_info", "name", generator, "version", version} {
+		appendText(token)
+	}
+
+	out := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+	writeChunk := func(chunkType string, data []byte) {
+		length := make([]byte, 4)
+		binary.BigEndian.PutUint32(length, uint32(len(data)))
+		out = append(out, length...)
+		out = append(out, chunkType...)
+		out = append(out, data...)
+		out = append(out, 0, 0, 0, 0)
+	}
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], 1024)
+	binary.BigEndian.PutUint32(ihdr[4:8], 768)
+	writeChunk("IHDR", ihdr)
+	writeChunk("caBX", manifest)
+	writeChunk("IDAT", []byte{0x00})
+	return out
+}
+
+// modelTestImageExecutor answers an images request with one signed PNG.
+type modelTestImageExecutor struct {
+	alt      string
+	model    string
+	payload  string
+	metadata map[string]any
+	calls    int
+}
+
+func (e *modelTestImageExecutor) Identifier() string { return "codex" }
+
+func (e *modelTestImageExecutor) Execute(
+	_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options,
+) (coreexecutor.Response, error) {
+	e.calls++
+	e.alt = opts.Alt
+	e.model = req.Model
+	e.payload = string(req.Payload)
+	e.metadata = opts.Metadata
+	encoded := base64.StdEncoding.EncodeToString(signedPNG("gpt-image", "2.0"))
+	body := `{"created":1,"data":[{"b64_json":"` + encoded + `","revised_prompt":"a red teapot"}]}`
+	return coreexecutor.Response{Payload: []byte(body)}, nil
+}
+
+func (e *modelTestImageExecutor) ExecuteStream(
+	context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options,
+) (*coreexecutor.StreamResult, error) {
+	return nil, http.ErrNotSupported
+}
+
+func (e *modelTestImageExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *modelTestImageExecutor) CountTokens(
+	context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options,
+) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, http.ErrNotSupported
+}
+
+func (e *modelTestImageExecutor) HttpRequest(
+	context.Context, *coreauth.Auth, *http.Request,
+) (*http.Response, error) {
+	return nil, http.ErrNotSupported
+}
+
+type modelTestTaskBody struct {
+	OK     bool   `json:"ok"`
+	Mode   string `json:"mode"`
+	TaskID string `json:"task_id"`
+	Status string `json:"status"`
+	Result struct {
+		Kind   string `json:"kind"`
+		Images []struct {
+			B64JSON string `json:"b64_json"`
+			Format  string `json:"format"`
+			Width   int    `json:"width"`
+			Height  int    `json:"height"`
+			C2PA    struct {
+				Present          bool   `json:"present"`
+				Generator        string `json:"generator"`
+				GeneratorVersion string `json:"generator_version"`
+			} `json:"c2pa"`
+		} `json:"images"`
+	} `json:"result"`
+	Metadata struct {
+		Mode              string `json:"mode"`
+		RequestedModel    string `json:"requested_model"`
+		Upstream          string `json:"upstream_endpoint"`
+		ProvenanceModel   string `json:"provenance_model"`
+		ProvenanceVersion string `json:"provenance_version"`
+		ProvenanceMatches *bool  `json:"provenance_matches"`
+	} `json:"metadata"`
+	Request map[string]any `json:"request"`
+}
+
+// labelManagementImageAuth gives a registered credential a channel name, which
+// is what an operator picks in the panel's channel selector.
+func labelManagementImageAuth(t *testing.T, manager *coreauth.Manager, id, label string) {
+	t.Helper()
+	auth, ok := manager.GetByID(id)
+	if !ok || auth == nil {
+		t.Fatalf("auth %q is not registered", id)
+	}
+	updated := auth.Clone()
+	updated.Label = label
+	if _, err := manager.Register(context.Background(), updated); err != nil {
+		t.Fatalf("label auth: %v", err)
+	}
+}
+
+func startModelTest(t *testing.T, h *Handler, body string) modelTestTaskBody {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/models/test", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.PostModelTest(c)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202, body=%s", rec.Code, rec.Body.String())
+	}
+	var decoded modelTestTaskBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+	return decoded
+}
+
+func waitForModelTest(t *testing.T, h *Handler, taskID string) modelTestTaskBody {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Set(managementPrincipalKey, identity.Principal{
+			EffectiveTenant: identity.Tenant{ID: identity.SystemTenantID},
+		})
+		c.Params = gin.Params{{Key: "task_id", Value: taskID}}
+		c.Request = httptest.NewRequest(http.MethodGet, "/models/test/"+taskID, nil)
+
+		h.GetModelTestTask(c)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("poll status = %d, body=%s", rec.Code, rec.Body.String())
+		}
+		var decoded modelTestTaskBody
+		if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
+			t.Fatalf("decode poll response: %v", err)
+		}
+		if decoded.Status == "succeeded" || decoded.Status == "failed" {
+			return decoded
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for model test %s, last body=%s", taskID, rec.Body.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestModelTestImageModelProducesAnImageNotProse(t *testing.T) {
+	executor := &modelTestImageExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	registerManagementImageAuth(t, manager, "codex-model-test", "gpt-image-2.5-flare")
+	// The probe restricts the run to the selected channel, so the registered
+	// credential has to answer to that name or routing correctly finds nothing.
+	labelManagementImageAuth(t, manager, "codex-model-test", "jd7@privaterelay.appleid.com")
+
+	h := &Handler{authManager: manager}
+	started := startModelTest(t, h, `{
+		"model":"gpt-image-2.5-flare",
+		"prompt":"a red ceramic teapot",
+		"channel":"jd7@privaterelay.appleid.com",
+		"size":"1024x1024",
+		"quality":"high"
+	}`)
+	if started.Mode != string(modeImage) {
+		t.Fatalf("mode = %q, want %q", started.Mode, modeImage)
+	}
+	if started.TaskID == "" {
+		t.Fatal("an image probe must run as a task; a clip or a large image outlives a gateway timeout")
+	}
+
+	done := waitForModelTest(t, h, started.TaskID)
+	if done.Status != "succeeded" {
+		t.Fatalf("status = %q, body result kind = %q", done.Status, done.Result.Kind)
+	}
+
+	// The request went to the images endpoint, not to chat completions.
+	if executor.alt != imageGenerationAlt {
+		t.Fatalf("alt = %q, want %q", executor.alt, imageGenerationAlt)
+	}
+	if strings.Contains(executor.payload, "messages") {
+		t.Fatalf("the upstream request must not be a chat completion: %s", executor.payload)
+	}
+	if !strings.Contains(executor.payload, `"quality":"high"`) {
+		t.Fatalf("image options must reach the upstream: %s", executor.payload)
+	}
+	// The channel the operator picked must scope the run, which is what the
+	// selector always implied.
+	if got := executor.metadata["allowed-channels"]; got != "jd7@privaterelay.appleid.com" {
+		t.Fatalf("allowed-channels = %v, want the selected channel", got)
+	}
+
+	if done.Result.Kind != "image" {
+		t.Fatalf("result kind = %q, want image", done.Result.Kind)
+	}
+	if len(done.Result.Images) != 1 {
+		t.Fatalf("images = %d, want 1", len(done.Result.Images))
+	}
+	image := done.Result.Images[0]
+	if image.Format != "png" || image.Width != 1024 || image.Height != 768 {
+		t.Fatalf("image described as %s %dx%d", image.Format, image.Width, image.Height)
+	}
+
+	// The provenance the file claims is reported, and the mismatch with the
+	// requested model is flagged rather than reported as a clean pass.
+	if !image.C2PA.Present || image.C2PA.Generator != "gpt-image" {
+		t.Fatalf("c2pa = %+v, want the embedded manifest", image.C2PA)
+	}
+	if done.Metadata.ProvenanceVersion != "2.0" {
+		t.Fatalf("provenance version = %q, want 2.0", done.Metadata.ProvenanceVersion)
+	}
+	if done.Metadata.ProvenanceMatches == nil || *done.Metadata.ProvenanceMatches {
+		t.Fatal("a 2.5 request served by a 2.0 manifest must be reported as a mismatch")
+	}
+	if done.Metadata.Upstream != "/v1/images/generations" {
+		t.Fatalf("upstream = %q", done.Metadata.Upstream)
+	}
+}
+
+// The request snapshot is what an operator reads to see what was actually sent;
+// it must describe uploads rather than echo megabytes of base64 back at them.
+func TestModelTestRequestSnapshotOmitsInlineMedia(t *testing.T) {
+	executor := &modelTestImageExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	registerManagementImageAuth(t, manager, "codex-model-test-edit", "gpt-image-2.5-flare")
+
+	upload := "data:image/png;base64," + base64.StdEncoding.EncodeToString(signedPNG("x", "1"))
+	h := &Handler{authManager: manager}
+	started := startModelTest(t, h, `{
+		"model":"gpt-image-2.5-flare",
+		"mode":"image_edit",
+		"prompt":"replace the background",
+		"images":["`+upload+`"]
+	}`)
+
+	encoded, err := json.Marshal(started.Request)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	snapshot := string(encoded)
+	if strings.Contains(snapshot, "iVBOR") || strings.Contains(snapshot, upload[40:80]) {
+		t.Fatalf("the snapshot must not carry the uploaded image: %s", snapshot)
+	}
+	if !strings.Contains(snapshot, "inline image/png") {
+		t.Fatalf("the snapshot must describe the upload: %s", snapshot)
+	}
+	if !strings.Contains(snapshot, "replace the background") {
+		t.Fatalf("the snapshot must keep the prompt: %s", snapshot)
+	}
+
+	done := waitForModelTest(t, h, started.TaskID)
+	if done.Status != "succeeded" {
+		t.Fatalf("status = %q", done.Status)
+	}
+	if executor.alt != imageEditsAlt {
+		t.Fatalf("alt = %q, want %q for an edit", executor.alt, imageEditsAlt)
+	}
+}

--- a/internal/api/handlers/management/model_test_task_test.go
+++ b/internal/api/handlers/management/model_test_task_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -14,7 +15,6 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/identity"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
-	"golang.org/x/net/context"
 )
 
 // End-to-end for the reported bug: selecting an image model in the catalog and
@@ -305,5 +305,22 @@ func TestModelTestRequestSnapshotOmitsInlineMedia(t *testing.T) {
 	}
 	if executor.alt != imageEditsAlt {
 		t.Fatalf("alt = %q, want %q for an edit", executor.alt, imageEditsAlt)
+	}
+}
+
+// Polling an id the task store does not have is "not found", not "service
+// unavailable". The all-routes smoke test treats a 503 as a broken route, and an
+// operator refreshing a finished task should not be told the feature is down.
+func TestGetModelTestTaskReportsNotFoundWithoutAnAuthManager(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "task_id", Value: "task-does-not-exist"}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/models/test/task-does-not-exist", nil)
+
+	(&Handler{}).GetModelTestTask(c)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404, body=%s", rec.Code, rec.Body.String())
 	}
 }

--- a/internal/api/routes/management_model_routes.go
+++ b/internal/api/routes/management_model_routes.go
@@ -10,8 +10,11 @@ func registerManagementModelRoutes(group *gin.RouterGroup, h *managementhandlers
 	group.GET("/models", models.GetModels)
 	group.GET("/models/configured-availability", models.GetConfiguredModelAvailability)
 	// Management-authority connectivity probe: no API key, so an end user's
-	// channel-group scope cannot make a healthy model look unreachable.
+	// channel-group scope cannot make a healthy model look unreachable. Media
+	// models answer as tasks, so the probe has a poll route beside it.
 	group.POST("/models/test", h.PostModelTest)
+	group.GET("/models/test/options", h.GetModelTestOptions)
+	group.GET("/models/test/:task_id", h.GetModelTestTask)
 	group.GET("/model-path-availability", models.GetModelPathAvailability)
 	group.GET("/model-configs", models.GetModelConfigs)
 	group.POST("/model-configs", models.PostModelConfig)

--- a/internal/api/routes/management_test.go
+++ b/internal/api/routes/management_test.go
@@ -26,7 +26,7 @@ func TestRegisterManagementRouteTable(t *testing.T) {
 		routes[key] = route
 	}
 
-	if got, want := len(routes), 335; got != want {
+	if got, want := len(routes), 337; got != want {
 		t.Fatalf("route count = %d, want %d", got, want)
 	}
 	if got, want := sortedRouteKeys(routes), expectedManagementRoutes(); !slices.Equal(got, want) {
@@ -364,6 +364,8 @@ func expectedManagementRoutes() []string {
 		"GET /v0/management/model-pricing",
 		"GET /v0/management/models",
 		"GET /v0/management/models/configured-availability",
+		"GET /v0/management/models/test/:task_id",
+		"GET /v0/management/models/test/options",
 		"POST /v0/management/models/test",
 		"GET /v0/management/oauth-excluded-models",
 		"GET /v0/management/oauth-model-alias",

--- a/internal/management/authfiles/codex_image_generation_bridge.go
+++ b/internal/management/authfiles/codex_image_generation_bridge.go
@@ -2,14 +2,26 @@ package authfiles
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
-const metadataKeyCodexImageGenerationBridge = "codex_image_generation_bridge"
+const (
+	metadataKeyCodexImageGenerationBridge = "codex_image_generation_bridge"
+	// Per-account image model for the injected tool. Absent means the build
+	// default, which is what every account used before the field existed.
+	metadataKeyCodexImageGenerationModel = "codex_image_generation_model"
+)
 
 // CodexImageGenerationBridgePayload returns the management-facing payload for
 // per-account Codex /responses image_generation tool injection.
+//
+// The selectable models are reported alongside the setting rather than hardcoded
+// in the panel: Codex serves more than one gpt-image release, they are added to
+// the catalog over time, and a list maintained in the browser would go stale the
+// first time one shipped.
 func CodexImageGenerationBridgePayload(auth *coreauth.Auth) map[string]any {
 	if !isCodexOAuthAdmissionAuth(auth) {
 		return nil
@@ -22,9 +34,36 @@ func CodexImageGenerationBridgePayload(auth *coreauth.Auth) map[string]any {
 			enabled = value
 		}
 	}
+
+	available := registry.ListImageGenerationModelsForProvider(registry.ImageProviderCodex)
+	models := make([]map[string]any, 0, len(available))
+	for _, model := range available {
+		models = append(models, map[string]any{
+			"id":            model.ID,
+			"display_name":  model.DisplayName,
+			"description":   model.Description,
+			"supports_edit": model.SupportsEdit,
+		})
+	}
+
 	return map[string]any{
 		"enabled": enabled,
+		// An empty model means "the build default"; the panel shows that as the
+		// default option rather than pre-selecting a specific release, so an
+		// account keeps following the default when it changes.
+		"model":            CodexImageGenerationModel(auth),
+		"available_models": models,
 	}
+}
+
+// CodexImageGenerationModel reports the image model an account pins for the
+// injected tool, or "" when it follows the build default.
+func CodexImageGenerationModel(auth *coreauth.Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return ""
+	}
+	value, _ := auth.Metadata[metadataKeyCodexImageGenerationModel].(string)
+	return strings.TrimSpace(value)
 }
 
 func ensureCodexImageGenerationBridgeEditable(auth *coreauth.Auth) error {
@@ -32,4 +71,30 @@ func ensureCodexImageGenerationBridgeEditable(auth *coreauth.Auth) error {
 		return fmt.Errorf("codex image generation bridge is only supported for Codex OAuth auth files")
 	}
 	return nil
+}
+
+// normalizeCodexImageGenerationModel validates a requested model against the
+// Codex image catalog.
+//
+// Validation happens here rather than at request time because a typo would
+// otherwise surface as an upstream 400 on the account's next image turn, long
+// after the operator left this form, and the setting would look accepted.
+func normalizeCodexImageGenerationModel(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		// Clearing the field returns the account to the build default.
+		return "", nil
+	}
+	available := registry.ListImageGenerationModelsForProvider(registry.ImageProviderCodex)
+	for _, model := range available {
+		if strings.EqualFold(model.ID, trimmed) {
+			return model.ID, nil
+		}
+	}
+	names := make([]string, 0, len(available))
+	for _, model := range available {
+		names = append(names, model.ID)
+	}
+	return "", fmt.Errorf("codex image generation model %q is not available (supported: %s)",
+		trimmed, strings.Join(names, ", "))
 }

--- a/internal/management/authfiles/codex_image_generation_bridge_test.go
+++ b/internal/management/authfiles/codex_image_generation_bridge_test.go
@@ -1,0 +1,91 @@
+package authfiles
+
+import (
+	"strings"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func codexAuth(metadata map[string]any) *coreauth.Auth {
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	return &coreauth.Auth{Provider: "codex", Metadata: metadata}
+}
+
+// The panel must not hold its own list of Codex image models: they are added to
+// the catalog over time, and a browser-side list goes stale the first time one
+// ships.
+func TestBridgePayloadReportsSelectableModels(t *testing.T) {
+	payload := CodexImageGenerationBridgePayload(codexAuth(nil))
+	if payload == nil {
+		t.Fatal("a codex OAuth auth must expose the bridge payload")
+	}
+	models, _ := payload["available_models"].([]map[string]any)
+	if len(models) < 2 {
+		t.Fatalf("available_models = %v, want the Codex image catalog", models)
+	}
+	ids := make([]string, 0, len(models))
+	for _, model := range models {
+		id, _ := model["id"].(string)
+		ids = append(ids, id)
+	}
+	for _, want := range []string{"gpt-image-2", "gpt-image-2.5-flare"} {
+		found := false
+		for _, id := range ids {
+			if id == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("available_models %v is missing %q", ids, want)
+		}
+	}
+	// No pin means "follow the build default", which the panel renders as the
+	// default option rather than pre-selecting a release.
+	if got := payload["model"]; got != "" {
+		t.Fatalf("model = %v, want empty for an account with no pin", got)
+	}
+}
+
+func TestBridgePayloadReportsThePin(t *testing.T) {
+	payload := CodexImageGenerationBridgePayload(codexAuth(map[string]any{
+		metadataKeyCodexImageGenerationModel: "gpt-image-2.5-flare",
+	}))
+	if got := payload["model"]; got != "gpt-image-2.5-flare" {
+		t.Fatalf("model = %v, want the pinned model", got)
+	}
+}
+
+// A typo must fail on save rather than surfacing as an upstream 400 on the
+// account's next image turn, long after the operator left the form.
+func TestNormalizeCodexImageGenerationModel(t *testing.T) {
+	got, err := normalizeCodexImageGenerationModel("  GPT-Image-2.5-Flare  ")
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if got != "gpt-image-2.5-flare" {
+		t.Fatalf("normalized = %q, want the catalog casing", got)
+	}
+	if got, err = normalizeCodexImageGenerationModel(""); err != nil || got != "" {
+		t.Fatalf("clearing the pin must be allowed, got %q %v", got, err)
+	}
+	_, err = normalizeCodexImageGenerationModel("gpt-image-9-not-real")
+	if err == nil {
+		t.Fatal("an unknown model must be rejected")
+	}
+	if !strings.Contains(err.Error(), "gpt-image-2") {
+		t.Fatalf("error %q should name the supported models", err)
+	}
+	// Another pool's image model cannot be served by a Codex token.
+	if _, err = normalizeCodexImageGenerationModel("grok-imagine-image"); err == nil {
+		t.Fatal("a non-Codex image model must be rejected")
+	}
+}
+
+func TestBridgePayloadIsCodexOnly(t *testing.T) {
+	if payload := CodexImageGenerationBridgePayload(&coreauth.Auth{Provider: "gemini"}); payload != nil {
+		t.Fatal("the bridge payload must not be reported for other providers")
+	}
+}

--- a/internal/management/authfiles/patch.go
+++ b/internal/management/authfiles/patch.go
@@ -28,6 +28,9 @@ type FieldPatch struct {
 	CodexCLIOnlyAllowedClients *[]string `json:"codex_cli_only_allowed_clients"`
 	// CodexImageGenerationBridge injects Responses-native image_generation for Codex OAuth.
 	CodexImageGenerationBridge *bool `json:"codex_image_generation_bridge"`
+	// CodexImageGenerationModel pins which image model the injected tool asks for.
+	// Empty clears the pin and returns the account to the build default.
+	CodexImageGenerationModel *string `json:"codex_image_generation_model"`
 	// UsingAPI selects xAI official API vs Grok Build/CLI for OAuth accounts.
 	UsingAPI *bool `json:"using_api"`
 	// ConcurrencyLimit sets the max active concurrent requests for this account (0 = unlimited).
@@ -263,6 +266,22 @@ func ApplyFieldPatch(auth *coreauth.Auth, patch FieldPatch, opts FieldPatchOptio
 		}
 		metadata := ensureMetadata(auth)
 		metadata[metadataKeyCodexImageGenerationBridge] = *patch.CodexImageGenerationBridge
+		changed = true
+	}
+	if patch.CodexImageGenerationModel != nil {
+		if err := ensureCodexImageGenerationBridgeEditable(auth); err != nil {
+			return result, err
+		}
+		model, errModel := normalizeCodexImageGenerationModel(*patch.CodexImageGenerationModel)
+		if errModel != nil {
+			return result, errModel
+		}
+		metadata := ensureMetadata(auth)
+		if model == "" {
+			delete(metadata, metadataKeyCodexImageGenerationModel)
+		} else {
+			metadata[metadataKeyCodexImageGenerationModel] = model
+		}
 		changed = true
 	}
 	if patch.UsingAPI != nil {

--- a/internal/registry/image_generation_models.go
+++ b/internal/registry/image_generation_models.go
@@ -201,6 +201,24 @@ func ListImageGenerationModels() []ImageGenerationModel {
 	return models
 }
 
+// ListImageGenerationModelsForProvider narrows the catalog to one credential
+// pool. The Codex bridge uses it to offer the image models a Codex account can
+// actually reach, derived from the same catalog as everything else so a newly
+// registered gpt-image release becomes selectable without a second edit here.
+func ListImageGenerationModelsForProvider(provider string) []ImageGenerationModel {
+	normalized := strings.ToLower(strings.TrimSpace(provider))
+	if normalized == "" {
+		return nil
+	}
+	models := make([]ImageGenerationModel, 0, 4)
+	for _, model := range ListImageGenerationModels() {
+		if strings.EqualFold(model.Provider, normalized) {
+			models = append(models, model)
+		}
+	}
+	return models
+}
+
 // SupportsImageEditing reports whether a model accepts reference images through the
 // /images/edits endpoint, as opposed to text-to-image only.
 func SupportsImageEditing(modelID string) bool {

--- a/internal/runtime/executor/codex_image_generation_bridge.go
+++ b/internal/runtime/executor/codex_image_generation_bridge.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/codexcarrier"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -17,9 +18,9 @@ const (
 	// Per-account opt-out switch, surfaced by the management API as
 	// codex_image_generation_bridge. Absent means enabled.
 	metadataKeyCodexImageGenerationBridge = "codex_image_generation_bridge"
-
-	codexHostedImageGenerateTool = `{"type":"image_generation","action":"generate","model":"` + codexImageModel + `"}`
-	codexHostedImageEditTool     = `{"type":"image_generation","action":"edit","model":"` + codexImageModel + `"}`
+	// Per-account image model for the injected tool, surfaced by the management
+	// API as codex_image_generation_model. Absent means the build default.
+	metadataKeyCodexImageGenerationModel = "codex_image_generation_model"
 
 	// Sub2API-style guidance: hosted image_generation is intentional for clients that
 	// cannot expose the local image_gen namespace (API-key custom providers).
@@ -27,22 +28,53 @@ const (
 	codexImageGenerationBridgeText   = codexImageGenerationBridgeMarker + "\nWhen the user asks for raster image generation or editing, use the OpenAI Responses native `image_generation` tool attached to this request. The local Codex client may not expose an `image_gen` namespace under custom/API-key providers; that does not mean image generation is unavailable. Do not claim the environment lacks image tooling solely because `image_gen` is absent, and do not ask the user to switch to CLI fallback as the primary fix.\n</cliproxy-codex-image-generation>"
 )
 
-var (
-	// Hosted image_generation tool payload.
-	//
-	// The field set mirrors the request that /v1/images/generations already sends to
-	// chatgpt.com/backend-api/codex/responses (see buildCodexImageResponsesRequest). A bare
-	// {"type":"image_generation"} is also invoked by the model, but it cannot express the edit
-	// action, and it leaves the image model up to whatever the backend defaults to — pinning
-	// both keeps the conversation path and the /v1/images endpoints on the same model.
-	imageGenToolJSON      = []byte(codexHostedImageGenerateTool)
-	imageGenToolArrayJSON = []byte(`[` + codexHostedImageGenerateTool + `]`)
+// codexHostedImageTool builds the hosted image_generation tool payload for one
+// account.
+//
+// The field set mirrors the request that /v1/images/generations already sends to
+// chatgpt.com/backend-api/codex/responses (see buildCodexImageResponsesRequest). A bare
+// {"type":"image_generation"} is also invoked by the model, but it cannot express the edit
+// action, and it leaves the image model up to whatever the backend defaults to — pinning
+// both keeps the conversation path and the /v1/images endpoints on the same model.
+//
+// The model is per account rather than compiled in: Codex serves several
+// gpt-image releases, and an operator comparing them had no way to move the
+// conversation path off the default without editing the binary.
+func codexHostedImageTool(action string, auth *cliproxyauth.Auth) []byte {
+	tool := []byte(`{"type":"image_generation","action":"","model":""}`)
+	tool, _ = sjson.SetBytes(tool, "action", action)
+	tool, _ = sjson.SetBytes(tool, "model", codexBridgeImageModel(auth))
+	return tool
+}
 
-	// Same tool in edit mode, used when the current turn carries input images so the model
-	// transforms what the user attached instead of generating an unrelated new picture.
-	imageEditToolJSON      = []byte(codexHostedImageEditTool)
-	imageEditToolArrayJSON = []byte(`[` + codexHostedImageEditTool + `]`)
-)
+func codexHostedImageToolArray(action string, auth *cliproxyauth.Auth) []byte {
+	array := []byte(`[]`)
+	array, _ = sjson.SetRawBytes(array, "0", codexHostedImageTool(action, auth))
+	return array
+}
+
+// codexBridgeImageModel resolves which image model the injected tool asks for.
+//
+// A pinned value is validated against the Codex image catalog before it is used.
+// The management API validates on write, but metadata also arrives from restored
+// credential files and hand-edited JSON, and an unknown model here would turn
+// every image turn on the account into an upstream 400 rather than falling back.
+func codexBridgeImageModel(auth *cliproxyauth.Auth) string {
+	if auth == nil || auth.Metadata == nil {
+		return codexImageModel
+	}
+	pinned, _ := auth.Metadata[metadataKeyCodexImageGenerationModel].(string)
+	pinned = strings.TrimSpace(pinned)
+	if pinned == "" {
+		return codexImageModel
+	}
+	for _, model := range registry.ListImageGenerationModelsForProvider(registry.ImageProviderCodex) {
+		if strings.EqualFold(model.ID, pinned) {
+			return model.ID
+		}
+	}
+	return codexImageModel
+}
 
 // maybeEnsureCodexImageGenerationTool prepares outbound /responses tools for image gen.
 //
@@ -339,10 +371,14 @@ func ensureCodexImageGenerationTool(body []byte, baseModel string, auth *cliprox
 		return body
 	}
 
-	toolJSON, toolArrayJSON := imageGenToolJSON, imageGenToolArrayJSON
+	action := "generate"
 	if requestCarriesImageInput(body) {
-		toolJSON, toolArrayJSON = imageEditToolJSON, imageEditToolArrayJSON
+		// The edit action transforms what the user attached; generate would invent
+		// an unrelated picture and ignore it.
+		action = "edit"
 	}
+	toolJSON := codexHostedImageTool(action, auth)
+	toolArrayJSON := codexHostedImageToolArray(action, auth)
 
 	tools := gjson.GetBytes(body, "tools")
 	if !tools.Exists() || !tools.IsArray() {

--- a/internal/runtime/executor/codex_image_generation_bridge_model_test.go
+++ b/internal/runtime/executor/codex_image_generation_bridge_model_test.go
@@ -1,0 +1,74 @@
+package executor
+
+import (
+	"net/http"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	"github.com/tidwall/gjson"
+)
+
+func codexBridgeAuth(metadata map[string]any) *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{Provider: "codex", Metadata: metadata}
+}
+
+// injectedToolModel returns the model of the image_generation tool the bridge
+// attached to an outbound /responses body.
+func injectedToolModel(t *testing.T, auth *cliproxyauth.Auth) string {
+	t.Helper()
+	body := []byte(`{"model":"gpt-5.5","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"draw a cat"}]}]}`)
+	out := maybeEnsureCodexImageGenerationTool(body, auth, "gpt-5.5", http.Header{})
+	for _, tool := range gjson.GetBytes(out, "tools").Array() {
+		if tool.Get("type").String() == "image_generation" {
+			return tool.Get("model").String()
+		}
+	}
+	t.Fatalf("no image_generation tool was injected: %s", out)
+	return ""
+}
+
+// Without a per-account setting the bridge keeps using the build default, which
+// is what every account did before the field existed.
+func TestBridgeInjectsDefaultImageModel(t *testing.T) {
+	if got := injectedToolModel(t, codexBridgeAuth(nil)); got != codexImageModel {
+		t.Fatalf("model = %q, want the build default %q", got, codexImageModel)
+	}
+}
+
+func TestBridgeInjectsThePinnedImageModel(t *testing.T) {
+	for _, model := range []string{"gpt-image-2.5-flare", "gpt-image-2.5-sunburst"} {
+		t.Run(model, func(t *testing.T) {
+			auth := codexBridgeAuth(map[string]any{metadataKeyCodexImageGenerationModel: model})
+			if got := injectedToolModel(t, auth); got != model {
+				t.Fatalf("model = %q, want %q", got, model)
+			}
+		})
+	}
+}
+
+// Metadata also arrives from restored credential files and hand edits, so an
+// unknown model must fall back rather than turn every image turn into a 400.
+func TestBridgeFallsBackForAnUnknownPinnedModel(t *testing.T) {
+	auth := codexBridgeAuth(map[string]any{metadataKeyCodexImageGenerationModel: "gpt-image-9-not-real"})
+	if got := injectedToolModel(t, auth); got != codexImageModel {
+		t.Fatalf("model = %q, want the build default for an unknown pin", got)
+	}
+	// A model from another provider's pool is equally unusable on a Codex token.
+	auth = codexBridgeAuth(map[string]any{metadataKeyCodexImageGenerationModel: "grok-imagine-image"})
+	if got := injectedToolModel(t, auth); got != codexImageModel {
+		t.Fatalf("model = %q, want the build default for another pool's model", got)
+	}
+}
+
+// The edit action must carry the pinned model too; picking it up only on the
+// generate path would silently downgrade every "change this image" turn.
+func TestBridgeEditToolCarriesThePinnedModel(t *testing.T) {
+	auth := codexBridgeAuth(map[string]any{metadataKeyCodexImageGenerationModel: "gpt-image-2.5-flare"})
+	tool := codexHostedImageTool("edit", auth)
+	if got := gjson.GetBytes(tool, "action").String(); got != "edit" {
+		t.Fatalf("action = %q, want edit", got)
+	}
+	if got := gjson.GetBytes(tool, "model").String(); got != "gpt-image-2.5-flare" {
+		t.Fatalf("model = %q, want the pinned model", got)
+	}
+}

--- a/internal/util/c2pa/c2pa.go
+++ b/internal/util/c2pa/c2pa.go
@@ -1,0 +1,352 @@
+// Package c2pa extracts a readable summary of the C2PA content credentials that
+// generated images carry.
+//
+// Why a panel needs this: the Codex image endpoint ignores the model field of
+// the request. Sending gpt-image-2.5-flare, gpt-image-2, or a model id that does
+// not exist at all each return 200 with a picture, so a green "test passed" in
+// the model catalog says nothing about which model actually served it. The C2PA
+// manifest the upstream signs into the file does say — it carries the generator
+// name and version the producer claims — which makes it the only evidence an
+// operator has for telling 2.5 apart from 2.0.
+//
+// This is a summary extractor, not a validator. It does not verify signatures or
+// trust chains, so its output must be presented as "what the file claims about
+// itself", never as proof of provenance.
+package c2pa
+
+import (
+	"encoding/binary"
+	"strings"
+	"unicode/utf8"
+)
+
+// Summary is what a manifest says about itself, flattened for display.
+type Summary struct {
+	// Present is false when the asset carries no manifest at all, which is itself
+	// worth showing: it means the upstream returned an unsigned image.
+	Present bool `json:"present"`
+	// Generator and GeneratorVersion come from claim_generator_info. For OpenAI
+	// images these read "gpt-image" / "2.0" even when 2.5 was requested.
+	Generator        string `json:"generator,omitempty"`
+	GeneratorVersion string `json:"generator_version,omitempty"`
+	// Issuer is the signing organization named in the certificate chain.
+	Issuer string `json:"issuer,omitempty"`
+	// DigitalSourceType is the IPTC term the producer asserts, e.g.
+	// trainedAlgorithmicMedia for a fully generated image.
+	DigitalSourceType string `json:"digital_source_type,omitempty"`
+	// Actions are the c2pa.actions entries, e.g. c2pa.created.
+	Actions []string `json:"actions,omitempty"`
+	// Fields carries every key/value pair recovered from the manifest, in the
+	// order found. Extraction is best-effort, so this is kept as the operator's
+	// escape hatch when the structured fields above come back empty.
+	Fields []Field `json:"fields,omitempty"`
+}
+
+// Field is one recovered key/value pair from a manifest.
+type Field struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// Interesting manifest keys, in the order they are reported.
+const (
+	keyClaimGenerator = "claim_generator"
+	keyGeneratorInfo  = "claim_generator_info"
+	keyName           = "name"
+	keyVersion        = "version"
+	keySoftwareAgent  = "softwareAgent"
+	keyAction         = "action"
+	keyDigitalSource  = "digitalSourceType"
+)
+
+// maxScanBytes bounds the work done on one asset. A manifest sits in the first
+// blocks of the file; scanning a multi-megabyte image past that only burns CPU
+// on pixel data that cannot contain CBOR.
+const maxScanBytes = 512 * 1024
+
+// Extract reads whatever provenance an asset declares. It never fails: an asset
+// with no manifest, a truncated manifest, or a container this build does not
+// know all return a Summary with Present false rather than an error, because the
+// probe's job is to report what it found, not to reject the image.
+func Extract(asset []byte) Summary {
+	block := manifestBlock(asset)
+	if len(block) == 0 {
+		return Summary{}
+	}
+	fields := scanCBORStrings(block)
+	if len(fields) == 0 {
+		return Summary{}
+	}
+
+	summary := Summary{Present: true, Fields: fields}
+	// claim_generator_info and softwareAgent both hold an object rather than a
+	// string, so the string that follows them is the nested "name" key, not the
+	// generator. Those keys only open the scope; the value is taken from the
+	// name/version pair inside it.
+	generatorScope := false
+	for _, field := range fields {
+		switch field.Key {
+		case keyGeneratorInfo, keyClaimGenerator, keySoftwareAgent:
+			generatorScope = true
+			if summary.Generator == "" && !isStructuralKey(field.Value) {
+				summary.Generator = field.Value
+			}
+		case keyName:
+			if generatorScope && summary.Generator == "" && !isStructuralKey(field.Value) {
+				summary.Generator = field.Value
+			}
+		case keyVersion:
+			if generatorScope && summary.GeneratorVersion == "" && !isStructuralKey(field.Value) {
+				summary.GeneratorVersion = field.Value
+			}
+		case keyDigitalSource:
+			if summary.DigitalSourceType == "" {
+				summary.DigitalSourceType = field.Value
+			}
+		case keyAction:
+			summary.Actions = appendUnique(summary.Actions, field.Value)
+		}
+	}
+	summary.Issuer = issuerFromChain(block)
+	summary.Actions = appendUnique(summary.Actions, claimActions(fields)...)
+	return summary
+}
+
+// claimActions picks up c2pa.* action identifiers that appear as bare strings
+// rather than as the value of an "action" key, which is how some producers
+// serialize the actions assertion.
+func claimActions(fields []Field) []string {
+	actions := make([]string, 0, 2)
+	for _, field := range fields {
+		for _, candidate := range []string{field.Key, field.Value} {
+			if strings.HasPrefix(candidate, "c2pa.") &&
+				(strings.Contains(candidate, ".created") || strings.Contains(candidate, ".converted") ||
+					strings.Contains(candidate, ".edited") || strings.Contains(candidate, ".placed")) {
+				actions = append(actions, candidate)
+			}
+		}
+	}
+	return actions
+}
+
+func appendUnique(list []string, values ...string) []string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		duplicate := false
+		for _, existing := range list {
+			if existing == value {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			list = append(list, value)
+		}
+	}
+	return list
+}
+
+// issuerFromChain reads the signing organization out of the embedded
+// certificate. The certificate is DER inside the COSE signature, and parsing the
+// whole chain to print one name would be disproportionate, so the organization
+// string is recovered from its length prefix instead.
+//
+// Both DER strings and CBOR text strings put a length immediately before the
+// bytes, so the byte in front of the match gives the exact end of the name.
+// Without it the read runs into whatever token follows and reports
+// "OpenAI Media Service APIdicon".
+func issuerFromChain(block []byte) string {
+	index := indexOf(block, []byte("OpenAI"))
+	if index <= 0 {
+		return ""
+	}
+	if length := int(block[index-1] & 0x7F); length >= len("OpenAI") && index+length <= len(block) {
+		if candidate := string(block[index : index+length]); isPrintable(candidate) {
+			return strings.TrimSpace(candidate)
+		}
+	}
+	end := index
+	for end < len(block) && end-index < 64 && isPrintableASCII(block[end]) {
+		end++
+	}
+	return strings.TrimSpace(string(block[index:end]))
+}
+
+func indexOf(haystack, needle []byte) int {
+	return strings.Index(string(haystack), string(needle))
+}
+
+// manifestBlock locates the JUMBF manifest store inside a container. PNG carries
+// it in a caBX chunk and JPEG in APP11 segments; for anything else the raw bytes
+// are scanned for the JUMBF magic so a format this build has not met still
+// reports what it can.
+func manifestBlock(asset []byte) []byte {
+	if len(asset) == 0 {
+		return nil
+	}
+	if block := pngManifest(asset); len(block) > 0 {
+		return block
+	}
+	scan := asset
+	if len(scan) > maxScanBytes {
+		scan = scan[:maxScanBytes]
+	}
+	// "jumb" is the JUMBF superbox type; "c2pa" is the manifest store label that
+	// follows it. Requiring both avoids matching the four letters in pixel noise.
+	start := indexOf(scan, []byte("jumb"))
+	if start < 0 || indexOf(scan, []byte("c2pa")) < 0 {
+		return nil
+	}
+	return scan[start:]
+}
+
+var pngSignature = []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+
+// pngManifest walks the PNG chunk list to the caBX chunk that holds the C2PA
+// manifest store. Walking chunks rather than searching bytes keeps a manifest
+// that happens to sit after a large chunk reachable, and keeps pixel data that
+// happens to spell "caBX" out of the result.
+func pngManifest(asset []byte) []byte {
+	if len(asset) < len(pngSignature) || string(asset[:len(pngSignature)]) != string(pngSignature) {
+		return nil
+	}
+	offset := len(pngSignature)
+	for offset+8 <= len(asset) {
+		length := int(binary.BigEndian.Uint32(asset[offset : offset+4]))
+		chunkType := string(asset[offset+4 : offset+8])
+		dataStart := offset + 8
+		if length < 0 || dataStart+length > len(asset) {
+			return nil
+		}
+		if chunkType == "caBX" {
+			return asset[dataStart : dataStart+length]
+		}
+		if chunkType == "IDAT" {
+			// Pixel data has begun; C2PA is written ahead of it, so there is
+			// nothing left to find and no reason to walk megabytes of scanlines.
+			return nil
+		}
+		offset = dataStart + length + 4 // +4 for the chunk CRC
+	}
+	return nil
+}
+
+// scanCBORStrings recovers the manifest's text strings in order and pairs each
+// recognized key with the string that follows it.
+//
+// A full CBOR decoder is deliberately not used. The manifest store nests CBOR
+// inside JUMBF boxes inside a COSE envelope, and decoding all three layers to
+// display a generator name would add a dependency and a large amount of code for
+// a read-only diagnostic. Definite-length text strings are self-delimiting
+// enough to recover reliably, and every value this reports is labeled in the UI
+// as the file's own claim rather than a verified fact.
+func scanCBORStrings(block []byte) []Field {
+	strs := make([]string, 0, 64)
+	for i := 0; i < len(block); {
+		text, size := readCBORText(block[i:])
+		if size == 0 {
+			i++
+			continue
+		}
+		strs = append(strs, text)
+		i += size
+	}
+
+	fields := make([]Field, 0, len(strs))
+	for i, text := range strs {
+		if !isInterestingKey(text) {
+			continue
+		}
+		value := ""
+		if i+1 < len(strs) {
+			value = strs[i+1]
+		}
+		fields = append(fields, Field{Key: text, Value: value})
+	}
+	return fields
+}
+
+func isInterestingKey(text string) bool {
+	switch text {
+	case keyClaimGenerator, keyGeneratorInfo, keyName, keyVersion,
+		keySoftwareAgent, keyAction, keyDigitalSource:
+		return true
+	}
+	return strings.HasPrefix(text, "c2pa.")
+}
+
+// isStructuralKey reports whether a recovered string is itself a manifest key.
+// When it is, it is the opening key of a nested object rather than the value of
+// the key before it, so reading it as a value would report "name" as the
+// generator.
+func isStructuralKey(text string) bool {
+	switch text {
+	case keyClaimGenerator, keyGeneratorInfo, keyName, keyVersion,
+		keySoftwareAgent, keyAction, keyDigitalSource:
+		return true
+	}
+	return text == ""
+}
+
+// readCBORText decodes one definite-length CBOR text string at the head of buf,
+// returning the string and how many bytes it occupied. A zero size means buf does
+// not start with a text string this reader accepts.
+func readCBORText(buf []byte) (string, int) {
+	if len(buf) == 0 {
+		return "", 0
+	}
+	const majorText = 0x60
+	head := buf[0]
+	if head&0xE0 != majorText {
+		return "", 0
+	}
+	info := int(head & 0x1F)
+	offset := 1
+	length := 0
+	switch {
+	case info < 24:
+		length = info
+	case info == 24:
+		if len(buf) < 2 {
+			return "", 0
+		}
+		length = int(buf[1])
+		offset = 2
+	case info == 25:
+		if len(buf) < 3 {
+			return "", 0
+		}
+		length = int(binary.BigEndian.Uint16(buf[1:3]))
+		offset = 3
+	default:
+		// Longer or indefinite-length strings are not manifest keys or short
+		// values, so they are skipped rather than decoded.
+		return "", 0
+	}
+	// Single characters are almost always coincidence in binary data, and a
+	// manifest key or generator name is never one byte.
+	if length < 2 || offset+length > len(buf) {
+		return "", 0
+	}
+	text := string(buf[offset : offset+length])
+	if !utf8.ValidString(text) || !isPrintable(text) {
+		return "", 0
+	}
+	return text, offset + length
+}
+
+func isPrintable(text string) bool {
+	for i := 0; i < len(text); i++ {
+		if !isPrintableASCII(text[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isPrintableASCII(char byte) bool {
+	return char >= 0x20 && char < 0x7F
+}

--- a/internal/util/c2pa/c2pa_test.go
+++ b/internal/util/c2pa/c2pa_test.go
@@ -1,0 +1,158 @@
+package c2pa
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// cborText encodes one definite-length CBOR text string, which is all the
+// manifest fields this extractor reads.
+func cborText(value string) []byte {
+	out := []byte{}
+	switch length := len(value); {
+	case length < 24:
+		out = append(out, byte(0x60|length))
+	case length < 256:
+		out = append(out, 0x78, byte(length))
+	default:
+		header := []byte{0x79, 0, 0}
+		binary.BigEndian.PutUint16(header[1:], uint16(length))
+		out = append(out, header...)
+	}
+	return append(out, value...)
+}
+
+// pngWithManifest builds the smallest PNG that carries a caBX chunk, so the
+// chunk walk is exercised rather than a raw byte search.
+func pngWithManifest(manifest []byte) []byte {
+	out := bytes.NewBuffer(pngSignature)
+
+	writeChunk := func(chunkType string, data []byte) {
+		length := make([]byte, 4)
+		binary.BigEndian.PutUint32(length, uint32(len(data)))
+		out.Write(length)
+		out.WriteString(chunkType)
+		out.Write(data)
+		out.Write([]byte{0, 0, 0, 0}) // CRC is not validated by the extractor
+	}
+
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], 1024)
+	binary.BigEndian.PutUint32(ihdr[4:8], 768)
+	writeChunk("IHDR", ihdr)
+	writeChunk("caBX", manifest)
+	writeChunk("IDAT", []byte{0x00})
+	return out.Bytes()
+}
+
+// openAIStyleManifest mirrors the layout a real OpenAI image carries: JUMBF box
+// headers with their binary lengths and UUID, then the CBOR assertion strings.
+// The binary preamble matters — it is what the string scanner has to walk past
+// without mistaking a length byte for a text header.
+func openAIStyleManifest() []byte {
+	manifest := []byte{0x00, 0x00, 0x00, 0x55}
+	manifest = append(manifest, "jumb"...)
+	manifest = append(manifest, 0x00, 0x00, 0x00, 0x47)
+	manifest = append(manifest, "jumd"...)
+	manifest = append(manifest, make([]byte, 16)...) // box UUID
+	manifest = append(manifest, "c2pa"...)
+	for _, token := range []string{
+		"c2pa.assertions",
+		"c2pa.actions",
+		"action", "c2pa.created",
+		// softwareAgent holds an object, so "name" follows it before the value.
+		// Reading the key that follows as the generator is the bug this guards.
+		"softwareAgent", "name", "gpt-image",
+		"version", "2.0",
+		"digitalSourceType", "trainedAlgorithmicMedia",
+	} {
+		manifest = append(manifest, cborText(token)...)
+	}
+	// A DER-style length prefix in front of the signing organization, which is
+	// how the issuer is bounded in the certificate chain.
+	manifest = append(manifest, byte(len("OpenAI Media Service API")))
+	manifest = append(manifest, "OpenAI Media Service API"...)
+	manifest = append(manifest, "dicon"...) // the token that follows it in a real file
+	return manifest
+}
+
+// The whole reason this package exists: the Codex image endpoint answers a
+// gpt-image-2.5-flare request with a 2.0 image, and the manifest is the only
+// place that shows it.
+func TestExtractReportsTheRealGeneratorVersion(t *testing.T) {
+	summary := Extract(pngWithManifest(openAIStyleManifest()))
+	if !summary.Present {
+		t.Fatal("a PNG with a caBX chunk must report a manifest")
+	}
+	if summary.Generator != "gpt-image" {
+		t.Fatalf("generator = %q, want gpt-image", summary.Generator)
+	}
+	if summary.GeneratorVersion != "2.0" {
+		t.Fatalf("version = %q, want 2.0", summary.GeneratorVersion)
+	}
+	if summary.DigitalSourceType != "trainedAlgorithmicMedia" {
+		t.Fatalf("digital source = %q", summary.DigitalSourceType)
+	}
+	if len(summary.Actions) == 0 {
+		t.Fatal("c2pa.created must be reported as an action")
+	}
+	if len(summary.Fields) == 0 {
+		t.Fatal("recovered fields must stay available as the operator's escape hatch")
+	}
+	// The issuer must stop at its length prefix instead of running into the next
+	// token, which produced "OpenAI Media Service APIdicon".
+	if summary.Issuer != "OpenAI Media Service API" {
+		t.Fatalf("issuer = %q, want it bounded by its length prefix", summary.Issuer)
+	}
+}
+
+func TestExtractReportsNothingForAnUnsignedAsset(t *testing.T) {
+	plain := pngWithManifest(nil)
+	// Rebuild without the caBX chunk entirely.
+	plain = bytes.Replace(plain, []byte("caBX"), []byte("tEXt"), 1)
+	if summary := Extract(plain); summary.Present {
+		t.Fatal("an asset with no manifest must not claim provenance")
+	}
+	if summary := Extract(nil); summary.Present {
+		t.Fatal("empty input must not claim provenance")
+	}
+	if summary := Extract([]byte("not an image at all")); summary.Present {
+		t.Fatal("arbitrary bytes must not be read as a manifest")
+	}
+}
+
+// Pixel data must not be mistaken for a manifest, and the walk must stop at
+// IDAT rather than scanning megabytes of scanlines.
+func TestPNGManifestStopsAtPixelData(t *testing.T) {
+	out := bytes.NewBuffer(pngSignature)
+	writeChunk := func(chunkType string, data []byte) {
+		length := make([]byte, 4)
+		binary.BigEndian.PutUint32(length, uint32(len(data)))
+		out.Write(length)
+		out.WriteString(chunkType)
+		out.Write(data)
+		out.Write([]byte{0, 0, 0, 0})
+	}
+	writeChunk("IHDR", make([]byte, 13))
+	writeChunk("IDAT", []byte("caBX jumb c2pa claim_generator_info"))
+	if block := pngManifest(out.Bytes()); block != nil {
+		t.Fatal("bytes inside IDAT must not be read as a manifest")
+	}
+}
+
+func TestReadCBORTextRejectsBinaryNoise(t *testing.T) {
+	// 0x62 is text(2) but the payload is not printable ASCII.
+	if text, size := readCBORText([]byte{0x62, 0x00, 0x01}); size != 0 {
+		t.Fatalf("decoded %q from binary noise", text)
+	}
+	// Single characters are coincidence in binary data far more often than they
+	// are manifest values.
+	if _, size := readCBORText([]byte{0x61, 'a'}); size != 0 {
+		t.Fatal("one-character strings must not be collected")
+	}
+	text, size := readCBORText(append([]byte{0x64}, "name"...))
+	if size != 5 || text != "name" {
+		t.Fatalf("text = %q size = %d, want name/5", text, size)
+	}
+}


### PR DESCRIPTION
## 问题

模型目录的「测试模型」对**所有**模型构造同一个请求形状 —— 一条非流式 chat completion：

```go
// internal/api/handlers/management/model_test_run.go
payload := []byte(`{"stream":false,"messages":[]}`)  // Format: "openai"
```

对文本模型这回答了操作员真正想问的问题。对 `gpt-image-2.5-flare` 不是：上游要么把生图模型当聊天模型处理并回一段文本，要么以一个与模型健康无关的原因失败。两种结果都在测一条真实图像客户端不会走的代码路径，而预填的提示词（"How is the weather in Los Angeles today?"）对它毫无意义。

系统里其实早就有 `/image-generation/test`（含 edits）和 `/video-generation/test`（含 image-to-video），模型目录一直没接上。

## 改动

**探针按模态分流。** 形状从模型注册表推导 —— 那是 `/v1/images/*` 与 `/v1/videos/*` 判定模型归属的同一处真源，跟着它走才不会出现「目录里能测、真实调用却不支持」的分叉。六种模式：文本、视觉理解、文生图、图生图、文生视频、图生视频，每种都有针对性的默认提示词（写成一眼能看出结果对不对的形式）。

**文本同步返回，图像与视频走任务。** 一段视频在上游要几分钟，单张图也经常超过浏览器与本进程之间任何中间层的空闲超时 —— 挂着请求只会把网关超时报成模型故障。

**渠道选择器现在真的生效。** 图像与视频路径此前根本没传 `allowed-channels`，选择器只是缩小了凭据池，请求仍可能落到另一个账号上。

**每次运行报告发了什么、回了什么，而不只是成功/失败。** 这一点对生图是刚需：Codex 图像端点忽略请求里的 model 字段，`gpt-image-2.5-flare`、`gpt-image-2`、乃至一个不存在的 id 都会返回 200 和一张图。已对线上端点实测确认 —— 用 2.5-flare 请求，回来的图片内容凭据写的是 **`gpt-image 2.0`**。新增 `internal/util/c2pa` 读取该 manifest 供面板展示，不引入新依赖；它是摘要提取器而非校验器，输出始终标注为「文件自述」而不是已验证的溯源。请求快照在展示前过滤：凭据脱敏，内联上传按大小描述而不是把几兆 base64 原样回显。

**Codex 生图工具注入的模型改为按账号可选。** 注入的 `image_generation` 工具请求哪个 gpt-image 版本原先是编译期常量，操作员想对比不同版本时无法把对话路径挪离默认值。可选列表来自注册表而非常量，新版本上线即可选，无需第二处改动。非法的 pin 回落到默认，而不是让该账号每次生图都变成上游 400 —— metadata 也会来自恢复的凭据文件和手工编辑。

## 新增端点

| 方法 | 路径 | 权限 |
|------|------|------|
| GET | `/models/test/options?model=` | `models.read` |
| GET | `/models/test/:task_id` | `models.read` |
| POST | `/models/test`（已存在，扩展） | `models.write` |

权限统一走 models.* ——操作员在模型目录里测生图模型不需要额外的 `image_generation.test`。

## 向后兼容

对文本模型仍同步返回 `{ok, content, duration_ms}`，旧前端不受影响；可先于前端 PR 合入。图像/视频返回 202 + `task_id`，旧前端会显示空响应 —— 比现在把文本当成功更诚实，且该路径本就是坏的。

## 验证

- `./scripts/ci-pr.sh` 通过（含 secret scan、结构检查、gofmt、go vet、`go test ./...`、golangci-lint、go build）
- `TestRegisterManagementRouteTable` 已随新路由更新
- C2PA 提取器用真实生成的图片验证过：正确读出 `gpt-image` / `2.0` / `OpenAI Media Service API`
- 新增 handler 层端到端测试：图像模型 → 任务 → 图片结果 + 元数据 + 渠道透传，并断言请求走 `images/generations` 而非 chat completions

前端 PR：kittors/codeProxy（随后提交）

🤖 Generated with [Claude Code](https://claude.com/claude-code)